### PR TITLE
Feat: display playtime as hours and minutes

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -13,6 +13,7 @@ import type { SteamAchievementView } from "@/lib/types/steam"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { ExternalLink, Lock, RefreshCw, Trophy } from "lucide-react"
+import { formatPlaytime } from "@/lib/utils"
 
 type AchievementTab = "pending" | "unlocked"
 
@@ -106,9 +107,7 @@ export default function GameDetailPage() {
             <div className="flex-1 space-y-4 pt-1">
               <div>
                 <h1 className="mb-1 text-2xl font-bold">{game.name}</h1>
-                <div className="text-muted-foreground text-sm">
-                  {(game.playtime_forever / 60).toFixed(1)} hours played
-                </div>
+                <div className="text-muted-foreground text-sm">{formatPlaytime(game.playtime_forever / 60)} played</div>
               </div>
 
               {!loadingAchievements && total > 0 && (

--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { useState } from "react"
 import { Clock, Trophy } from "lucide-react"
 import { Progress } from "@/components/ui/progress"
+import { formatPlaytime } from "@/lib/utils"
 import type { SteamAchievementView } from "@/lib/types/steam"
 
 interface GameCardProps {
@@ -80,7 +81,7 @@ export function GameCard({
             {playtime !== undefined ? (
               <div className="flex items-center gap-2">
                 <Clock className="h-3 w-3" />
-                <span>{playtime.toFixed(1)} hours</span>
+                <span>{formatPlaytime(playtime)}</span>
               </div>
             ) : null}
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatPlaytime(hours: number): string {
+  if (hours < 1) {
+    const mins = Math.round(hours * 60)
+    return `${mins}m`
+  }
+  const h = Math.floor(hours)
+  const m = Math.round((hours - h) * 60)
+  return m > 0 ? `${h}h ${m}m` : `${h}h`
+}


### PR DESCRIPTION
Closes #25

## Summary
- Add `formatPlaytime()` utility to `lib/utils.ts`
- Update game card and game detail page to use new format
- Examples: `14h 30m`, `45m`, `3h`

🤖 Generated with [Claude Code](https://claude.com/claude-code)