### PR TITLE
feat: bulk-sync achievements via GetTopAchievementsForGames (PR #3/4)

### DIFF
--- a/lib/server/steam-achievements-sync.ts
+++ b/lib/server/steam-achievements-sync.ts
@@ -227,6 +227,61 @@ export function persistAchievements(steamId: string, appId: number, achievements
 }
 
 /**
+ * Persists a bulk `GetTopAchievementsForGames` result for a single game.
+ *
+ * The bulk endpoint only returns **unlocked** achievements, so this function
+ * writes the unlocked-count metadata onto `user_games` and replaces the
+ * game's `user_achievements` rows with one row per unlocked apiname. Locked
+ * achievements are not materialised — they're derived at read time via a
+ * LEFT JOIN against `game_achievements`.
+ *
+ * Unlike `persistAchievements`, this function does not touch the legacy
+ * `achievements_json` blob. That blob is only read as a safety net during
+ * the dual-write period and is unused by the normalized read path.
+ */
+export function persistBulkGameStats(steamId: string, appId: number, totalCount: number, unlockedApinames: string[]) {
+  const db = getSqliteDatabase()
+  const now = nowIso()
+  const unlockedCount = unlockedApinames.length
+  const perfectGame = totalCount > 0 && unlockedCount === totalCount ? 1 : 0
+
+  db.exec("BEGIN")
+  try {
+    db.prepare(
+      `
+      UPDATE user_games
+      SET
+        achievements_synced_at = ?,
+        unlocked_count = ?,
+        total_count = ?,
+        perfect_game = ?,
+        updated_at = ?
+      WHERE steam_id = ? AND appid = ? AND owned = 1
+    `,
+    ).run(now, unlockedCount, totalCount, perfectGame, now, steamId, appId)
+
+    db.prepare(`DELETE FROM user_achievements WHERE steam_id = ? AND appid = ?`).run(steamId, appId)
+
+    if (unlockedCount > 0) {
+      const insert = db.prepare(`
+        INSERT INTO user_achievements (
+          steam_id, appid, apiname, achieved, unlock_time, created_at, updated_at
+        ) VALUES (?, ?, ?, 1, NULL, ?, ?)
+      `)
+      for (const apiname of unlockedApinames) {
+        if (!apiname) continue
+        insert.run(steamId, appId, apiname, now, now)
+      }
+    }
+
+    db.exec("COMMIT")
+  } catch (error) {
+    db.exec("ROLLBACK")
+    throw error
+  }
+}
+
+/**
  * Dual-writes the game schema into both the legacy `games.schema_json` blob
  * and the normalized `game_achievements` table.
  */

--- a/lib/server/steam-stats-compute.ts
+++ b/lib/server/steam-stats-compute.ts
@@ -1,18 +1,20 @@
 import "server-only"
 
 import type { SteamStatsResponse } from "@/lib/types/steam"
+import { getTopAchievementsForGames } from "@/lib/steam-api"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { isStale, upsertProfile, getProfileSync, roundPercent } from "@/lib/server/steam-store-utils"
 import { ensureOwnedGamesSynced, getRecentlyPlayedGamesForUser } from "@/lib/server/steam-games-sync"
+import { logger } from "@/lib/server/logger"
 import {
   ACHIEVEMENTS_STALE_MS,
   getStoredAchievements,
-  getAchievementsForGame,
+  persistBulkGameStats,
 } from "@/lib/server/steam-achievements-sync"
 
 export const OWNED_GAMES_STALE_MS = 24 * 60 * 60 * 1000
 const STATS_STALE_MS = 15 * 60 * 1000
-const ACHIEVEMENTS_CONCURRENCY = 8
+const BULK_ACHIEVEMENTS_BATCH_SIZE = 100
 
 type StatsSnapshotRow = {
   total_games: number
@@ -144,32 +146,61 @@ export function getStoredStatsSnapshot(steamId: string) {
 async function syncAchievementsForStats(steamId: string, forceRefresh: boolean) {
   const ownedGames = await ensureOwnedGamesSynced(steamId, { forceRefresh })
 
-  // Only sync games that already have confirmed achievements (total_count > 0)
-  // or that have never been checked yet (no achievements_synced_at)
-  const candidateGames = ownedGames.filter((game) => {
+  // Candidate set: games with community stats that aren't already known-broken
+  // (synced once and confirmed to have 0 achievements), and whose stored
+  // unlock state is either missing or stale.
+  const stale = ownedGames.filter((game) => {
     if (!game.has_community_visible_stats) return false
     const stored = getStoredAchievements(steamId, game.appid)
-    // Already synced with 0 achievements — skip (broken/retired game)
     if (stored?.achievements_synced_at && (stored.total_count ?? 0) === 0) return false
+    if (!forceRefresh && stored && !isStale(stored.achievements_synced_at, ACHIEVEMENTS_STALE_MS)) {
+      return false
+    }
     return true
   })
 
-  for (let index = 0; index < candidateGames.length; index += ACHIEVEMENTS_CONCURRENCY) {
-    const chunk = candidateGames.slice(index, index + ACHIEVEMENTS_CONCURRENCY)
-    await Promise.allSettled(
-      chunk.map(async (game) => {
-        const storedAchievements = getStoredAchievements(steamId, game.appid)
-        if (
-          !forceRefresh &&
-          storedAchievements &&
-          !isStale(storedAchievements.achievements_synced_at, ACHIEVEMENTS_STALE_MS)
-        ) {
-          return
-        }
+  if (stale.length === 0) return
 
-        await getAchievementsForGame(steamId, game.appid, { forceRefresh })
-      }),
-    )
+  // Batch stale games into the undocumented GetTopAchievementsForGames
+  // endpoint (~100 games per HTTP call). For 1000-game libraries this
+  // collapses ~1000 per-game GetPlayerAchievements calls into ~10 bulk calls.
+  for (let index = 0; index < stale.length; index += BULK_ACHIEVEMENTS_BATCH_SIZE) {
+    const chunk = stale.slice(index, index + BULK_ACHIEVEMENTS_BATCH_SIZE)
+    const requestedAppIds = new Set(chunk.map((game) => game.appid))
+
+    let games: Awaited<ReturnType<typeof getTopAchievementsForGames>>
+    try {
+      games = await getTopAchievementsForGames(
+        steamId,
+        chunk.map((game) => game.appid),
+      )
+    } catch (error) {
+      logger.warn(
+        { err: error, batchSize: chunk.length },
+        "Bulk achievements batch failed — stale games will retry on next sync",
+      )
+      continue
+    }
+
+    const seen = new Set<number>()
+    for (const game of games) {
+      if (!requestedAppIds.has(game.appid)) continue
+      seen.add(game.appid)
+      const unlockedApinames = (game.achievements ?? [])
+        .map((achievement) => achievement.name ?? "")
+        .filter((name) => name.length > 0)
+      persistBulkGameStats(steamId, game.appid, game.total_achievements ?? 0, unlockedApinames)
+    }
+
+    // Games in the batch that the endpoint silently dropped — mark nothing;
+    // they'll be retried on the next sync.
+    const missing = chunk.filter((game) => !seen.has(game.appid))
+    if (missing.length > 0) {
+      logger.debug(
+        { missingCount: missing.length, batchStart: index },
+        "Bulk achievements response omitted games — will retry next sync",
+      )
+    }
   }
 }
 

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -143,6 +143,70 @@ export async function getPlayerAchievements(steamId: string, appId: number): Pro
   }
 }
 
+export interface BulkTopAchievement {
+  statid?: number
+  bit?: number
+  name?: string
+  desc?: string
+  icon?: string
+  icon_gray?: string
+  hidden?: boolean
+  player_percent_unlocked?: string
+}
+
+export interface BulkGameAchievements {
+  appid: number
+  total_achievements: number
+  achievements?: BulkTopAchievement[]
+}
+
+/**
+ * Fetches top achievement data for multiple games in a single request using
+ * the undocumented IPlayerService/GetTopAchievementsForGames endpoint.
+ *
+ * The response only includes **unlocked** achievements for each game; locked
+ * achievements are implied by `total_achievements - achievements.length`.
+ * Games the user hasn't unlocked anything in are returned with just
+ * `total_achievements` and no `achievements` array.
+ *
+ * Returns an empty array if the request fails (the caller can fall back to
+ * per-game syncs for the affected batch).
+ */
+export async function getTopAchievementsForGames(
+  steamId: string,
+  appIds: number[],
+  maxAchievements = 10_000,
+): Promise<BulkGameAchievements[]> {
+  if (appIds.length === 0) return []
+
+  const apiKey = process.env.STEAM_API_KEY
+  if (!apiKey) {
+    throw new SteamAPIError("STEAM_API_KEY is not configured", 500)
+  }
+
+  const url = new URL(`${STEAM_API_BASE}/IPlayerService/GetTopAchievementsForGames/v1/`)
+  url.searchParams.set("key", apiKey)
+  url.searchParams.set("format", "json")
+  url.searchParams.set("steamid", steamId)
+  url.searchParams.set("language", "es")
+  url.searchParams.set("max_achievements", String(maxAchievements))
+  appIds.forEach((appId, index) => {
+    url.searchParams.set(`appids[${index}]`, String(appId))
+  })
+
+  try {
+    const response = await fetch(url.toString(), { cache: "no-store" })
+    if (!response.ok) {
+      throw new SteamAPIError(`Steam API request failed: ${response.status}`, response.status)
+    }
+    const data = (await response.json()) as { response?: { games?: BulkGameAchievements[] } }
+    return data.response?.games ?? []
+  } catch (error) {
+    console.error("Error fetching bulk achievements for batch of", appIds.length, "games:", error)
+    return []
+  }
+}
+
 /** Fetches the game schema (achievement and stat definitions) from the Steam API. */
 export async function getGameSchema(appId: number): Promise<unknown> {
   try {

--- a/test/achievements-bulk-sync.test.ts
+++ b/test/achievements-bulk-sync.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-bulk-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.SQLITE_PATH
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const STEAM_ID = "76561198000000001"
+
+async function seedOwnedGames(
+  entries: Array<{ appid: number; name: string; hasStats?: boolean; syncedAt?: string | null; totalCount?: number }>,
+) {
+  const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+  const db = getSqliteDatabase()
+  const now = new Date().toISOString()
+
+  db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
+
+  for (const entry of entries) {
+    db.prepare(
+      `INSERT INTO games (appid, name, has_community_visible_stats, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(entry.appid, entry.name, entry.hasStats === false ? 0 : 1, now, now)
+
+    db.prepare(
+      `INSERT INTO user_games (
+        steam_id, appid, playtime_forever, owned, achievements_synced_at,
+        unlocked_count, total_count, perfect_game, created_at, updated_at
+      ) VALUES (?, ?, 0, 1, ?, 0, ?, 0, ?, ?)`,
+    ).run(STEAM_ID, entry.appid, entry.syncedAt ?? null, entry.totalCount ?? 0, now, now)
+  }
+
+  return db
+}
+
+describe("persistBulkGameStats", () => {
+  it("writes metadata and replaces user_achievements rows from a bulk response", async () => {
+    const db = await seedOwnedGames([{ appid: 730, name: "CS2" }])
+    const { persistBulkGameStats } = await import("@/lib/server/steam-achievements-sync")
+
+    persistBulkGameStats(STEAM_ID, 730, 5, ["ACH_ONE", "ACH_TWO"])
+
+    const meta = db
+      .prepare(
+        "SELECT unlocked_count, total_count, perfect_game, achievements_synced_at FROM user_games WHERE steam_id = ? AND appid = ?",
+      )
+      .get(STEAM_ID, 730) as {
+      unlocked_count: number
+      total_count: number
+      perfect_game: number
+      achievements_synced_at: string | null
+    }
+
+    expect(meta.unlocked_count).toBe(2)
+    expect(meta.total_count).toBe(5)
+    expect(meta.perfect_game).toBe(0)
+    expect(meta.achievements_synced_at).toBeTruthy()
+
+    const rows = db
+      .prepare(
+        "SELECT apiname, achieved, unlock_time FROM user_achievements WHERE steam_id = ? AND appid = ? ORDER BY apiname",
+      )
+      .all(STEAM_ID, 730) as Array<{ apiname: string; achieved: number; unlock_time: number | null }>
+
+    expect(rows).toEqual([
+      { apiname: "ACH_ONE", achieved: 1, unlock_time: null },
+      { apiname: "ACH_TWO", achieved: 1, unlock_time: null },
+    ])
+  })
+
+  it("flags perfect_game when unlocked === total", async () => {
+    const db = await seedOwnedGames([{ appid: 440, name: "TF2" }])
+    const { persistBulkGameStats } = await import("@/lib/server/steam-achievements-sync")
+
+    persistBulkGameStats(STEAM_ID, 440, 3, ["A", "B", "C"])
+
+    const meta = db
+      .prepare("SELECT unlocked_count, total_count, perfect_game FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, 440) as { unlocked_count: number; total_count: number; perfect_game: number }
+
+    expect(meta).toEqual({ unlocked_count: 3, total_count: 3, perfect_game: 1 })
+  })
+
+  it("clears stale user_achievements when re-persisting with fewer unlocks", async () => {
+    const db = await seedOwnedGames([{ appid: 570, name: "Dota 2" }])
+    const { persistBulkGameStats } = await import("@/lib/server/steam-achievements-sync")
+
+    persistBulkGameStats(STEAM_ID, 570, 4, ["A", "B", "C"])
+    persistBulkGameStats(STEAM_ID, 570, 4, ["A"])
+
+    const rows = db
+      .prepare("SELECT apiname FROM user_achievements WHERE steam_id = ? AND appid = ?")
+      .all(STEAM_ID, 570) as Array<{ apiname: string }>
+
+    expect(rows).toEqual([{ apiname: "A" }])
+  })
+})
+
+describe("syncAchievementsForStats (bulk endpoint)", () => {
+  it("batches stale games through getTopAchievementsForGames and persists results", async () => {
+    const mockGetTop = vi.fn().mockResolvedValue([
+      { appid: 730, total_achievements: 2, achievements: [{ name: "ACH_ONE" }] },
+      { appid: 440, total_achievements: 3, achievements: [{ name: "ACH_A" }, { name: "ACH_B" }, { name: "ACH_C" }] },
+      { appid: 570, total_achievements: 0 },
+    ])
+
+    vi.doMock("@/lib/steam-api", () => ({
+      getTopAchievementsForGames: mockGetTop,
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
+      getPlayerAchievements: vi.fn(),
+      getGameSchema: vi.fn(),
+    }))
+    vi.doMock("@/lib/server/steam-images", () => ({
+      ensureGameImages: vi.fn().mockResolvedValue(undefined),
+    }))
+
+    const db = await seedOwnedGames([
+      { appid: 730, name: "CS2" },
+      { appid: 440, name: "TF2" },
+      { appid: 570, name: "Dota 2" },
+      // This one has no community stats — should be excluded from the bulk call
+      { appid: 999, name: "No Stats Game", hasStats: false },
+    ])
+
+    // Mark owned-games sync as fresh so ensureOwnedGamesSynced is a no-op
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(now, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+    // forceRefresh: false so ensureOwnedGamesSynced returns the seeded cache
+    // instead of calling the mocked getOwnedGames (which would return []).
+    // The stale filter still fires because achievements_synced_at is NULL.
+    const stats = await getStatsForUser(STEAM_ID, { forceRefresh: false })
+
+    expect(mockGetTop).toHaveBeenCalledTimes(1)
+    expect(mockGetTop.mock.calls[0][0]).toBe(STEAM_ID)
+    // The candidate list is filtered by has_community_visible_stats, so 999 is excluded.
+    expect(new Set(mockGetTop.mock.calls[0][1])).toEqual(new Set([730, 440, 570]))
+
+    const rows = db
+      .prepare(
+        "SELECT appid, unlocked_count, total_count, perfect_game FROM user_games WHERE steam_id = ? ORDER BY appid",
+      )
+      .all(STEAM_ID) as Array<{ appid: number; unlocked_count: number; total_count: number; perfect_game: number }>
+
+    expect(rows).toEqual([
+      { appid: 440, unlocked_count: 3, total_count: 3, perfect_game: 1 },
+      { appid: 570, unlocked_count: 0, total_count: 0, perfect_game: 0 },
+      { appid: 730, unlocked_count: 1, total_count: 2, perfect_game: 0 },
+      { appid: 999, unlocked_count: 0, total_count: 0, perfect_game: 0 },
+    ])
+
+    expect(stats.totalAchievements).toBe(4) // 1 + 3 + 0
+    expect(stats.perfectGames).toBe(1)
+  })
+
+  it("skips games that are already fresh and not forced", async () => {
+    const mockGetTop = vi.fn().mockResolvedValue([])
+
+    vi.doMock("@/lib/steam-api", () => ({
+      getTopAchievementsForGames: mockGetTop,
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
+      getPlayerAchievements: vi.fn(),
+      getGameSchema: vi.fn(),
+    }))
+    vi.doMock("@/lib/server/steam-images", () => ({
+      ensureGameImages: vi.fn().mockResolvedValue(undefined),
+    }))
+
+    const freshIso = new Date().toISOString()
+    const db = await seedOwnedGames([{ appid: 730, name: "CS2", syncedAt: freshIso, totalCount: 5 }])
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(freshIso, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+    // Force stats recompute but not forceRefresh at the achievements layer
+    await getStatsForUser(STEAM_ID, { forceRefresh: false })
+    // Stats snapshot is stale-by-default on first call, so it will run syncAchievementsForStats.
+    // With the only candidate game fresh, the bulk call should NOT fire.
+    expect(mockGetTop).not.toHaveBeenCalled()
+  })
+
+  it("continues sync when a bulk batch throws — affected games stay stale", async () => {
+    const mockGetTop = vi.fn().mockRejectedValue(new Error("network blip"))
+
+    vi.doMock("@/lib/steam-api", () => ({
+      getTopAchievementsForGames: mockGetTop,
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
+      getPlayerAchievements: vi.fn(),
+      getGameSchema: vi.fn(),
+    }))
+    vi.doMock("@/lib/server/steam-images", () => ({
+      ensureGameImages: vi.fn().mockResolvedValue(undefined),
+    }))
+
+    const db = await seedOwnedGames([{ appid: 730, name: "CS2" }])
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(now, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+    await expect(getStatsForUser(STEAM_ID, { forceRefresh: false })).resolves.toBeTruthy()
+
+    // Stale game remains unsynced (no achievements_synced_at written)
+    const row = db
+      .prepare("SELECT achievements_synced_at FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, 730) as { achievements_synced_at: string | null }
+    expect(row.achievements_synced_at).toBeNull()
+  })
+})


### PR DESCRIPTION
Implements step 3 of #100. Builds on #101 and #102 (both merged).

## Summary
- Adds `getTopAchievementsForGames(steamId, appIds[])` wrapper in `lib/steam-api.ts` for the undocumented `IPlayerService/GetTopAchievementsForGames/v1/` endpoint. Accepts up to ~100 appids per request and returns unlocked-achievement data + `total_achievements` counts for each game in a single HTTP call.
- Adds `persistBulkGameStats(steamId, appId, totalCount, unlockedApinames)` in `steam-achievements-sync.ts`. Writes unlock metadata (`unlocked_count`, `total_count`, `perfect_game`, `achievements_synced_at`) onto `user_games` and replaces the game's `user_achievements` rows with one row per unlocked apiname, inside a transaction. Locked achievements are derived at read time via the LEFT JOIN against `game_achievements` — no need to materialise them.
- Rewrites `syncAchievementsForStats` to batch stale games into the bulk endpoint (`BULK_ACHIEVEMENTS_BATCH_SIZE = 100`). For a 1000-game library this collapses ~1000 per-game `GetPlayerAchievements` calls into ~10 bulk HTTP calls.
- Failed bulk batches are logged and skipped — stale games stay stale and will be retried on the next sync, so one bad response doesn't block the rest.

## What's deliberately untouched
- The `/game/[id]` detail view still uses `GetPlayerAchievements` + `GetSchemaForGame` via `getAchievementsForGame`. The bulk endpoint does not return `unlocktime` or the full schema, so it can't power the detailed per-achievement view. This is the right split: bulk for stats aggregation, per-game for detail.
- `persistAchievements` (per-game path) still dual-writes the legacy `achievements_json` blob. PR #4 drops it.

## Caveat noted in the Stack Overflow answer
> If the user has completed achievements for a game, they will appear in the `achievements` array. If no achievements are completed, only the `appid` and `total_achievements` fields are returned.

`persistBulkGameStats` handles both shapes: unlocked list can be empty, `total_achievements: 0` is treated as "broken/retired game" on the next sync via the existing candidate filter.

## Test plan
- [x] `persistBulkGameStats` unit behaviours: metadata + user_achievements replacement, perfect_game flag, idempotent replacement when unlocks shrink.
- [x] `syncAchievementsForStats` integration: batches stale games into one bulk call, excludes games without `has_community_visible_stats`, persists results correctly, fresh games are skipped, and a thrown bulk batch leaves affected games stale without crashing the sync.
- [x] `pnpm test` — all 106 tests pass (100 + 6 new)
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)