### PR TITLE
Reorder dashboard: insights before recent games

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -43,8 +43,8 @@ export default function DashboardPage() {
       <h1 className="sr-only">Dashboard</h1>
       <div className="grid gap-8">
         <UserProfile user={user} stats={stats} statsLoading={statsLoading} syncLabel={syncLabel ?? "Not synced yet"} />
-        <RecentGames />
         <DashboardInsights stats={stats} loading={statsLoading} />
+        <RecentGames />
       </div>
     </PageContainer>
   )


### PR DESCRIPTION
Closes #21

## Summary
- Move DashboardInsights above RecentGames
- Flow: Profile → Insights → Recent Games

🤖 Generated with [Claude Code](https://claude.com/claude-code)