### PR TITLE
feat: enrich admin user list with Steam profile data

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -101,9 +101,11 @@ export default function AdminPage() {
       })
       if (res.ok) {
         await loadUsers()
+      } else {
+        setError("Failed to refresh profile")
       }
     } catch {
-      // ignore
+      setError("Failed to refresh profile")
     } finally {
       setRefreshingId(null)
     }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,17 +1,21 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { useCurrentUser } from "@/hooks/use-current-user"
 import { PageContainer } from "@/components/ui/page-container"
 import { LoadingMessage } from "@/components/ui/loading-message"
 import { Button } from "@/components/ui/button"
-import { Trash2, UserPlus } from "lucide-react"
+import { ExternalLink, RefreshCw, Trash2, UserPlus } from "lucide-react"
 
 interface AllowedUser {
   steam_id: string
   added_by: string | null
   added_at: string
+  persona_name: string | null
+  avatar_url: string | null
+  profile_url: string | null
+  last_login_at: string | null
 }
 
 export default function AdminPage() {
@@ -21,6 +25,7 @@ export default function AdminPage() {
   const [loadingUsers, setLoadingUsers] = useState(true)
   const [newSteamId, setNewSteamId] = useState("")
   const [error, setError] = useState<string | null>(null)
+  const [refreshingId, setRefreshingId] = useState<string | null>(null)
 
   useEffect(() => {
     if (!loading && !user) {
@@ -28,25 +33,23 @@ export default function AdminPage() {
     }
   }, [loading, user, router])
 
-  useEffect(() => {
-    async function loadUsers() {
-      try {
-        const res = await fetch("/api/admin/users")
-        if (res.status === 403) {
-          router.push("/dashboard")
-          return
-        }
-        if (!res.ok) throw new Error("Failed to load users")
-        const data = await res.json()
-        setUsers(data.users)
-      } catch {
-        setError("Failed to load users")
-      } finally {
-        setLoadingUsers(false)
-      }
+  const loadUsers = useCallback(async () => {
+    const res = await fetch("/api/admin/users")
+    if (res.status === 403) {
+      router.push("/dashboard")
+      return
     }
-    if (user) void loadUsers()
-  }, [user, router])
+    if (!res.ok) throw new Error("Failed to load users")
+    const data = await res.json()
+    setUsers(data.users)
+  }, [router])
+
+  useEffect(() => {
+    if (!user) return
+    loadUsers()
+      .catch(() => setError("Failed to load users"))
+      .finally(() => setLoadingUsers(false))
+  }, [user, loadUsers])
 
   const handleAdd = async () => {
     if (!/^\d{17}$/.test(newSteamId.trim())) {
@@ -65,13 +68,7 @@ export default function AdminPage() {
         throw new Error(data.error || "Failed to add user")
       }
       setNewSteamId("")
-      // Reload users
-      const res2 = await fetch("/api/admin/users")
-      if (!res2.ok) {
-        throw new Error("User added, but failed to reload users list")
-      }
-      const data = await res2.json()
-      setUsers(data.users)
+      await loadUsers()
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to add user")
     }
@@ -91,6 +88,24 @@ export default function AdminPage() {
       setUsers((prev) => prev.filter((u) => u.steam_id !== steamId))
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to remove user")
+    }
+  }
+
+  const handleRefresh = async (steamId: string) => {
+    setRefreshingId(steamId)
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ steamId }),
+      })
+      if (res.ok) {
+        await loadUsers()
+      }
+    } catch {
+      // ignore
+    } finally {
+      setRefreshingId(null)
     }
   }
 
@@ -129,26 +144,68 @@ export default function AdminPage() {
           {users.map((u) => (
             <div
               key={u.steam_id}
-              className="border-surface-4 bg-surface-1 flex items-center justify-between rounded-lg border px-4 py-3"
+              className="border-surface-4 bg-surface-1 flex items-center gap-4 rounded-lg border px-4 py-3"
             >
-              <div>
-                <p className="text-sm font-medium">{u.steam_id}</p>
-                <p className="text-muted-foreground text-xs">
-                  Added {u.added_by === "env_seed" ? "from env var" : u.added_by ? `by ${u.added_by}` : "manually"} ·{" "}
-                  {new Date(u.added_at).toLocaleDateString()}
-                </p>
+              {u.avatar_url ? (
+                <img
+                  src={u.avatar_url}
+                  alt={`${u.persona_name || u.steam_id}'s avatar`}
+                  className="border-surface-4 h-10 w-10 rounded-full border"
+                />
+              ) : (
+                <div className="border-surface-4 bg-surface-2 h-10 w-10 rounded-full border" />
+              )}
+
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="truncate text-sm font-medium">{u.persona_name || u.steam_id}</p>
+                  {u.profile_url && (
+                    <a href={u.profile_url} target="_blank" rel="noopener noreferrer" aria-label="Steam profile">
+                      <ExternalLink className="text-muted-foreground hover:text-foreground h-3.5 w-3.5" />
+                    </a>
+                  )}
+                </div>
+                <div className="text-muted-foreground flex flex-wrap gap-x-3 text-xs">
+                  <span>{u.steam_id}</span>
+                  <span>
+                    Added {u.added_by === "env_seed" ? "from env" : u.added_by ? `by ${u.added_by}` : "manually"}
+                  </span>
+                  {u.last_login_at && (
+                    <span>
+                      Last login{" "}
+                      {new Date(u.last_login_at).toLocaleDateString(undefined, {
+                        day: "numeric",
+                        month: "short",
+                        year: "numeric",
+                      })}
+                    </span>
+                  )}
+                </div>
               </div>
-              {u.steam_id !== user.steamId && (
+
+              <div className="flex items-center gap-1">
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => handleRemove(u.steam_id)}
-                  className="text-muted-foreground hover:text-destructive"
-                  aria-label={`Remove ${u.steam_id}`}
+                  onClick={() => handleRefresh(u.steam_id)}
+                  disabled={refreshingId === u.steam_id}
+                  className="text-muted-foreground hover:text-foreground"
+                  aria-label={`Refresh ${u.persona_name || u.steam_id}`}
                 >
-                  <Trash2 className="h-3.5 w-3.5" />
+                  <RefreshCw className={`h-3.5 w-3.5 ${refreshingId === u.steam_id ? "animate-spin" : ""}`} />
                 </Button>
-              )}
+                {u.steam_id !== user.steamId && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemove(u.steam_id)}
+                    className="text-muted-foreground hover:text-destructive"
+                    aria-label={`Remove ${u.persona_name || u.steam_id}`}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,16 +1,33 @@
 import { NextResponse } from "next/server"
 import { requireAdmin } from "@/app/lib/require-admin"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
+import { upsertProfile } from "@/lib/server/steam-store-utils"
 import { logger } from "@/lib/server/logger"
 
-/** GET /api/admin/users - List allowed users */
+/** GET /api/admin/users - List allowed users with profile info */
 export async function GET() {
   try {
     const admin = await requireAdmin()
     if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
 
     const db = getSqliteDatabase()
-    const users = db.prepare("SELECT steam_id, added_by, added_at FROM allowed_users ORDER BY added_at DESC").all()
+    const users = db
+      .prepare(
+        `
+      SELECT
+        au.steam_id,
+        au.added_by,
+        au.added_at,
+        sp.persona_name,
+        sp.avatar_url,
+        sp.profile_url,
+        sp.last_login_at
+      FROM allowed_users au
+      LEFT JOIN steam_profile sp ON sp.steam_id = au.steam_id
+      ORDER BY au.added_at DESC
+    `,
+      )
+      .all()
     return NextResponse.json({ users })
   } catch (error) {
     logger.error({ err: error }, "List users error")
@@ -46,6 +63,10 @@ export async function POST(request: Request) {
       admin.steamId,
       new Date().toISOString(),
     )
+
+    // Try to fetch profile info from Steam
+    await refreshSteamProfile(steamId)
+
     return NextResponse.json({ success: true })
   } catch (error) {
     logger.error({ err: error }, "Add user error")
@@ -85,5 +106,72 @@ export async function DELETE(request: Request) {
   } catch (error) {
     logger.error({ err: error }, "Remove user error")
     return NextResponse.json({ error: "Failed to remove user" }, { status: 500 })
+  }
+}
+
+/** PATCH /api/admin/users - Refresh a user's Steam profile data */
+export async function PATCH(request: Request) {
+  try {
+    const admin = await requireAdmin()
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    if (!body || typeof body !== "object") {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const { steamId } = body as { steamId?: string }
+    if (!steamId || !/^\d{17}$/.test(steamId)) {
+      return NextResponse.json({ error: "Valid Steam ID required (17 digits)" }, { status: 400 })
+    }
+
+    const profile = await refreshSteamProfile(steamId)
+    if (!profile) {
+      return NextResponse.json({ error: "Could not fetch Steam profile" }, { status: 502 })
+    }
+
+    return NextResponse.json({ success: true, profile })
+  } catch (error) {
+    logger.error({ err: error }, "Refresh user profile error")
+    return NextResponse.json({ error: "Failed to refresh profile" }, { status: 500 })
+  }
+}
+
+/** Fetches a user's Steam profile and updates the local database. */
+async function refreshSteamProfile(steamId: string) {
+  const apiKey = process.env.STEAM_API_KEY
+  if (!apiKey) return null
+
+  try {
+    const url = new URL("https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/")
+    url.searchParams.set("key", apiKey)
+    url.searchParams.set("steamids", steamId)
+
+    const res = await fetch(url)
+    if (!res.ok) return null
+
+    const data = await res.json()
+    const player = data.response?.players?.[0]
+    if (!player) return null
+
+    upsertProfile(steamId, {
+      personaName: player.personaname,
+      avatarUrl: player.avatarfull,
+      profileUrl: player.profileurl,
+    })
+
+    return {
+      persona_name: player.personaname,
+      avatar_url: player.avatarfull,
+      profile_url: player.profileurl,
+    }
+  } catch {
+    return null
   }
 }

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -131,6 +131,12 @@ export async function PATCH(request: Request) {
       return NextResponse.json({ error: "Valid Steam ID required (17 digits)" }, { status: 400 })
     }
 
+    const db = getSqliteDatabase()
+    const exists = db.prepare("SELECT 1 FROM allowed_users WHERE steam_id = ?").get(steamId)
+    if (!exists) {
+      return NextResponse.json({ error: "User not found in allowed list" }, { status: 404 })
+    }
+
     const profile = await refreshSteamProfile(steamId)
     if (!profile) {
       return NextResponse.json({ error: "Could not fetch Steam profile" }, { status: 502 })

--- a/app/api/auth/steam/callback/route.ts
+++ b/app/api/auth/steam/callback/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import crypto from "node:crypto"
 import { cookies } from "next/headers"
 import { isSteamIdWhitelisted } from "@/lib/whitelist"
+import { upsertProfile } from "@/lib/server/steam-store-utils"
 import { logger } from "@/lib/server/logger"
 
 const STEAM_OPENID_URL = "https://steamcommunity.com/openid/login"
@@ -168,6 +169,13 @@ export async function GET(request: NextRequest) {
         maxAge: 60 * 60 * 24 * 7, // 7 days
       },
     )
+
+    upsertProfile(player.steamid, {
+      personaName: player.personaname,
+      avatarUrl: player.avatarfull,
+      profileUrl: player.profileurl,
+      lastLoginAt: new Date().toISOString(),
+    })
 
     logger.info({ steamId: player.steamid }, "Successful Steam login")
 

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -250,6 +250,20 @@ const migrations: Array<(db: DatabaseSync) => void> = [
   (db) => {
     db.exec("DROP TABLE IF EXISTS tracked_games;")
   },
+
+  // Migration 7: Add avatar, profile URL, and last login to steam_profile
+  (db) => {
+    const addColumnIfMissing = (table: string, column: string, definition: string) => {
+      const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+      if (!cols.some((c) => c.name === column)) {
+        db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition};`)
+      }
+    }
+
+    addColumnIfMissing("steam_profile", "avatar_url", "TEXT")
+    addColumnIfMissing("steam_profile", "profile_url", "TEXT")
+    addColumnIfMissing("steam_profile", "last_login_at", "TEXT")
+  },
 ]
 
 function runMigrations(db: DatabaseSync) {

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -38,6 +38,9 @@ function createBaseSchema(db: DatabaseSync) {
     CREATE TABLE IF NOT EXISTS steam_profile (
       steam_id TEXT PRIMARY KEY,
       persona_name TEXT,
+      avatar_url TEXT,
+      profile_url TEXT,
+      last_login_at TEXT,
       last_owned_games_sync_at TEXT,
       last_recent_games_sync_at TEXT,
       created_at TEXT NOT NULL,

--- a/lib/server/steam-store-utils.ts
+++ b/lib/server/steam-store-utils.ts
@@ -42,7 +42,14 @@ export function parseJson<T>(value: string | null | undefined): T | null {
   }
 }
 
-export function upsertProfile(steamId: string) {
+interface UpsertProfileOptions {
+  personaName?: string
+  avatarUrl?: string
+  profileUrl?: string
+  lastLoginAt?: string
+}
+
+export function upsertProfile(steamId: string, options?: UpsertProfileOptions) {
   const db = getSqliteDatabase()
   const now = nowIso()
 
@@ -50,13 +57,29 @@ export function upsertProfile(steamId: string) {
     `
     INSERT INTO steam_profile (
       steam_id,
+      persona_name,
+      avatar_url,
+      profile_url,
+      last_login_at,
       created_at,
       updated_at
-    ) VALUES (?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(steam_id) DO UPDATE SET
+      persona_name = COALESCE(excluded.persona_name, steam_profile.persona_name),
+      avatar_url = COALESCE(excluded.avatar_url, steam_profile.avatar_url),
+      profile_url = COALESCE(excluded.profile_url, steam_profile.profile_url),
+      last_login_at = COALESCE(excluded.last_login_at, steam_profile.last_login_at),
       updated_at = excluded.updated_at
   `,
-  ).run(steamId, now, now)
+  ).run(
+    steamId,
+    options?.personaName ?? null,
+    options?.avatarUrl ?? null,
+    options?.profileUrl ?? null,
+    options?.lastLoginAt ?? null,
+    now,
+    now,
+  )
 }
 
 export function markProfileSync(


### PR DESCRIPTION
## Summary
- **Migration 7**: adds avatar_url, profile_url, last_login_at to steam_profile
- **Login**: persists display name, avatar, profile URL, and last login timestamp
- **Admin API**: GET returns profile data via JOIN; PATCH refreshes profile from Steam; POST auto-fetches on add
- **Admin UI**: avatar, name, profile link, last login, refresh button per user

## Test plan
- [ ] Login — profile data persisted
- [ ] Admin page shows avatars, names, last login dates
- [ ] Refresh button updates name/avatar from Steam
- [ ] Add new user — profile auto-fetched
- [ ] \`pnpm test\` — 90 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)