### PR TITLE
Fix: show achievement progress from server stats as fallback

### DIFF
--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -178,6 +178,9 @@ export function LibraryOverview({ initialFilter, initialOrder }: LibraryOverview
               achievements={game.achievements}
               achievementsLoading={achievementsLoading}
               href={`/game/${game.id}`}
+              serverTotal={game.totalAchievements}
+              serverUnlocked={game.unlockedAchievements}
+              serverPerfect={game.completed}
             />
           ))}
         </div>

--- a/components/dashboard/recent-games.tsx
+++ b/components/dashboard/recent-games.tsx
@@ -17,6 +17,9 @@ export function RecentGames() {
         playtime: Number((game.playtime_forever / 60).toFixed(1)),
         image: getSteamHeaderImageUrl(game.appid),
         appid: game.appid,
+        total_count: game.total_count ?? 0,
+        unlocked_count: game.unlocked_count ?? 0,
+        perfect_game: game.perfect_game ?? false,
       })),
     [games],
   )
@@ -95,6 +98,9 @@ export function RecentGames() {
                     href={`/game/${game.id}`}
                     achievements={achievements}
                     achievementsLoading={achievementsLoading}
+                    serverTotal={game.total_count}
+                    serverUnlocked={game.unlocked_count}
+                    serverPerfect={game.perfect_game}
                   />
                 </div>
               )

--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -15,6 +15,9 @@ interface GameCardProps {
   achievements?: SteamAchievementView[]
   achievementsLoading?: boolean
   href?: string
+  serverTotal?: number
+  serverUnlocked?: number
+  serverPerfect?: boolean
 }
 
 const FALLBACK_STAGES = ["primary", "header", "legacy", "capsule", "generic", "placeholder"] as const
@@ -45,17 +48,22 @@ export function GameCard({
   achievements = [],
   achievementsLoading = false,
   href,
+  serverTotal = 0,
+  serverUnlocked = 0,
+  serverPerfect = false,
 }: GameCardProps) {
   const [imageSrc, setImageSrc] = useState(image || "/placeholder-landscape.svg")
   const [fallbackIndex, setFallbackIndex] = useState(0)
 
-  const unlocked = achievements.filter((achievement) => achievement.achieved === 1).length
-  const total = achievements.length
+  // Use detailed achievements if available, fall back to server-side counts
+  const hasDetail = achievements.length > 0
+  const unlocked = hasDetail ? achievements.filter((a) => a.achieved === 1).length : serverUnlocked
+  const total = hasDetail ? achievements.length : serverTotal
   const percent = total > 0 ? Math.round((unlocked / total) * 100) : 0
   let progressColor = "bg-danger"
   if (percent >= 80) progressColor = "bg-success"
   else if (percent >= 40) progressColor = "bg-warning"
-  const isCompleted = total > 0 && unlocked === total
+  const isCompleted = serverPerfect || (total > 0 && unlocked === total)
   const cardContent = (
     <div
       data-game-id={id}

--- a/lib/games-mapping.ts
+++ b/lib/games-mapping.ts
@@ -56,6 +56,7 @@ export function buildGamesWithStats(
       percent,
       completed,
       totalAchievements: total,
+      unlockedAchievements: unlocked,
     }
   })
 }

--- a/lib/types/steam.ts
+++ b/lib/types/steam.ts
@@ -27,6 +27,7 @@ export interface SteamGameCardModel {
   percent: number
   completed: boolean
   totalAchievements: number
+  unlockedAchievements: number
 }
 
 export type SteamGamesResponse = {


### PR DESCRIPTION
## Summary
- GameCard falls back to server-side `unlocked_count`/`total_count` when detailed achievements aren't synced
- Fixes games discovered by migration 3 showing no progress bar
- Both library and recent games pass server stats to cards

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)