### PR TITLE
feat: add skeleton loading states for dashboard and library

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import { RecentGames } from "@/components/dashboard/recent-games"
 import { DashboardInsights } from "@/components/dashboard/dashboard-insights"
 import { PageContainer } from "@/components/ui/page-container"
 import { usePageTitle } from "@/components/ui/page-title-context"
-import { LoadingMessage } from "@/components/ui/loading-message"
+import { DashboardSkeleton } from "@/components/skeletons/dashboard-skeleton"
 import { useSteamStats } from "@/hooks/use-steam-data"
 import { useSyncStatus } from "@/components/dashboard/sync-status-button"
 
@@ -31,8 +31,8 @@ export default function DashboardPage() {
     }
   }, [loading, router, user])
 
-  if (loading) {
-    return <LoadingMessage />
+  if (loading || statsLoading) {
+    return <DashboardSkeleton />
   }
   if (!user) {
     return null

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { useCurrentUser } from "@/hooks/use-current-user"
 import { LibraryOverview } from "@/components/dashboard/library-overview"
 import { PageContainer } from "@/components/ui/page-container"
-import { LoadingMessage } from "@/components/ui/loading-message"
+import { LibrarySkeleton } from "@/components/skeletons/library-skeleton"
 
 export default function GamesPage() {
   const { user, loading } = useCurrentUser()
@@ -24,7 +24,7 @@ export default function GamesPage() {
   }, [loading, router, user])
 
   if (loading) {
-    return <LoadingMessage />
+    return <LibrarySkeleton />
   }
   if (!user) {
     return null

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -5,6 +5,7 @@ import { Trophy, PieChart, ArrowUpDown, Play, Search } from "lucide-react"
 import Select from "react-select"
 
 import { GameCard } from "@/components/ui/game-card"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useSteamAchievementsBatch, useSteamGames } from "@/hooks/use-steam-data"
 import { getSteamHeaderImageUrl } from "@/lib/steam-api"
 import { buildGamesWithStats, mapOwnedGamesToGameCards, sortGames } from "@/lib/games-mapping"
@@ -330,7 +331,21 @@ export function LibraryOverview({
       <hr className="border-surface-4" />
 
       {listLoading ? (
-        <p className="text-muted-foreground py-8 text-center">Loading games...</p>
+        <div className="space-y-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="border-surface-4 bg-surface-1 flex items-stretch gap-4 rounded-lg border px-4 py-4">
+              <Skeleton className="h-[5.9rem] w-48 rounded-2xl" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-5 w-44" />
+                <div className="flex gap-4">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+                <Skeleton className="h-2 w-full rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
       ) : error ? (
         <p className="text-destructive py-8 text-center">{error}</p>
       ) : visibleGames.length === 0 ? (

--- a/components/skeletons/dashboard-skeleton.tsx
+++ b/components/skeletons/dashboard-skeleton.tsx
@@ -1,0 +1,116 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { PageContainer } from "@/components/ui/page-container"
+
+function UserProfileSkeleton() {
+  return (
+    <Card className="border-surface-4 overflow-hidden">
+      <CardHeader className="pb-0">
+        <div className="flex items-start justify-between">
+          <div className="flex items-start gap-4">
+            <Skeleton className="h-14 w-14 rounded-2xl" />
+            <div className="space-y-2">
+              <Skeleton className="h-7 w-40" />
+              <div className="flex gap-2">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <Skeleton className="h-10 w-10 rounded-full" />
+              </div>
+            </div>
+          </div>
+          <div className="space-y-2 text-right">
+            <Skeleton className="ml-auto h-3 w-24" />
+            <Skeleton className="ml-auto h-8 w-16" />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-5">
+          <Skeleton className="h-9 w-32" />
+          <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="border-surface-4 bg-surface-1 rounded-lg border px-4 py-4">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="mt-3 h-7 w-12" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function InsightCardSkeleton() {
+  return (
+    <Card className="border-surface-4">
+      <CardHeader className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="h-6 w-28" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-5">
+          <div className="border-surface-3 bg-surface-1 rounded-lg border p-4">
+            <Skeleton className="mb-2 h-4 w-32" />
+            <Skeleton className="mb-3 h-3 w-48" />
+            <Skeleton className="mx-auto h-44 w-44 rounded-full" />
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="bg-surface-1 flex items-center justify-between rounded-lg px-3 py-2.5">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-2.5 w-2.5 rounded-full" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+                <Skeleton className="h-4 w-8" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function RecentGamesSkeleton() {
+  return (
+    <Card className="border-surface-4">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5 rounded" />
+          <Skeleton className="h-6 w-48" />
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="border-surface-4 flex items-stretch gap-4 rounded-lg border px-4 py-4">
+              <Skeleton className="h-[5.9rem] w-48 rounded-2xl" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-2 w-full rounded-full" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function DashboardSkeleton() {
+  return (
+    <PageContainer>
+      <div className="grid gap-8">
+        <UserProfileSkeleton />
+        <div className="grid gap-6 xl:grid-cols-2">
+          <InsightCardSkeleton />
+          <InsightCardSkeleton />
+        </div>
+        <RecentGamesSkeleton />
+      </div>
+    </PageContainer>
+  )
+}

--- a/components/skeletons/library-skeleton.tsx
+++ b/components/skeletons/library-skeleton.tsx
@@ -1,0 +1,60 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import { PageContainer } from "@/components/ui/page-container"
+
+function GameCardSkeleton() {
+  return (
+    <div className="border-surface-4 bg-surface-1 flex items-stretch gap-4 rounded-lg border px-4 py-4">
+      <Skeleton className="h-[5.9rem] w-48 rounded-2xl" />
+      <div className="min-w-0 flex-1 space-y-2">
+        <Skeleton className="h-5 w-44" />
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <Skeleton className="h-2 w-full rounded-full" />
+      </div>
+    </div>
+  )
+}
+
+export function LibrarySkeleton() {
+  return (
+    <PageContainer>
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="w-36 space-y-1.5">
+              <Skeleton className="h-3 w-14" />
+              <Skeleton className="h-9 w-full rounded-lg" />
+            </div>
+            <div className="w-44 space-y-1.5">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-9 w-full rounded-lg" />
+            </div>
+            <div className="w-48 space-y-1.5">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-9 w-full rounded-lg" />
+            </div>
+          </div>
+          <div className="w-48 space-y-1.5">
+            <Skeleton className="h-3 w-14" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <Skeleton className="h-9 flex-1 rounded-lg" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+
+        <hr className="border-surface-4" />
+
+        <div className="space-y-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <GameCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </PageContainer>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `DashboardSkeleton` matching the profile card, stat boxes, charts, and recent games layout
- Add `LibrarySkeleton` matching the filter controls and game card list layout
- Replace inline "Loading games..." text in library overview with game card skeletons
- Dashboard stays in skeleton until both auth and stats finish loading (no intermediate "..." state)

## Test plan
- [ ] Open `/dashboard` — skeleton should appear briefly, then transition directly to populated content
- [ ] Open `/games` — skeleton should appear, then transition to game list
- [ ] Verify no intermediate "..." or empty states between skeleton and real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)