### PR TITLE
fix(ci): drop GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an explicit `permissions: contents: read` block to `.github/workflows/ci.yml`
- Drops the default write-all `GITHUB_TOKEN` scope down to the minimum needed for lint + test + build
- Resolves CodeQL alert `actions/missing-workflow-permissions` (medium severity)

## Why
Principle of least privilege. The CI workflow only reads the repo — it doesn't push, doesn't comment on PRs, doesn't create issues. There's no reason for its token to have write access to anything.

## Test plan
- [x] `yaml-lint` — clean (single-line addition, no syntax risk)
- [x] Workflow still runs on push to main + pull requests (trigger block unchanged)
- [ ] CI on this PR runs successfully with the restricted token (verified by GitHub on PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)