### PR TITLE
Fix: use server-side stats for library filtering

### DIFF
--- a/lib/games-mapping.ts
+++ b/lib/games-mapping.ts
@@ -8,6 +8,9 @@ type GameBase = {
   name: string
   image: string
   playtime: number
+  unlocked_count: number
+  total_count: number
+  perfect_game: boolean
 }
 
 /**
@@ -27,6 +30,9 @@ export function mapOwnedGamesToGameCards(
       name: game.name,
       image: game.image_landscape_url || getImageUrl(game.appid, game.img_icon_url),
       playtime: Number((game.playtime_forever / 60).toFixed(1)),
+      unlocked_count: game.unlocked_count ?? 0,
+      total_count: game.total_count ?? 0,
+      perfect_game: game.perfect_game ?? false,
     }))
 }
 
@@ -37,10 +43,12 @@ export function buildGamesWithStats(
 ): SteamGameCardModel[] {
   return games.map((game) => {
     const achievements = achievementsMap[game.id] || []
-    const unlocked = achievements.filter((achievement) => achievement.achieved === 1).length
-    const total = achievements.length
+    // Use server-side stats (from DB) as source of truth for filtering,
+    // fall back to achievementsMap only for the detailed achievement list
+    const total = game.total_count > 0 ? game.total_count : achievements.length
+    const unlocked = game.unlocked_count > 0 ? game.unlocked_count : achievements.filter((a) => a.achieved === 1).length
     const percent = total > 0 ? Math.round((unlocked / total) * 100) : 0
-    const completed = total > 0 && unlocked === total
+    const completed = game.perfect_game || (total > 0 && unlocked === total)
 
     return {
       ...game,

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -27,6 +27,9 @@ export type GameRow = {
   image_landscape_url: string | null
   image_portrait_url: string | null
   has_community_visible_stats: number | null
+  unlocked_count: number | null
+  total_count: number | null
+  perfect_game: number | null
 }
 
 /** Converts a SQLite game row into a SteamGame object. */
@@ -44,6 +47,9 @@ export function mapRowToSteamGame(row: GameRow): SteamGame {
     image_portrait_url: row.image_portrait_url ?? undefined,
     has_community_visible_stats:
       row.has_community_visible_stats === null ? undefined : row.has_community_visible_stats === 1,
+    unlocked_count: row.unlocked_count ?? undefined,
+    total_count: row.total_count ?? undefined,
+    perfect_game: row.perfect_game === 1,
   }
 }
 
@@ -64,7 +70,10 @@ export function getStoredOwnedGames(steamId: string): SteamGame[] {
       g.image_icon_url,
       g.image_landscape_url,
       g.image_portrait_url,
-      g.has_community_visible_stats
+      g.has_community_visible_stats,
+      ug.unlocked_count,
+      ug.total_count,
+      ug.perfect_game
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.owned = 1
@@ -241,7 +250,10 @@ export async function getRecentlyPlayedGamesForUser(steamId: string, options?: {
       g.image_icon_url,
       g.image_landscape_url,
       g.image_portrait_url,
-      g.has_community_visible_stats
+      g.has_community_visible_stats,
+      ug.unlocked_count,
+      ug.total_count,
+      ug.perfect_game
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.owned = 1 AND ug.rtime_last_played > 0

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -10,6 +10,9 @@ export interface SteamGame {
   image_portrait_url?: string
   rtime_last_played?: number
   has_community_visible_stats?: boolean
+  unlocked_count?: number
+  total_count?: number
+  perfect_game?: boolean
 }
 
 export interface SteamAchievement {

--- a/test/games-mapping.test.ts
+++ b/test/games-mapping.test.ts
@@ -37,8 +37,8 @@ describe("games mapping", () => {
   it("builds stats and sorts by completion", () => {
     const gamesWithStats = buildGamesWithStats(
       [
-        { id: 1, name: "A", image: "a", playtime: 1 },
-        { id: 2, name: "B", image: "b", playtime: 1 },
+        { id: 1, name: "A", image: "a", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
+        { id: 2, name: "B", image: "b", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
       ],
       {
         1: [{ apiname: "x", achieved: 1, unlocktime: 1, displayName: "x", description: "", icon: "", icongray: "" }],
@@ -56,8 +56,8 @@ describe("games mapping", () => {
   it("filterVisibleGames with showCompleted=true returns all games", () => {
     const games = buildGamesWithStats(
       [
-        { id: 1, name: "A", image: "a", playtime: 1 },
-        { id: 2, name: "B", image: "b", playtime: 1 },
+        { id: 1, name: "A", image: "a", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
+        { id: 2, name: "B", image: "b", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
       ],
       {
         1: [{ apiname: "x", achieved: 1, unlocktime: 1, displayName: "x", description: "", icon: "", icongray: "" }],
@@ -72,9 +72,9 @@ describe("games mapping", () => {
   it("sortGames with alphabetical sorts by name", () => {
     const games = buildGamesWithStats(
       [
-        { id: 1, name: "Zelda", image: "z", playtime: 1 },
-        { id: 2, name: "Alpha", image: "a", playtime: 1 },
-        { id: 3, name: "Mario", image: "m", playtime: 1 },
+        { id: 1, name: "Zelda", image: "z", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
+        { id: 2, name: "Alpha", image: "a", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
+        { id: 3, name: "Mario", image: "m", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
       ],
       {},
     )
@@ -86,9 +86,9 @@ describe("games mapping", () => {
   it("sortGames with achievementsDesc sorts by achievement count", () => {
     const games = buildGamesWithStats(
       [
-        { id: 1, name: "A", image: "a", playtime: 1 },
-        { id: 2, name: "B", image: "b", playtime: 1 },
-        { id: 3, name: "C", image: "c", playtime: 1 },
+        { id: 1, name: "A", image: "a", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
+        { id: 2, name: "B", image: "b", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
+        { id: 3, name: "C", image: "c", playtime: 1, unlocked_count: 0, total_count: 0, perfect_game: false },
       ],
       {
         1: [{ apiname: "x", achieved: 0, unlocktime: 0, displayName: "x", description: "", icon: "", icongray: "" }],


### PR DESCRIPTION
## Summary
- Add `unlocked_count`, `total_count`, `perfect_game` to SteamGame type and games API
- `buildGamesWithStats` uses server-side stats as source of truth instead of client achievementsMap
- Fixes mismatch between /games filters and dashboard insights numbers

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)