### PR TITLE
feat: read achievements from normalized tables (PR #2/4)

### DIFF
--- a/lib/server/steam-achievements-sync.ts
+++ b/lib/server/steam-achievements-sync.ts
@@ -11,12 +11,35 @@ const SCHEMA_STALE_MS = 30 * 24 * 60 * 60 * 1000
 
 export { ACHIEVEMENTS_STALE_MS }
 
-type UserAchievementRow = {
-  achievements_json: string | null
+type UserAchievementMetaRow = {
   achievements_synced_at: string | null
   unlocked_count: number | null
   total_count: number | null
   perfect_game: number | null
+}
+
+type AchievementJoinRow = {
+  appid: number
+  apiname: string
+  display_name: string | null
+  description: string | null
+  icon: string | null
+  icon_gray: string | null
+  achieved: number
+  unlock_time: number | null
+}
+
+function mapJoinRowToView(row: AchievementJoinRow): SteamAchievementView {
+  return {
+    apiname: row.apiname,
+    achieved: row.achieved,
+    unlocktime: row.unlock_time ?? 0,
+    name: row.display_name ?? row.apiname,
+    description: row.description ?? "",
+    displayName: row.display_name ?? row.apiname,
+    icon: row.icon ?? "",
+    icongray: row.icon_gray ?? "",
+  }
 }
 
 type SchemaRow = {
@@ -39,22 +62,70 @@ type GameSchema = {
   }
 }
 
-/** Retrieves stored achievement data for a single game from SQLite. */
+/** Retrieves stored achievement sync metadata (counts, timestamp, perfect flag) for a single game. */
 export function getStoredAchievements(steamId: string, appId: number) {
   const db = getSqliteDatabase()
   return db
     .prepare(
       `
-    SELECT achievements_json, achievements_synced_at, unlocked_count, total_count, perfect_game
+    SELECT achievements_synced_at, unlocked_count, total_count, perfect_game
     FROM user_games
     WHERE steam_id = ? AND appid = ? AND owned = 1
   `,
     )
-    .get(steamId, appId) as UserAchievementRow | undefined
+    .get(steamId, appId) as UserAchievementMetaRow | undefined
 }
 
 /**
- * Retrieves stored achievements for multiple games in a single query.
+ * Reads a single game's enriched achievements from the normalized tables.
+ *
+ * Returns the full achievement list (including locked entries) by joining
+ * `game_achievements` with `user_achievements`, or `null` if the game has
+ * never been synced or has no achievements defined in its schema.
+ */
+export function readStoredAchievementsList(steamId: string, appId: number): SteamAchievementView[] | null {
+  const db = getSqliteDatabase()
+  const meta = db
+    .prepare(
+      `SELECT achievements_synced_at FROM user_games
+       WHERE steam_id = ? AND appid = ? AND owned = 1`,
+    )
+    .get(steamId, appId) as { achievements_synced_at: string | null } | undefined
+
+  if (!meta?.achievements_synced_at) return null
+
+  const rows = db
+    .prepare(
+      `
+      SELECT
+        ga.appid,
+        ga.apiname,
+        ga.display_name,
+        ga.description,
+        ga.icon,
+        ga.icon_gray,
+        COALESCE(ua.achieved, 0) AS achieved,
+        COALESCE(ua.unlock_time, 0) AS unlock_time
+      FROM game_achievements ga
+      LEFT JOIN user_achievements ua
+        ON ua.appid = ga.appid
+        AND ua.apiname = ga.apiname
+        AND ua.steam_id = ?
+      WHERE ga.appid = ?
+      ORDER BY ga.apiname
+    `,
+    )
+    .all(steamId, appId) as AchievementJoinRow[]
+
+  if (rows.length === 0) return null
+  return rows.map(mapJoinRowToView)
+}
+
+/**
+ * Retrieves stored achievements for multiple games in a single JOIN query.
+ *
+ * Filters to games the user has already synced (`achievements_synced_at IS NOT NULL`)
+ * so that unsynced games are absent from the result rather than appearing as all-locked.
  *
  * @returns A map of app ID to achievement views
  */
@@ -62,23 +133,38 @@ export function getBatchStoredAchievements(steamId: string, appIds: number[]): R
   if (appIds.length === 0) return {}
 
   const db = getSqliteDatabase()
+  const placeholders = appIds.map(() => "?").join(",")
   const rows = db
     .prepare(
       `
-    SELECT appid, achievements_json
-    FROM user_games
-    WHERE steam_id = ? AND owned = 1 AND achievements_json IS NOT NULL
-      AND appid IN (${appIds.map(() => "?").join(",")})
-  `,
+      SELECT
+        ga.appid,
+        ga.apiname,
+        ga.display_name,
+        ga.description,
+        ga.icon,
+        ga.icon_gray,
+        COALESCE(ua.achieved, 0) AS achieved,
+        COALESCE(ua.unlock_time, 0) AS unlock_time
+      FROM user_games ug
+      JOIN game_achievements ga ON ga.appid = ug.appid
+      LEFT JOIN user_achievements ua
+        ON ua.appid = ga.appid
+        AND ua.apiname = ga.apiname
+        AND ua.steam_id = ug.steam_id
+      WHERE ug.steam_id = ?
+        AND ug.owned = 1
+        AND ug.achievements_synced_at IS NOT NULL
+        AND ug.appid IN (${placeholders})
+      ORDER BY ga.appid, ga.apiname
+    `,
     )
-    .all(steamId, ...appIds) as Array<{ appid: number; achievements_json: string }>
+    .all(steamId, ...appIds) as AchievementJoinRow[]
 
   const result: Record<number, SteamAchievementView[]> = {}
   for (const row of rows) {
-    const parsed = parseJson<SteamAchievementView[]>(row.achievements_json)
-    if (parsed) {
-      result[row.appid] = parsed
-    }
+    const list = result[row.appid] ?? (result[row.appid] = [])
+    list.push(mapJoinRowToView(row))
   }
   return result
 }
@@ -263,12 +349,12 @@ export async function getAchievementsForGame(steamId: string, appId: number, opt
     storedAchievements &&
     !isStale(storedAchievements.achievements_synced_at, ACHIEVEMENTS_STALE_MS)
   ) {
-    const parsed = parseJson<SteamAchievementView[]>(storedAchievements.achievements_json)
-    if (parsed) {
+    const cached = readStoredAchievementsList(steamId, appId)
+    if (cached) {
       return {
         steamID: steamId,
         gameName: game.name,
-        achievements: parsed,
+        achievements: cached,
         success: true,
       }
     }

--- a/test/achievements-normalized-reads.test.ts
+++ b/test/achievements-normalized-reads.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-read-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.SQLITE_PATH
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const STEAM_ID = "76561198000000001"
+const APPID_A = 730
+const APPID_B = 440
+
+async function seed() {
+  const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+  const db = getSqliteDatabase()
+  const now = new Date().toISOString()
+
+  db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
+
+  for (const appid of [APPID_A, APPID_B]) {
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)`).run(
+      appid,
+      `Game ${appid}`,
+      now,
+      now,
+    )
+  }
+
+  // Seed game_achievements (schema) directly — bypass the dual-write path
+  // so the test can't pass by accidentally reading achievements_json.
+  const insertGameAch = db.prepare(`
+    INSERT INTO game_achievements (
+      appid, apiname, display_name, description, icon, icon_gray, hidden, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `)
+
+  insertGameAch.run(APPID_A, "ACH_A1", "Alpha One", "First alpha", "a1.jpg", "a1g.jpg", 0, now, now)
+  insertGameAch.run(APPID_A, "ACH_A2", "Alpha Two", "Second alpha", "a2.jpg", "a2g.jpg", 0, now, now)
+  insertGameAch.run(APPID_B, "ACH_B1", "Bravo One", "First bravo", "b1.jpg", "b1g.jpg", 0, now, now)
+
+  // Mark user_games as owned + synced, but leave achievements_json NULL so
+  // only the normalized path can satisfy reads.
+  for (const appid of [APPID_A, APPID_B]) {
+    db.prepare(
+      `INSERT INTO user_games (
+        steam_id, appid, playtime_forever, owned, achievements_synced_at,
+        unlocked_count, total_count, perfect_game, created_at, updated_at
+      ) VALUES (?, ?, 0, 1, ?, 1, 2, 0, ?, ?)`,
+    ).run(STEAM_ID, appid, now, now, now)
+  }
+
+  // Seed user_achievements for APPID_A only (one unlocked, one locked)
+  const insertUserAch = db.prepare(`
+    INSERT INTO user_achievements (
+      steam_id, appid, apiname, achieved, unlock_time, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `)
+  insertUserAch.run(STEAM_ID, APPID_A, "ACH_A1", 1, 1_700_000_000, now, now)
+  // ACH_A2 is intentionally absent — LEFT JOIN should yield achieved=0
+
+  return db
+}
+
+describe("achievements normalized read path (PR #2)", () => {
+  it("getBatchStoredAchievements reads from normalized tables, not achievements_json", async () => {
+    await seed()
+    const { getBatchStoredAchievements } = await import("@/lib/server/steam-achievements-sync")
+
+    const result = getBatchStoredAchievements(STEAM_ID, [APPID_A, APPID_B])
+
+    expect(Object.keys(result).map(Number).sort()).toEqual([APPID_B, APPID_A])
+
+    expect(result[APPID_A]).toEqual([
+      {
+        apiname: "ACH_A1",
+        achieved: 1,
+        unlocktime: 1_700_000_000,
+        name: "Alpha One",
+        displayName: "Alpha One",
+        description: "First alpha",
+        icon: "a1.jpg",
+        icongray: "a1g.jpg",
+      },
+      {
+        apiname: "ACH_A2",
+        achieved: 0,
+        unlocktime: 0,
+        name: "Alpha Two",
+        displayName: "Alpha Two",
+        description: "Second alpha",
+        icon: "a2.jpg",
+        icongray: "a2g.jpg",
+      },
+    ])
+
+    // APPID_B has a schema row but no user_achievements rows — should still
+    // return the locked achievement (LEFT JOIN).
+    expect(result[APPID_B]).toEqual([
+      {
+        apiname: "ACH_B1",
+        achieved: 0,
+        unlocktime: 0,
+        name: "Bravo One",
+        displayName: "Bravo One",
+        description: "First bravo",
+        icon: "b1.jpg",
+        icongray: "b1g.jpg",
+      },
+    ])
+  })
+
+  it("getBatchStoredAchievements omits games that were never synced", async () => {
+    const db = await seed()
+    // Unsync APPID_B — the batch read should drop it entirely rather than
+    // return an all-locked stub.
+    db.prepare(`UPDATE user_games SET achievements_synced_at = NULL WHERE steam_id = ? AND appid = ?`).run(
+      STEAM_ID,
+      APPID_B,
+    )
+
+    const { getBatchStoredAchievements } = await import("@/lib/server/steam-achievements-sync")
+
+    const result = getBatchStoredAchievements(STEAM_ID, [APPID_A, APPID_B])
+
+    expect(Object.keys(result)).toEqual([String(APPID_A)])
+  })
+
+  it("readStoredAchievementsList returns null when the game was never synced", async () => {
+    const db = await seed()
+    db.prepare(`UPDATE user_games SET achievements_synced_at = NULL WHERE steam_id = ? AND appid = ?`).run(
+      STEAM_ID,
+      APPID_A,
+    )
+
+    const { readStoredAchievementsList } = await import("@/lib/server/steam-achievements-sync")
+
+    expect(readStoredAchievementsList(STEAM_ID, APPID_A)).toBeNull()
+  })
+
+  it("readStoredAchievementsList returns the full enriched list via JOIN", async () => {
+    await seed()
+    const { readStoredAchievementsList } = await import("@/lib/server/steam-achievements-sync")
+
+    const list = readStoredAchievementsList(STEAM_ID, APPID_A)
+
+    expect(list).toHaveLength(2)
+    expect(list?.[0]).toMatchObject({ apiname: "ACH_A1", achieved: 1, displayName: "Alpha One" })
+    expect(list?.[1]).toMatchObject({ apiname: "ACH_A2", achieved: 0, displayName: "Alpha Two" })
+  })
+
+  it("getStoredAchievements returns metadata only (no achievements_json field)", async () => {
+    await seed()
+    const { getStoredAchievements } = await import("@/lib/server/steam-achievements-sync")
+
+    const meta = getStoredAchievements(STEAM_ID, APPID_A)
+
+    expect(meta).toMatchObject({
+      unlocked_count: 1,
+      total_count: 2,
+      perfect_game: 0,
+    })
+    expect(meta?.achievements_synced_at).toBeTruthy()
+    // achievements_json should not be part of the returned shape anymore
+    expect((meta as unknown as { achievements_json?: unknown }).achievements_json).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Implements step 2 of #100. Builds on #101 (merged).

## Summary
- `getStoredAchievements` now returns metadata only (`achievements_synced_at`, `unlocked_count`, `total_count`, `perfect_game`). The `achievements_json` field is gone from the return type — no caller still reads it.
- New `readStoredAchievementsList(steamId, appId)` helper reconstructs the full enriched view via a LEFT JOIN between `game_achievements` and `user_achievements`. Returns `null` when the game was never synced.
- `getBatchStoredAchievements` becomes a single JOIN query with `WHERE ug.appid IN (...)`, filtered by `ug.achievements_synced_at IS NOT NULL`. Unsynced games are dropped from the result rather than appearing as all-locked stubs.
- `getAchievementsForGame` reads from the normalized path via `readStoredAchievementsList` instead of parsing `achievements_json`.

## Safety net
`persistAchievements` still dual-writes `achievements_json` alongside `user_achievements`. Nothing reads the blob anymore, but it stays on disk until PR #4 drops the column. This PR is a pure read-path switch — rollback is a straight revert.

## Test plan
- [x] New integration tests verify reads come from the normalized tables (seed `game_achievements` + `user_achievements` directly, leave `achievements_json` NULL, confirm reads still succeed).
- [x] LEFT JOIN correctness: a game with schema rows but no `user_achievements` rows returns all-locked achievements.
- [x] Unsynced games are omitted from batch reads and `readStoredAchievementsList` returns `null`.
- [x] `getStoredAchievements` no longer exposes `achievements_json`.
- [x] `pnpm test` — all 100 tests pass (95 + 5 new)
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)