### PR TITLE
feat: detect private Steam profiles and warn users

### DIFF
--- a/app/api/auth/steam/callback/route.ts
+++ b/app/api/auth/steam/callback/route.ts
@@ -157,6 +157,7 @@ export async function GET(request: NextRequest) {
         profileUrl: player.profileurl,
         timecreated: player.timecreated || null,
         personaState: player.personastate ?? null,
+        communityVisibilityState: player.communityvisibilitystate ?? null,
         steamLevel,
         badges,
       }),

--- a/components/dashboard/user-profile.tsx
+++ b/components/dashboard/user-profile.tsx
@@ -268,9 +268,11 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
         <div className="border-warning/30 bg-warning/10 mx-6 mb-2 flex items-start gap-3 rounded-lg border px-4 py-3">
           <AlertTriangle className="text-warning mt-0.5 h-4 w-4 shrink-0" />
           <div className="text-sm">
-            <p className="text-warning font-medium">Your Steam profile is private</p>
+            <p role="alert" className="text-warning font-medium">
+              Your Steam profile is not public
+            </p>
             <p className="text-muted-foreground mt-0.5">
-              Game and achievement data cannot be loaded with a private profile. Change your{" "}
+              Game and achievement data cannot be loaded unless your profile is public. Change your{" "}
               <a
                 href="https://steamcommunity.com/my/edit/settings"
                 target="_blank"

--- a/components/dashboard/user-profile.tsx
+++ b/components/dashboard/user-profile.tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { AnimatedNumber } from "@/components/ui/animated-number"
-import { ExternalLink } from "lucide-react"
+import { AlertTriangle, ExternalLink } from "lucide-react"
 import type { SteamUser } from "@/lib/auth"
 import type { SteamStatsResponse } from "@/lib/types/steam"
 
@@ -263,6 +263,27 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
           )}
         </div>
       </CardHeader>
+
+      {user.communityVisibilityState != null && user.communityVisibilityState !== 3 && (
+        <div className="border-warning/30 bg-warning/10 mx-6 mb-2 flex items-start gap-3 rounded-lg border px-4 py-3">
+          <AlertTriangle className="text-warning mt-0.5 h-4 w-4 shrink-0" />
+          <div className="text-sm">
+            <p className="text-warning font-medium">Your Steam profile is private</p>
+            <p className="text-muted-foreground mt-0.5">
+              Game and achievement data cannot be loaded with a private profile. Change your{" "}
+              <a
+                href="https://steamcommunity.com/my/edit/settings"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-foreground underline underline-offset-2"
+              >
+                Steam privacy settings
+              </a>{" "}
+              to public, then sync again.
+            </p>
+          </div>
+        </div>
+      )}
 
       <CardContent>
         <div className="space-y-5">

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,6 +10,7 @@ export interface SteamUser {
   profileUrl: string
   timecreated?: number | null
   personaState?: number | null
+  communityVisibilityState?: number | null
   steamLevel?: number | null
   badges?: SteamBadge[] | null
 }


### PR DESCRIPTION
## Summary
- Store `communityVisibilityState` from Steam GetPlayerSummaries in session cookie
- Show warning banner on dashboard when profile is not public (visibility !== 3)
- Banner links directly to Steam privacy settings

## Test plan
- [ ] Public profile — no warning
- [ ] Private profile — yellow warning with Steam settings link
- [ ] No skeleton loop with private profile
- [ ] `pnpm test` — 90 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)