### PR TITLE
feat: normalize achievements storage (PR #1/4 — migration + dual-write)

### DIFF
--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -120,6 +120,34 @@ function createBaseSchema(db: DatabaseSync) {
       added_at TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS game_achievements (
+      appid INTEGER NOT NULL,
+      apiname TEXT NOT NULL,
+      display_name TEXT,
+      description TEXT,
+      icon TEXT,
+      icon_gray TEXT,
+      hidden INTEGER NOT NULL DEFAULT 0,
+      global_percent REAL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (appid, apiname),
+      FOREIGN KEY (appid) REFERENCES games(appid)
+    );
+
+    CREATE TABLE IF NOT EXISTS user_achievements (
+      steam_id TEXT NOT NULL,
+      appid INTEGER NOT NULL,
+      apiname TEXT NOT NULL,
+      achieved INTEGER NOT NULL DEFAULT 0,
+      unlock_time INTEGER,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (steam_id, appid, apiname),
+      FOREIGN KEY (steam_id) REFERENCES steam_profile(steam_id),
+      FOREIGN KEY (appid) REFERENCES games(appid)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id ON user_games(steam_id);
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id_owned ON user_games(steam_id, owned);
     CREATE INDEX IF NOT EXISTS idx_stats_snapshot_steam_id ON stats_snapshot(steam_id);
@@ -266,6 +294,136 @@ const migrations: Array<(db: DatabaseSync) => void> = [
     addColumnIfMissing("steam_profile", "avatar_url", "TEXT")
     addColumnIfMissing("steam_profile", "profile_url", "TEXT")
     addColumnIfMissing("steam_profile", "last_login_at", "TEXT")
+  },
+
+  // Migration 8: Create normalized achievements tables and backfill from
+  // existing schema_json / achievements_json blobs. The JSON columns are
+  // still dual-written while read paths are migrated in a follow-up.
+  (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS game_achievements (
+        appid INTEGER NOT NULL,
+        apiname TEXT NOT NULL,
+        display_name TEXT,
+        description TEXT,
+        icon TEXT,
+        icon_gray TEXT,
+        hidden INTEGER NOT NULL DEFAULT 0,
+        global_percent REAL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (appid, apiname),
+        FOREIGN KEY (appid) REFERENCES games(appid)
+      );
+
+      CREATE TABLE IF NOT EXISTS user_achievements (
+        steam_id TEXT NOT NULL,
+        appid INTEGER NOT NULL,
+        apiname TEXT NOT NULL,
+        achieved INTEGER NOT NULL DEFAULT 0,
+        unlock_time INTEGER,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (steam_id, appid, apiname),
+        FOREIGN KEY (steam_id) REFERENCES steam_profile(steam_id),
+        FOREIGN KEY (appid) REFERENCES games(appid)
+      );
+    `)
+
+    const now = new Date().toISOString()
+
+    const insertGameAch = db.prepare(`
+      INSERT INTO game_achievements (
+        appid, apiname, display_name, description, icon, icon_gray, hidden, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(appid, apiname) DO UPDATE SET
+        display_name = excluded.display_name,
+        description = excluded.description,
+        icon = excluded.icon,
+        icon_gray = excluded.icon_gray,
+        hidden = excluded.hidden,
+        updated_at = excluded.updated_at
+    `)
+
+    type SchemaRow = { appid: number; schema_json: string | null }
+    const schemaRows = db
+      .prepare("SELECT appid, schema_json FROM games WHERE schema_json IS NOT NULL")
+      .all() as SchemaRow[]
+
+    for (const row of schemaRows) {
+      if (!row.schema_json) continue
+      try {
+        const schema = JSON.parse(row.schema_json) as {
+          availableGameStats?: {
+            achievements?: Array<{
+              name: string
+              displayName?: string
+              description?: string
+              icon?: string
+              icongray?: string
+              hidden?: number
+            }>
+          }
+        }
+        const list = schema.availableGameStats?.achievements ?? []
+        for (const item of list) {
+          if (!item.name) continue
+          insertGameAch.run(
+            row.appid,
+            item.name,
+            item.displayName ?? null,
+            item.description ?? null,
+            item.icon ?? null,
+            item.icongray ?? null,
+            item.hidden ? 1 : 0,
+            now,
+            now,
+          )
+        }
+      } catch {
+        // Skip malformed rows — dual-write will repopulate on next sync.
+      }
+    }
+
+    const insertUserAch = db.prepare(`
+      INSERT INTO user_achievements (
+        steam_id, appid, apiname, achieved, unlock_time, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(steam_id, appid, apiname) DO UPDATE SET
+        achieved = excluded.achieved,
+        unlock_time = excluded.unlock_time,
+        updated_at = excluded.updated_at
+    `)
+
+    type UserRow = { steam_id: string; appid: number; achievements_json: string | null }
+    const userRows = db
+      .prepare("SELECT steam_id, appid, achievements_json FROM user_games WHERE achievements_json IS NOT NULL")
+      .all() as UserRow[]
+
+    for (const row of userRows) {
+      if (!row.achievements_json) continue
+      try {
+        const list = JSON.parse(row.achievements_json) as Array<{
+          apiname: string
+          achieved: number
+          unlocktime?: number
+        }>
+        for (const item of list) {
+          if (!item.apiname) continue
+          insertUserAch.run(
+            row.steam_id,
+            row.appid,
+            item.apiname,
+            item.achieved ? 1 : 0,
+            item.unlocktime ?? null,
+            now,
+            now,
+          )
+        }
+      } catch {
+        // Skip malformed rows — dual-write will repopulate on next sync.
+      }
+    }
   },
 ]
 

--- a/lib/server/steam-achievements-sync.ts
+++ b/lib/server/steam-achievements-sync.ts
@@ -30,6 +30,7 @@ type SchemaAchievement = {
   description?: string
   icon?: string
   icongray?: string
+  hidden?: number
 }
 
 type GameSchema = {
@@ -82,7 +83,12 @@ export function getBatchStoredAchievements(steamId: string, appIds: number[]): R
   return result
 }
 
-/** Saves achievement data to SQLite, computing unlocked/total counts and perfect game status. */
+/**
+ * Saves achievement data to SQLite, computing unlocked/total counts and perfect game status.
+ *
+ * Dual-writes into both the legacy `user_games.achievements_json` blob and the
+ * normalized `user_achievements` table while the read path is being migrated.
+ */
 export function persistAchievements(steamId: string, appId: number, achievements: SteamAchievementView[]) {
   const db = getSqliteDatabase()
   const now = nowIso()
@@ -90,31 +96,102 @@ export function persistAchievements(steamId: string, appId: number, achievements
   const totalCount = achievements.length
   const perfectGame = totalCount > 0 && unlockedCount === totalCount ? 1 : 0
 
-  db.prepare(
-    `
-    UPDATE user_games
-    SET
-      achievements_json = ?,
-      achievements_synced_at = ?,
-      unlocked_count = ?,
-      total_count = ?,
-      perfect_game = ?,
-      updated_at = ?
-    WHERE steam_id = ? AND appid = ? AND owned = 1
-  `,
-  ).run(JSON.stringify(achievements), now, unlockedCount, totalCount, perfectGame, now, steamId, appId)
+  db.exec("BEGIN")
+  try {
+    db.prepare(
+      `
+      UPDATE user_games
+      SET
+        achievements_json = ?,
+        achievements_synced_at = ?,
+        unlocked_count = ?,
+        total_count = ?,
+        perfect_game = ?,
+        updated_at = ?
+      WHERE steam_id = ? AND appid = ? AND owned = 1
+    `,
+    ).run(JSON.stringify(achievements), now, unlockedCount, totalCount, perfectGame, now, steamId, appId)
+
+    db.prepare(`DELETE FROM user_achievements WHERE steam_id = ? AND appid = ?`).run(steamId, appId)
+
+    const insert = db.prepare(`
+      INSERT INTO user_achievements (
+        steam_id, appid, apiname, achieved, unlock_time, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `)
+
+    for (const achievement of achievements) {
+      if (!achievement.apiname) continue
+      insert.run(
+        steamId,
+        appId,
+        achievement.apiname,
+        achievement.achieved ? 1 : 0,
+        achievement.unlocktime ?? null,
+        now,
+        now,
+      )
+    }
+
+    db.exec("COMMIT")
+  } catch (error) {
+    db.exec("ROLLBACK")
+    throw error
+  }
 }
 
+/**
+ * Dual-writes the game schema into both the legacy `games.schema_json` blob
+ * and the normalized `game_achievements` table.
+ */
 function persistSchema(appId: number, schema: GameSchema | null) {
   const db = getSqliteDatabase()
   const now = nowIso()
-  db.prepare(
-    `
-    UPDATE games
-    SET schema_json = ?, schema_synced_at = ?, updated_at = ?
-    WHERE appid = ?
-  `,
-  ).run(schema ? JSON.stringify(schema) : null, now, now, appId)
+
+  db.exec("BEGIN")
+  try {
+    db.prepare(
+      `
+      UPDATE games
+      SET schema_json = ?, schema_synced_at = ?, updated_at = ?
+      WHERE appid = ?
+    `,
+    ).run(schema ? JSON.stringify(schema) : null, now, now, appId)
+
+    const achievements = schema?.availableGameStats?.achievements ?? []
+    const upsert = db.prepare(`
+      INSERT INTO game_achievements (
+        appid, apiname, display_name, description, icon, icon_gray, hidden, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(appid, apiname) DO UPDATE SET
+        display_name = excluded.display_name,
+        description = excluded.description,
+        icon = excluded.icon,
+        icon_gray = excluded.icon_gray,
+        hidden = excluded.hidden,
+        updated_at = excluded.updated_at
+    `)
+
+    for (const achievement of achievements) {
+      if (!achievement.name) continue
+      upsert.run(
+        appId,
+        achievement.name,
+        achievement.displayName ?? null,
+        achievement.description ?? null,
+        achievement.icon ?? null,
+        achievement.icongray ?? null,
+        achievement.hidden ? 1 : 0,
+        now,
+        now,
+      )
+    }
+
+    db.exec("COMMIT")
+  } catch (error) {
+    db.exec("ROLLBACK")
+    throw error
+  }
 }
 
 /** Retrieves the stored game schema (achievement definitions) from SQLite. */

--- a/test/achievements-dual-write.test.ts
+++ b/test/achievements-dual-write.test.ts
@@ -183,6 +183,147 @@ describe("achievements dual-write (PR #1)", () => {
     ])
   })
 
+  it("migration 8 backfills normalized tables from legacy JSON blobs on upgrade", async () => {
+    // Phase 1: initialise a fully-migrated DB, seed legacy blobs, then revert
+    // to a pre-migration-8 state (drop normalized tables + unapply migration 8)
+    // so we can observe the upgrade path run on re-open.
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const seedDb = getSqliteDatabase()
+    const now = new Date().toISOString()
+
+    seedDb
+      .prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`)
+      .run(STEAM_ID, now, now)
+
+    const legacySchema = {
+      availableGameStats: {
+        achievements: [
+          {
+            name: "ACH_LEGACY_ONE",
+            displayName: "Legacy One",
+            description: "Unlocked legacy achievement",
+            icon: "legacy-one.jpg",
+            icongray: "legacy-one-gray.jpg",
+            hidden: 0,
+          },
+          {
+            name: "ACH_LEGACY_TWO",
+            displayName: "Legacy Two",
+            description: "Still-locked legacy achievement",
+            icon: "legacy-two.jpg",
+            icongray: "legacy-two-gray.jpg",
+            hidden: 1,
+          },
+        ],
+      },
+    }
+
+    seedDb
+      .prepare(
+        `INSERT INTO games (appid, name, schema_json, schema_synced_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(APPID, "Legacy Game", JSON.stringify(legacySchema), now, now, now)
+
+    const legacyUserAchievements = [
+      {
+        apiname: "ACH_LEGACY_ONE",
+        achieved: 1,
+        unlocktime: 1_650_000_000,
+        displayName: "Legacy One",
+        description: "",
+        icon: "",
+        icongray: "",
+      },
+      {
+        apiname: "ACH_LEGACY_TWO",
+        achieved: 0,
+        unlocktime: 0,
+        displayName: "Legacy Two",
+        description: "",
+        icon: "",
+        icongray: "",
+      },
+    ]
+
+    seedDb
+      .prepare(
+        `INSERT INTO user_games (
+          steam_id, appid, playtime_forever, owned, achievements_json,
+          achievements_synced_at, unlocked_count, total_count, perfect_game,
+          created_at, updated_at
+        ) VALUES (?, ?, 0, 1, ?, ?, 1, 2, 0, ?, ?)`,
+      )
+      .run(STEAM_ID, APPID, JSON.stringify(legacyUserAchievements), now, now, now)
+
+    // Revert to pre-migration-8 state: drop normalized tables + unapply v8.
+    // Also wipe any rows the dual-write path wrote into the normalized tables
+    // during seeding — we want to verify the backfill alone reconstructs them.
+    seedDb.exec(`
+      DROP TABLE IF EXISTS game_achievements;
+      DROP TABLE IF EXISTS user_achievements;
+      DELETE FROM schema_migrations WHERE version = 8;
+    `)
+
+    // Close this handle so the re-import gets a fresh DatabaseSync to the
+    // same file and triggers migration 8.
+    seedDb.close()
+
+    vi.resetModules()
+    const { getSqliteDatabase: getFreshDb } = await import("@/lib/server/sqlite")
+    const db = getFreshDb()
+
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+      name: string
+    }>
+    const names = tables.map((t) => t.name)
+    expect(names).toContain("game_achievements")
+    expect(names).toContain("user_achievements")
+
+    const gameAchRows = db
+      .prepare(
+        "SELECT apiname, display_name, description, icon, icon_gray, hidden FROM game_achievements WHERE appid = ? ORDER BY apiname",
+      )
+      .all(APPID) as Array<{
+      apiname: string
+      display_name: string | null
+      description: string | null
+      icon: string | null
+      icon_gray: string | null
+      hidden: number
+    }>
+
+    expect(gameAchRows).toEqual([
+      {
+        apiname: "ACH_LEGACY_ONE",
+        display_name: "Legacy One",
+        description: "Unlocked legacy achievement",
+        icon: "legacy-one.jpg",
+        icon_gray: "legacy-one-gray.jpg",
+        hidden: 0,
+      },
+      {
+        apiname: "ACH_LEGACY_TWO",
+        display_name: "Legacy Two",
+        description: "Still-locked legacy achievement",
+        icon: "legacy-two.jpg",
+        icon_gray: "legacy-two-gray.jpg",
+        hidden: 1,
+      },
+    ])
+
+    const userAchRows = db
+      .prepare(
+        "SELECT apiname, achieved, unlock_time FROM user_achievements WHERE steam_id = ? AND appid = ? ORDER BY apiname",
+      )
+      .all(STEAM_ID, APPID) as Array<{ apiname: string; achieved: number; unlock_time: number | null }>
+
+    expect(userAchRows).toEqual([
+      { apiname: "ACH_LEGACY_ONE", achieved: 1, unlock_time: 1_650_000_000 },
+      { apiname: "ACH_LEGACY_TWO", achieved: 0, unlock_time: 0 },
+    ])
+  })
+
   it("persistAchievements is idempotent — re-running replaces normalized rows", async () => {
     const db = await seedProfileAndGame()
     const { persistAchievements } = await import("@/lib/server/steam-achievements-sync")

--- a/test/achievements-dual-write.test.ts
+++ b/test/achievements-dual-write.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-ach-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.SQLITE_PATH
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const STEAM_ID = "76561198000000001"
+const APPID = 730
+
+async function seedProfileAndGame() {
+  const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+  const db = getSqliteDatabase()
+  const now = new Date().toISOString()
+  db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
+  db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)`).run(
+    APPID,
+    "Test Game",
+    now,
+    now,
+  )
+  db.prepare(
+    `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+     VALUES (?, ?, 0, 1, ?, ?)`,
+  ).run(STEAM_ID, APPID, now, now)
+  return db
+}
+
+describe("achievements dual-write (PR #1)", () => {
+  it("creates game_achievements and user_achievements tables via migration", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+
+    const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+      name: string
+    }>
+    const names = tables.map((t) => t.name)
+
+    expect(names).toContain("game_achievements")
+    expect(names).toContain("user_achievements")
+  })
+
+  it("persistSchema writes to both schema_json and game_achievements", async () => {
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue({
+        availableGameStats: {
+          achievements: [
+            {
+              name: "ACH_WIN_ONE_GAME",
+              displayName: "Win one game",
+              description: "Win your first game",
+              icon: "icon.jpg",
+              icongray: "icongray.jpg",
+              hidden: 0,
+            },
+            {
+              name: "ACH_SECRET",
+              displayName: "Secret",
+              hidden: 1,
+            },
+          ],
+        },
+      }),
+      getPlayerAchievements: vi.fn(),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+    }))
+
+    const db = await seedProfileAndGame()
+    const { ensureSchema } = await import("@/lib/server/steam-achievements-sync")
+
+    await ensureSchema(STEAM_ID, APPID, { forceRefresh: true })
+
+    const schemaRow = db.prepare("SELECT schema_json FROM games WHERE appid = ?").get(APPID) as {
+      schema_json: string | null
+    }
+    expect(schemaRow.schema_json).toBeTruthy()
+
+    const rows = db
+      .prepare(
+        "SELECT apiname, display_name, description, icon, icon_gray, hidden FROM game_achievements WHERE appid = ? ORDER BY apiname",
+      )
+      .all(APPID) as Array<{
+      apiname: string
+      display_name: string | null
+      description: string | null
+      icon: string | null
+      icon_gray: string | null
+      hidden: number
+    }>
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      apiname: "ACH_SECRET",
+      display_name: "Secret",
+      hidden: 1,
+    })
+    expect(rows[1]).toMatchObject({
+      apiname: "ACH_WIN_ONE_GAME",
+      display_name: "Win one game",
+      description: "Win your first game",
+      icon: "icon.jpg",
+      icon_gray: "icongray.jpg",
+      hidden: 0,
+    })
+  })
+
+  it("persistAchievements writes to both achievements_json and user_achievements", async () => {
+    const db = await seedProfileAndGame()
+    const { persistAchievements } = await import("@/lib/server/steam-achievements-sync")
+
+    persistAchievements(STEAM_ID, APPID, [
+      {
+        apiname: "ACH_WIN_ONE_GAME",
+        achieved: 1,
+        unlocktime: 1_700_000_000,
+        displayName: "Win one game",
+        description: "",
+        icon: "",
+        icongray: "",
+      },
+      {
+        apiname: "ACH_KILL_100",
+        achieved: 0,
+        unlocktime: 0,
+        displayName: "Kill 100 enemies",
+        description: "",
+        icon: "",
+        icongray: "",
+      },
+    ])
+
+    const userGameRow = db
+      .prepare(
+        "SELECT achievements_json, unlocked_count, total_count, perfect_game FROM user_games WHERE steam_id = ? AND appid = ?",
+      )
+      .get(STEAM_ID, APPID) as {
+      achievements_json: string
+      unlocked_count: number
+      total_count: number
+      perfect_game: number
+    }
+    expect(userGameRow.unlocked_count).toBe(1)
+    expect(userGameRow.total_count).toBe(2)
+    expect(userGameRow.perfect_game).toBe(0)
+    expect(JSON.parse(userGameRow.achievements_json)).toHaveLength(2)
+
+    const normalized = db
+      .prepare(
+        "SELECT apiname, achieved, unlock_time FROM user_achievements WHERE steam_id = ? AND appid = ? ORDER BY apiname",
+      )
+      .all(STEAM_ID, APPID) as Array<{ apiname: string; achieved: number; unlock_time: number | null }>
+
+    expect(normalized).toEqual([
+      { apiname: "ACH_KILL_100", achieved: 0, unlock_time: 0 },
+      { apiname: "ACH_WIN_ONE_GAME", achieved: 1, unlock_time: 1_700_000_000 },
+    ])
+  })
+
+  it("persistAchievements is idempotent — re-running replaces normalized rows", async () => {
+    const db = await seedProfileAndGame()
+    const { persistAchievements } = await import("@/lib/server/steam-achievements-sync")
+
+    persistAchievements(STEAM_ID, APPID, [
+      { apiname: "A", achieved: 0, unlocktime: 0, displayName: "", description: "", icon: "", icongray: "" },
+      { apiname: "B", achieved: 0, unlocktime: 0, displayName: "", description: "", icon: "", icongray: "" },
+    ])
+    persistAchievements(STEAM_ID, APPID, [
+      { apiname: "A", achieved: 1, unlocktime: 123, displayName: "", description: "", icon: "", icongray: "" },
+    ])
+
+    const rows = db
+      .prepare("SELECT apiname, achieved FROM user_achievements WHERE steam_id = ? AND appid = ?")
+      .all(STEAM_ID, APPID) as Array<{ apiname: string; achieved: number }>
+
+    expect(rows).toEqual([{ apiname: "A", achieved: 1 }])
+  })
+})


### PR DESCRIPTION
Implements step 1 of #100.

## Summary
- Adds `game_achievements` and `user_achievements` tables via migration 8, with backfill from existing `schema_json` / `achievements_json` blobs so the normalized copy is complete from the moment this ships.
- `persistSchema` now dual-writes the game achievement definitions into `game_achievements` alongside the legacy `schema_json` blob.
- `persistAchievements` now dual-writes per-user unlock state into `user_achievements` (inside a transaction) alongside the legacy `achievements_json` blob.
- Read paths are untouched — this PR is purely additive and safe to revert.

## Why dual-write
Standard zero-downtime storage migration pattern: decouple schema creation from read-path rewrite. PR #2 will switch reads to JOIN-based queries, PR #3 will wire in the `GetTopAchievementsForGames` bulk endpoint writing directly into `user_achievements`, and PR #4 will drop the JSON columns once the old path is gone.

## Test plan
- [x] New integration tests against a real SQLite DB (temp file) verifying:
  - migration creates both tables
  - `persistSchema` writes to `games.schema_json` **and** `game_achievements`
  - `persistAchievements` writes to `user_games.achievements_json` **and** `user_achievements`
  - re-running `persistAchievements` is idempotent (old rows replaced)
- [x] **Upgrade-path test**: seed a database with legacy `schema_json` / `achievements_json` blobs, revert it to the pre-migration-8 state (drop normalized tables, delete migration 8 from `schema_migrations`), re-open, and verify migration 8 reconstructs `game_achievements` and `user_achievements` entirely from the legacy blobs. Exercises the exact upgrade path that will run on next deploy.
- [x] `pnpm test` — all 95 tests pass
- [x] `pnpm lint` — clean (eslint + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)