### PR TITLE
fix: clear user state on logout to prevent redirect loop

### DIFF
--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -8,6 +8,7 @@ import { useRouter, usePathname } from "next/navigation"
 import Link from "next/link"
 import React from "react"
 import { SyncStatusButton } from "@/components/dashboard/sync-status-button"
+import { clearCurrentUser } from "@/hooks/use-current-user"
 
 interface DashboardHeaderProps {
   user: SteamUser
@@ -50,6 +51,7 @@ export function DashboardHeader({ user }: DashboardHeaderProps) {
   const handleLogout = async () => {
     try {
       await fetch("/api/auth/logout", { method: "POST" })
+      clearCurrentUser()
       router.push("/")
     } catch (error) {
       console.error("Logout error:", error)

--- a/hooks/use-current-user.ts
+++ b/hooks/use-current-user.ts
@@ -82,6 +82,11 @@ async function revalidateCurrentUser(): Promise<void> {
   return ensureCurrentUserLoaded()
 }
 
+export function clearCurrentUser() {
+  inFlightRequest = null
+  emitState({ user: null, loading: false })
+}
+
 export function useCurrentUser() {
   const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 


### PR DESCRIPTION
## Summary
- Export `clearCurrentUser()` from the user store to reset module-level state
- Call it in `handleLogout` before `router.push("/")` to prevent stale session data from triggering a redirect loop between `/` and `/dashboard`

## Test plan
- [ ] Login with Steam, navigate to dashboard
- [ ] Logout — should land on `/` cleanly with no flicker or loop
- [ ] Verify dev server logs show a single `GET /` after logout, not repeated requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)