### PR TITLE
chore: rate limit game sync, cache auth state, drop tracked_games

### DIFF
--- a/app/api/steam/game/[id]/sync/route.ts
+++ b/app/api/steam/game/[id]/sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { getCurrentUser } from "@/app/lib/server-auth"
+import { rateLimit } from "@/lib/server/rate-limit"
 import { getAchievementsForGame } from "@/lib/server/steam-achievements-sync"
 import { getStoredGame } from "@/lib/server/steam-games-sync"
 
@@ -25,6 +26,11 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
   const appId = Number(id)
   if (!id || !Number.isFinite(appId) || appId <= 0) {
     return NextResponse.json({ error: "Valid App ID required" }, { status: 400 })
+  }
+
+  const { success } = rateLimit(`game-sync:${user.steamId}`, 10, 60_000)
+  if (!success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
   }
 
   const game = getStoredGame(user.steamId, appId)

--- a/hooks/use-current-user.ts
+++ b/hooks/use-current-user.ts
@@ -44,6 +44,11 @@ async function ensureCurrentUserLoaded(): Promise<void> {
     return inFlightRequest
   }
 
+  // Already loaded — skip redundant fetches on navigation
+  if (!currentUserState.loading) {
+    return
+  }
+
   inFlightRequest = (async () => {
     try {
       const res = await fetch("/api/auth/me")

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -257,6 +257,11 @@ const migrations: Array<(db: DatabaseSync) => void> = [
       }
     }
   },
+
+  // Migration 6: Drop legacy tracked_games table (concept removed)
+  (db) => {
+    db.exec("DROP TABLE IF EXISTS tracked_games;")
+  },
 ]
 
 function runMigrations(db: DatabaseSync) {


### PR DESCRIPTION
## Summary
- **Rate limiting**: Add 10 req/min limit to `POST /api/steam/game/:id/sync` to prevent Steam API abuse
- **Auth cache**: Skip redundant `/api/auth/me` fetches on client-side navigation when user is already loaded (revalidation on tab focus still works)
- **Migration 6**: Drop legacy `tracked_games` table — the tracked games concept was removed but the table remained

## Test plan
- [ ] Rapidly click "Update achievements" on game detail page — should get 429 after 10 clicks
- [ ] Navigate between dashboard/games/game detail — only 1 `/api/auth/me` call on initial load
- [ ] Tab away and back — `/api/auth/me` fires once on return (revalidation still works)
- [ ] Fresh deploy — migration 6 runs without error, tracked_games table is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)