### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10.25.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `pnpm/action-setup` v4 → v5

Fixes Node.js 20 deprecation warnings in CI.

Closes #'"$ISSUE"'

🤖 Generated with [Claude Code](https://claude.com/claude-code)