### PR TITLE
feat: update playtime distribution bands

### DIFF
--- a/components/dashboard/dashboard-insights.tsx
+++ b/components/dashboard/dashboard-insights.tsx
@@ -190,17 +190,17 @@ export function DashboardInsights({ stats, loading = false }: DashboardInsightsP
   const libraryModel = useMemo(() => {
     if (libraryMetric === "playtime") {
       const bands = [
-        { name: "0h", value: 0 },
-        { name: "<10h", value: 0 },
-        { name: "10-50h", value: 0 },
-        { name: "50h+", value: 0 },
+        { name: "<1h", value: 0 },
+        { name: "1-5h", value: 0 },
+        { name: "5-25h", value: 0 },
+        { name: "25h+", value: 0 },
       ]
 
       for (const game of allGames) {
         const hours = game.playtime_forever / 60
-        if (hours === 0) bands[0].value += 1
-        else if (hours < 10) bands[1].value += 1
-        else if (hours < 50) bands[2].value += 1
+        if (hours < 1) bands[0].value += 1
+        else if (hours < 5) bands[1].value += 1
+        else if (hours < 25) bands[2].value += 1
         else bands[3].value += 1
       }
 
@@ -209,7 +209,7 @@ export function DashboardInsights({ stats, loading = false }: DashboardInsightsP
         data: bands,
         insight:
           allGames.length > 0
-            ? `${bands[0].value} games remain untouched, while ${bands[3].value} already have 50+ hours logged.`
+            ? `${bands[0].value} games under 1 hour, ${bands[3].value} with 25+ hours logged.`
             : "Load the full library to reveal playtime bands.",
         chartKind: "bars" as const,
       }


### PR DESCRIPTION
## Summary
- Update playtime chart bands from `0h / <10h / 10-50h / 50h+` to `<1h / 1-5h / 5-25h / 25h+`
- Merge unplayed games into the `<1h` bucket for a cleaner continuous distribution

## Test plan
- [ ] Verify playtime bands render correctly on the dashboard insights card

🤖 Generated with [Claude Code](https://claude.com/claude-code)