### PR TITLE
Fix: compute gamesWithAchievements from confirmed data

### DIFF
--- a/lib/server/steam-stats-compute.ts
+++ b/lib/server/steam-stats-compute.ts
@@ -43,6 +43,7 @@ function computeStatsFromDatabase(steamId: string): SteamStatsResponse {
     .prepare(
       `
     SELECT
+      COUNT(*) AS games_with_achievements,
       COALESCE(SUM(unlocked_count), 0) AS total_achievements,
       COALESCE(SUM(CASE WHEN total_count > unlocked_count THEN total_count - unlocked_count ELSE 0 END), 0) AS pending_achievements,
       COALESCE(SUM(CASE WHEN unlocked_count > 0 THEN 1 ELSE 0 END), 0) AS started_games,
@@ -52,6 +53,7 @@ function computeStatsFromDatabase(steamId: string): SteamStatsResponse {
   `,
     )
     .get(steamId) as {
+    games_with_achievements: number
     total_achievements: number
     pending_achievements: number
     started_games: number
@@ -70,6 +72,7 @@ function computeStatsFromDatabase(steamId: string): SteamStatsResponse {
 
   return {
     totalGames: totals.total_games ?? 0,
+    gamesWithAchievements: achievementTotals.games_with_achievements ?? 0,
     totalAchievements: achievementTotals.total_achievements ?? 0,
     pendingAchievements: achievementTotals.pending_achievements ?? 0,
     startedGames: achievementTotals.started_games ?? 0,
@@ -177,8 +180,13 @@ export async function getStatsForUser(steamId: string, options?: { forceRefresh?
 
   const snapshot = getStoredStatsSnapshot(steamId)
   if (!forceRefresh && snapshot && !isStale(snapshot.computed_at, STATS_STALE_MS)) {
+    const db = getSqliteDatabase()
+    const achCount = db
+      .prepare("SELECT COUNT(*) as c FROM user_games WHERE steam_id = ? AND owned = 1 AND total_count > 0")
+      .get(steamId) as { c: number }
     return {
       totalGames: snapshot.total_games,
+      gamesWithAchievements: achCount.c,
       totalAchievements: snapshot.total_achievements,
       pendingAchievements: snapshot.pending_achievements,
       startedGames: snapshot.started_games,

--- a/lib/steam-stats.ts
+++ b/lib/steam-stats.ts
@@ -12,6 +12,7 @@ export async function getUserStats(steamId: string, options?: { forceRefresh?: b
     logger.error({ err: error }, "Error fetching user stats")
     return {
       totalGames: 0,
+      gamesWithAchievements: 0,
       totalAchievements: 0,
       pendingAchievements: 0,
       startedGames: 0,

--- a/lib/types/steam.ts
+++ b/lib/types/steam.ts
@@ -9,6 +9,7 @@ export interface SteamAchievementView extends SteamAchievement {
 
 export interface SteamStatsResponse {
   totalGames: number
+  gamesWithAchievements: number
   totalAchievements: number
   pendingAchievements: number
   startedGames: number

--- a/test/api-stats-route.test.ts
+++ b/test/api-stats-route.test.ts
@@ -33,6 +33,7 @@ describe("GET /api/steam/stats", () => {
     })
     vi.mocked(getUserStats).mockResolvedValue({
       totalGames: 1,
+      gamesWithAchievements: 1,
       totalAchievements: 2,
       pendingAchievements: 3,
       startedGames: 1,
@@ -50,6 +51,7 @@ describe("GET /api/steam/stats", () => {
   it("returns stats data in response body", async () => {
     const expectedStats = {
       totalGames: 5,
+      gamesWithAchievements: 3,
       totalAchievements: 42,
       pendingAchievements: 10,
       startedGames: 3,


### PR DESCRIPTION
## Summary
- Add `gamesWithAchievements` to `SteamStatsResponse` computed from `total_count > 0`
- Replaces unreliable `has_community_visible_stats` flag for completion chart calculations
- Update defaults and tests

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)