### PR TITLE
feat: add og:url and og:logo meta tags

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,11 @@ export const metadata: Metadata = {
     title: "Steam Backlog Hunter",
     description: "Track your Steam backlog, monitor achievement progress, and hunt down completions.",
     type: "website",
+    url: "/",
     images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "Steam Backlog Hunter" }],
+  },
+  other: {
+    "og:logo": "/icon.svg",
   },
   twitter: {
     card: "summary_large_image",


### PR DESCRIPTION
## Summary
- Add `og:url` meta tag via Next.js `openGraph.url` (resolves against `metadataBase`)
- Add `og:logo` meta tag pointing to the existing favicon SVG (`/icon.svg`)

## Test plan
- [ ] Verify meta tags render correctly in page source
- [ ] Validate with an OG debugger tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)