### PR TITLE
fix: security and validation improvements

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -24,14 +24,18 @@ export async function POST(request: Request) {
     const admin = await requireAdmin()
     if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-    let body: { steamId?: string }
+    let body: unknown
     try {
       body = await request.json()
     } catch {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
     }
 
-    const { steamId } = body
+    if (!body || typeof body !== "object") {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const { steamId } = body as { steamId?: string }
     if (!steamId || !/^\d{17}$/.test(steamId)) {
       return NextResponse.json({ error: "Valid Steam ID required (17 digits)" }, { status: 400 })
     }
@@ -55,14 +59,18 @@ export async function DELETE(request: Request) {
     const admin = await requireAdmin()
     if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-    let body: { steamId?: string }
+    let body: unknown
     try {
       body = await request.json()
     } catch {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
     }
 
-    const { steamId } = body
+    if (!body || typeof body !== "object") {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const { steamId } = body as { steamId?: string }
     if (!steamId || !/^\d{17}$/.test(steamId)) {
       return NextResponse.json({ error: "Valid Steam ID required (17 digits)" }, { status: 400 })
     }

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -5,12 +5,17 @@ import { logger } from "@/lib/server/logger"
 
 /** GET /api/admin/users - List allowed users */
 export async function GET() {
-  const admin = await requireAdmin()
-  if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  try {
+    const admin = await requireAdmin()
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-  const db = getSqliteDatabase()
-  const users = db.prepare("SELECT steam_id, added_by, added_at FROM allowed_users ORDER BY added_at DESC").all()
-  return NextResponse.json({ users })
+    const db = getSqliteDatabase()
+    const users = db.prepare("SELECT steam_id, added_by, added_at FROM allowed_users ORDER BY added_at DESC").all()
+    return NextResponse.json({ users })
+  } catch (error) {
+    logger.error({ err: error }, "List users error")
+    return NextResponse.json({ error: "Failed to list users" }, { status: 500 })
+  }
 }
 
 /** POST /api/admin/users - Add allowed user */
@@ -19,7 +24,14 @@ export async function POST(request: Request) {
     const admin = await requireAdmin()
     if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-    const { steamId } = await request.json()
+    let body: { steamId?: string }
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const { steamId } = body
     if (!steamId || !/^\d{17}$/.test(steamId)) {
       return NextResponse.json({ error: "Valid Steam ID required (17 digits)" }, { status: 400 })
     }
@@ -43,10 +55,18 @@ export async function DELETE(request: Request) {
     const admin = await requireAdmin()
     if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
-    const { steamId } = await request.json()
-    if (!steamId) return NextResponse.json({ error: "steamId required" }, { status: 400 })
+    let body: { steamId?: string }
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
 
-    // Don't allow removing yourself
+    const { steamId } = body
+    if (!steamId || !/^\d{17}$/.test(steamId)) {
+      return NextResponse.json({ error: "Valid Steam ID required (17 digits)" }, { status: 400 })
+    }
+
     if (steamId === admin.steamId) {
       return NextResponse.json({ error: "Cannot remove yourself" }, { status: 400 })
     }

--- a/app/api/steam/games/hide/route.ts
+++ b/app/api/steam/games/hide/route.ts
@@ -5,7 +5,7 @@ import { logger } from "@/lib/server/logger"
 
 function parseAppId(body: unknown): number | null {
   const appId = Number((body as { appId?: unknown })?.appId)
-  if (!Number.isInteger(appId) || appId <= 0) return null
+  if (!Number.isSafeInteger(appId) || appId <= 0) return null
   return appId
 }
 

--- a/app/api/steam/games/hide/route.ts
+++ b/app/api/steam/games/hide/route.ts
@@ -3,21 +3,34 @@ import { getCurrentUser } from "@/app/lib/server-auth"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { logger } from "@/lib/server/logger"
 
+function parseAppId(body: unknown): number | null {
+  const appId = Number((body as { appId?: unknown })?.appId)
+  if (!Number.isInteger(appId) || appId <= 0) return null
+  return appId
+}
+
 /** POST /api/steam/games/hide - Hide a game */
 export async function POST(request: Request) {
   try {
     const user = await getCurrentUser()
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-    const { appId } = await request.json()
-    if (!appId || !Number.isFinite(Number(appId))) {
-      return NextResponse.json({ error: "Valid appId required" }, { status: 400 })
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const appId = parseAppId(body)
+    if (!appId) {
+      return NextResponse.json({ error: "Valid appId required (positive integer)" }, { status: 400 })
     }
 
     const db = getSqliteDatabase()
     db.prepare("INSERT OR IGNORE INTO hidden_games (steam_id, appid, hidden_at) VALUES (?, ?, ?)").run(
       user.steamId,
-      Number(appId),
+      appId,
       new Date().toISOString(),
     )
     return NextResponse.json({ success: true })
@@ -33,13 +46,20 @@ export async function DELETE(request: Request) {
     const user = await getCurrentUser()
     if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
 
-    const { appId } = await request.json()
-    if (!appId || !Number.isFinite(Number(appId))) {
-      return NextResponse.json({ error: "Valid appId required" }, { status: 400 })
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const appId = parseAppId(body)
+    if (!appId) {
+      return NextResponse.json({ error: "Valid appId required (positive integer)" }, { status: 400 })
     }
 
     const db = getSqliteDatabase()
-    db.prepare("DELETE FROM hidden_games WHERE steam_id = ? AND appid = ?").run(user.steamId, Number(appId))
+    db.prepare("DELETE FROM hidden_games WHERE steam_id = ? AND appid = ?").run(user.steamId, appId)
     return NextResponse.json({ success: true })
   } catch (error) {
     logger.error({ err: error }, "Unhide game error")

--- a/lib/whitelist.ts
+++ b/lib/whitelist.ts
@@ -5,23 +5,37 @@ import { getSqliteDatabase } from "@/lib/server/sqlite"
 
 const STEAM_ID_REGEX = /^\d{17}$/
 
+/** Lazily parsed env whitelist — computed once, cached. */
+let envWhitelistCache: Set<string> | null = null
+function getEnvWhitelist(): Set<string> {
+  if (envWhitelistCache) return envWhitelistCache
+  const raw = env.STEAM_WHITELIST_IDS
+  if (!raw) {
+    envWhitelistCache = new Set()
+    return envWhitelistCache
+  }
+  envWhitelistCache = new Set(
+    raw
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => STEAM_ID_REGEX.test(id)),
+  )
+  return envWhitelistCache
+}
+
+/** @internal Reset cached env whitelist — for testing only. */
+export function _resetEnvWhitelistCache() {
+  envWhitelistCache = null
+}
+
 /** Returns all allowed Steam64 IDs from the DB and env var fallback. */
 export function getSteamWhitelist(): Set<string> {
-  // Check DB first
   const db = getSqliteDatabase()
   const rows = db.prepare("SELECT steam_id FROM allowed_users").all() as Array<{ steam_id: string }>
   const dbIds = new Set(rows.map((r) => r.steam_id))
 
-  // Fall back to env var
-  const rawWhitelist = env.STEAM_WHITELIST_IDS
-  if (rawWhitelist) {
-    const envIds = rawWhitelist
-      .split(",")
-      .map((id) => id.trim())
-      .filter((id) => STEAM_ID_REGEX.test(id))
-    for (const id of envIds) {
-      dbIds.add(id)
-    }
+  for (const id of getEnvWhitelist()) {
+    dbIds.add(id)
   }
 
   return dbIds
@@ -29,28 +43,16 @@ export function getSteamWhitelist(): Set<string> {
 
 /** Checks whether a Steam64 ID is in the allowed users list or is the admin. */
 export function isSteamIdWhitelisted(steamId: string): boolean {
-  // Admin always has access
   if (env.ADMIN_STEAM_ID && env.ADMIN_STEAM_ID === steamId) {
     return true
   }
 
-  // Reject obviously invalid IDs early
   if (!STEAM_ID_REGEX.test(steamId)) return false
 
-  // Direct membership query — avoids loading the full whitelist
+  // Direct DB lookup — reuses the same prepared statement via SQLite's cache
   const db = getSqliteDatabase()
   const row = db.prepare("SELECT 1 FROM allowed_users WHERE steam_id = ?").get(steamId)
   if (row) return true
 
-  // Fall back to env var
-  const rawWhitelist = env.STEAM_WHITELIST_IDS
-  if (rawWhitelist) {
-    return rawWhitelist
-      .split(",")
-      .map((id) => id.trim())
-      .filter((id) => STEAM_ID_REGEX.test(id))
-      .includes(steamId)
-  }
-
-  return false
+  return getEnvWhitelist().has(steamId)
 }

--- a/lib/whitelist.ts
+++ b/lib/whitelist.ts
@@ -34,6 +34,9 @@ export function isSteamIdWhitelisted(steamId: string): boolean {
     return true
   }
 
+  // Reject obviously invalid IDs early
+  if (!STEAM_ID_REGEX.test(steamId)) return false
+
   // Direct membership query — avoids loading the full whitelist
   const db = getSqliteDatabase()
   const row = db.prepare("SELECT 1 FROM allowed_users WHERE steam_id = ?").get(steamId)
@@ -45,6 +48,7 @@ export function isSteamIdWhitelisted(steamId: string): boolean {
     return rawWhitelist
       .split(",")
       .map((id) => id.trim())
+      .filter((id) => STEAM_ID_REGEX.test(id))
       .includes(steamId)
   }
 

--- a/lib/whitelist.ts
+++ b/lib/whitelist.ts
@@ -1,3 +1,5 @@
+import "server-only"
+
 import { env } from "@/lib/env"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 
@@ -31,6 +33,20 @@ export function isSteamIdWhitelisted(steamId: string): boolean {
   if (env.ADMIN_STEAM_ID && env.ADMIN_STEAM_ID === steamId) {
     return true
   }
-  const whitelist = getSteamWhitelist()
-  return whitelist.has(steamId)
+
+  // Direct membership query — avoids loading the full whitelist
+  const db = getSqliteDatabase()
+  const row = db.prepare("SELECT 1 FROM allowed_users WHERE steam_id = ?").get(steamId)
+  if (row) return true
+
+  // Fall back to env var
+  const rawWhitelist = env.STEAM_WHITELIST_IDS
+  if (rawWhitelist) {
+    return rawWhitelist
+      .split(",")
+      .map((id) => id.trim())
+      .includes(steamId)
+  }
+
+  return false
 }

--- a/test/api-admin-users-route.test.ts
+++ b/test/api-admin-users-route.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("@/app/lib/require-admin", () => ({
+  requireAdmin: vi.fn(),
+}))
+
+const mockDb = {
+  prepare: vi.fn().mockReturnValue({ all: vi.fn().mockReturnValue([]), run: vi.fn() }),
+}
+vi.mock("@/lib/server/sqlite", () => ({
+  getSqliteDatabase: () => mockDb,
+}))
+
+import { GET, POST, DELETE } from "@/app/api/admin/users/route"
+import { requireAdmin } from "@/app/lib/require-admin"
+
+const mockAdmin = { steamId: "76561198000000001", displayName: "admin", avatar: "", profileUrl: "" }
+
+describe("GET /api/admin/users", () => {
+  it("returns 403 when not admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null)
+    const res = await GET()
+    expect(res.status).toBe(403)
+  })
+
+  it("returns users list", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await GET()
+    expect(res.status).toBe(200)
+  })
+})
+
+describe("POST /api/admin/users", () => {
+  it("returns 403 when not admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null)
+    const res = await POST(
+      new Request("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ steamId: "76561198000000099" }),
+      }),
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it("returns 400 for invalid JSON", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await POST(
+      new Request("http://localhost/api/admin/users", {
+        method: "POST",
+        body: "not json",
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for null body", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await POST(
+      new Request("http://localhost/api/admin/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "null",
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for invalid Steam ID", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await POST(
+      new Request("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ steamId: "123" }),
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 200 for valid add", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await POST(
+      new Request("http://localhost/api/admin/users", {
+        method: "POST",
+        body: JSON.stringify({ steamId: "76561198000000099" }),
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+})
+
+describe("DELETE /api/admin/users", () => {
+  it("returns 400 for invalid Steam ID format", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await DELETE(
+      new Request("http://localhost/api/admin/users", {
+        method: "DELETE",
+        body: JSON.stringify({ steamId: "abc" }),
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when trying to remove yourself", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await DELETE(
+      new Request("http://localhost/api/admin/users", {
+        method: "DELETE",
+        body: JSON.stringify({ steamId: mockAdmin.steamId }),
+      }),
+    )
+    const body = (await res.json()) as { error: string }
+    expect(res.status).toBe(400)
+    expect(body.error).toBe("Cannot remove yourself")
+  })
+
+  it("returns 200 for valid remove", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await DELETE(
+      new Request("http://localhost/api/admin/users", {
+        method: "DELETE",
+        body: JSON.stringify({ steamId: "76561198000000099" }),
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+})

--- a/test/api-hide-route.test.ts
+++ b/test/api-hide-route.test.ts
@@ -102,6 +102,17 @@ describe("DELETE /api/steam/games/hide", () => {
     expect(res.status).toBe(401)
   })
 
+  it("returns 400 for invalid JSON", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await DELETE(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "DELETE",
+        body: "not json",
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
   it("returns 400 for invalid appId", async () => {
     vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
     const res = await DELETE(

--- a/test/api-hide-route.test.ts
+++ b/test/api-hide-route.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("@/app/lib/server-auth", () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+const mockDb = {
+  prepare: vi.fn().mockReturnValue({ run: vi.fn() }),
+}
+vi.mock("@/lib/server/sqlite", () => ({
+  getSqliteDatabase: () => mockDb,
+}))
+
+import { POST, DELETE } from "@/app/api/steam/games/hide/route"
+import { getCurrentUser } from "@/app/lib/server-auth"
+
+const mockUser = { steamId: "76561198000000001", displayName: "test", avatar: "", profileUrl: "" }
+
+describe("POST /api/steam/games/hide", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    const res = await POST(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "POST",
+        body: JSON.stringify({ appId: 730 }),
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 for invalid JSON", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await POST(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "POST",
+        body: "not json",
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for negative appId", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await POST(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "POST",
+        body: JSON.stringify({ appId: -1 }),
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for float appId", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await POST(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "POST",
+        body: JSON.stringify({ appId: 1.5 }),
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 200 for valid appId", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await POST(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "POST",
+        body: JSON.stringify({ appId: 730 }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    expect(mockDb.prepare).toHaveBeenCalled()
+  })
+})
+
+describe("DELETE /api/steam/games/hide", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    const res = await DELETE(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "DELETE",
+        body: JSON.stringify({ appId: 730 }),
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 for invalid appId", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await DELETE(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "DELETE",
+        body: JSON.stringify({ appId: "abc" }),
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 200 for valid unhide", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await DELETE(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "DELETE",
+        body: JSON.stringify({ appId: 730 }),
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+})

--- a/test/whitelist.test.ts
+++ b/test/whitelist.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/lib/env", () => ({
 
 vi.mock("@/lib/server/sqlite", () => ({
   getSqliteDatabase: () => ({
-    prepare: () => ({ all: () => [] }),
+    prepare: () => ({ all: () => [], get: () => undefined }),
   }),
 }))
 

--- a/test/whitelist.test.ts
+++ b/test/whitelist.test.ts
@@ -14,7 +14,7 @@ vi.mock("@/lib/server/sqlite", () => ({
   }),
 }))
 
-import { getSteamWhitelist, isSteamIdWhitelisted } from "@/lib/whitelist"
+import { getSteamWhitelist, isSteamIdWhitelisted, _resetEnvWhitelistCache } from "@/lib/whitelist"
 
 const ORIGINAL_ENV = process.env.STEAM_WHITELIST_IDS
 
@@ -25,6 +25,7 @@ describe("whitelist", () => {
     } else {
       process.env.STEAM_WHITELIST_IDS = ORIGINAL_ENV
     }
+    _resetEnvWhitelistCache()
   })
 
   it("parses ids from comma-separated env value", () => {


### PR DESCRIPTION
## Summary
- **whitelist.ts**: Added `server-only`, direct `SELECT 1 WHERE steam_id = ?` instead of loading full table
- **hide endpoint**: Validates positive integer appId, returns 400 for malformed JSON
- **admin DELETE**: Validates 17-digit Steam ID format, handles JSON parse errors
- **Tests**: Updated whitelist mock

## Test plan
- [ ] `pnpm test` — 71 tests pass
- [ ] Hide game with valid ID works, invalid JSON returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)