### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Something in the app is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. A good report includes what you did, what you expected, and what actually happened — that's usually enough to get started.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug. Screenshots or logs are welcome.
+      placeholder: "When I click sync on the dashboard, the achievement counts freeze at zero."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      placeholder: "Counts should update to reflect the current Steam data within a few seconds."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal sequence that triggers the bug. Include the route, any relevant filters, and the game(s) involved if it's game-specific.
+      placeholder: |
+        1. Log in as steam id 76561...
+        2. Go to /dashboard
+        3. Click "Sync"
+        4. Observe counts stay at 0
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Where were you running the app?
+      placeholder: "Local dev (pnpm dev, Node 24.13, macOS), or deployed instance"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / console output
+      description: Paste any relevant server logs, browser console errors, or network request failures.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/finallyjay/steam-backlog-hunter/security/advisories/new
+    about: Please report security issues privately via GitHub security advisories, not via public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest a new capability, improvement, or refactor
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for anything that isn't a bug — new features, UX improvements, refactors, or infrastructure changes. Focus on the *why* more than the *what*.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem is this solving?
+      description: The situation that makes this worth doing. "Users can't X" or "Every sync takes Y minutes because Z".
+      placeholder: "First-time sync on a 1000-game library takes ~5 minutes because we fetch achievements one game at a time."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: How you'd solve it. Sketch is fine — doesn't need to be a full design.
+      placeholder: "Use the undocumented GetTopAchievementsForGames endpoint to batch ~100 appids per request."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they're worse. Helps avoid re-litigating dead ends.
+    validations:
+      required: false
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact / tradeoffs
+      description: What breaks, what migrates, what gets worse. Be honest about the tradeoffs.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds YAML issue forms for bug reports and feature requests
- `config.yml` disables blank issues and redirects security reports to the private advisory flow
- Completes the community standards set (alongside SECURITY, CONTRIBUTING, CoC, and the PR template PRs)

## Test plan
- [x] YAML is valid and fields render as expected in GitHub's "New issue" flow (verified after merge)
- [x] Blank issues are disabled
- [x] Security advisory link is the first contact option

🤖 Generated with [Claude Code](https://claude.com/claude-code)