### PR TITLE
Fix: rediscover achievements for all games via migration

### DIFF
--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -190,6 +190,20 @@ const migrations: Array<(db: DatabaseSync) => void> = [
       CREATE INDEX IF NOT EXISTS idx_tracked_games_steam_id ON tracked_games(steam_id);
     `)
   },
+
+  // Migration 3: Reset achievements_synced_at for games with total_count=0
+  // so they get re-discovered after removing the tracked games system.
+  // Games that truly have no achievements will be marked again with empty
+  // achievements (total_count stays 0, achievements_synced_at gets set).
+  (db) => {
+    db.prepare(
+      `
+      UPDATE user_games
+      SET achievements_synced_at = NULL
+      WHERE total_count = 0 AND achievements_synced_at IS NOT NULL
+    `,
+    ).run()
+  },
 ]
 
 function runMigrations(db: DatabaseSync) {


### PR DESCRIPTION
## Summary
- Add migration 3: reset `achievements_synced_at` for games with `total_count=0`
- Next sync will re-check all games with `has_community_visible_stats`
- Fixes games like Forza Horizon, Stanley Parable not appearing in library
- Broken/retired games get marked with empty achievements and won't retry

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)