### PR TITLE
fix(achievements): dedupe apinames before inserting user_achievements

### DIFF
--- a/lib/server/steam-achievements-sync.ts
+++ b/lib/server/steam-achievements-sync.ts
@@ -176,7 +176,14 @@ export function getBatchStoredAchievements(steamId: string, appIds: number[]): R
 export function persistAchievements(steamId: string, appId: number, achievements: SteamAchievement[]) {
   const db = getSqliteDatabase()
   const now = nowIso()
-  const unlockedCount = achievements.filter((achievement) => achievement.achieved === 1).length
+  const unlockedByApiname = new Map<string, SteamAchievement>()
+  for (const achievement of achievements) {
+    if (!achievement.apiname || achievement.achieved !== 1) continue
+    if (!unlockedByApiname.has(achievement.apiname)) {
+      unlockedByApiname.set(achievement.apiname, achievement)
+    }
+  }
+  const unlockedCount = unlockedByApiname.size
   const totalCount = achievements.length
   const perfectGame = totalCount > 0 && unlockedCount === totalCount ? 1 : 0
 
@@ -203,8 +210,7 @@ export function persistAchievements(steamId: string, appId: number, achievements
       ) VALUES (?, ?, ?, 1, ?, ?, ?)
     `)
 
-    for (const achievement of achievements) {
-      if (!achievement.apiname || achievement.achieved !== 1) continue
+    for (const achievement of unlockedByApiname.values()) {
       insert.run(steamId, appId, achievement.apiname, achievement.unlocktime ?? null, now, now)
     }
 
@@ -231,7 +237,8 @@ export function persistAchievements(steamId: string, appId: number, achievements
 export function persistBulkGameStats(steamId: string, appId: number, totalCount: number, unlockedApinames: string[]) {
   const db = getSqliteDatabase()
   const now = nowIso()
-  const unlockedCount = unlockedApinames.length
+  const uniqueApinames = Array.from(new Set(unlockedApinames.filter((name) => name.length > 0)))
+  const unlockedCount = uniqueApinames.length
   const perfectGame = totalCount > 0 && unlockedCount === totalCount ? 1 : 0
 
   db.exec("BEGIN")
@@ -257,8 +264,7 @@ export function persistBulkGameStats(steamId: string, appId: number, totalCount:
           steam_id, appid, apiname, achieved, unlock_time, created_at, updated_at
         ) VALUES (?, ?, ?, 1, NULL, ?, ?)
       `)
-      for (const apiname of unlockedApinames) {
-        if (!apiname) continue
+      for (const apiname of uniqueApinames) {
         insert.run(steamId, appId, apiname, now, now)
       }
     }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts"
+import "./.next/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/achievements-bulk-sync.test.ts
+++ b/test/achievements-bulk-sync.test.ts
@@ -108,6 +108,23 @@ describe("persistBulkGameStats", () => {
     expect(meta).toEqual({ unlocked_count: 3, total_count: 3, perfect_game: 1 })
   })
 
+  it("dedupes duplicate apinames returned by the bulk endpoint", async () => {
+    const db = await seedOwnedGames([{ appid: 620, name: "Portal 2" }])
+    const { persistBulkGameStats } = await import("@/lib/server/steam-achievements-sync")
+
+    persistBulkGameStats(STEAM_ID, 620, 5, ["A", "B", "A", "C", "B"])
+
+    const meta = db
+      .prepare("SELECT unlocked_count, total_count FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, 620) as { unlocked_count: number; total_count: number }
+    expect(meta).toEqual({ unlocked_count: 3, total_count: 5 })
+
+    const rows = db
+      .prepare("SELECT apiname FROM user_achievements WHERE steam_id = ? AND appid = ? ORDER BY apiname")
+      .all(STEAM_ID, 620) as Array<{ apiname: string }>
+    expect(rows).toEqual([{ apiname: "A" }, { apiname: "B" }, { apiname: "C" }])
+  })
+
   it("clears stale user_achievements when re-persisting with fewer unlocks", async () => {
     const db = await seedOwnedGames([{ appid: 570, name: "Dota 2" }])
     const { persistBulkGameStats } = await import("@/lib/server/steam-achievements-sync")

--- a/test/achievements-persist.test.ts
+++ b/test/achievements-persist.test.ts
@@ -130,6 +130,27 @@ describe("persistAchievements (post-cleanup)", () => {
     expect(rows).toEqual([{ apiname: "A" }])
   })
 
+  it("dedupes duplicate apinames within a single persist call", async () => {
+    const db = await seedProfileAndGame()
+    const { persistAchievements } = await import("@/lib/server/steam-achievements-sync")
+
+    persistAchievements(STEAM_ID, APPID, [
+      { apiname: "ACH_ONE", achieved: 1, unlocktime: 1_700_000_000 },
+      { apiname: "ACH_ONE", achieved: 1, unlocktime: 1_700_000_500 },
+      { apiname: "ACH_TWO", achieved: 1, unlocktime: 1_700_000_600 },
+    ])
+
+    const rows = db
+      .prepare("SELECT apiname FROM user_achievements WHERE steam_id = ? AND appid = ? ORDER BY apiname")
+      .all(STEAM_ID, APPID) as Array<{ apiname: string }>
+    expect(rows).toEqual([{ apiname: "ACH_ONE" }, { apiname: "ACH_TWO" }])
+
+    const meta = db.prepare("SELECT unlocked_count FROM user_games WHERE appid = ?").get(APPID) as {
+      unlocked_count: number
+    }
+    expect(meta.unlocked_count).toBe(2)
+  })
+
   it("empty array marks game as broken/retired (total_count=0, synced_at set)", async () => {
     const db = await seedProfileAndGame()
     const { persistAchievements } = await import("@/lib/server/steam-achievements-sync")


### PR DESCRIPTION
## Summary
- Root cause of \"Failed to synchronize Steam data\": Steam's bulk `GetTopAchievementsForGames` endpoint occasionally returns the same apiname twice for a single game. `persistBulkGameStats` deletes then re-inserts, so the duplicate tripped `UNIQUE constraint failed: user_achievements.steam_id, appid, apiname`, aborting the whole sync transaction.
- Dedupe apinames in both `persistBulkGameStats` and `persistAchievements` so a noisy upstream response can't take down the sync.
- Regression tests in both `achievements-bulk-sync.test.ts` and `achievements-persist.test.ts`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (109 passed)
- [ ] Click the header sync button — should complete without the error toast
- [ ] Spot-check a previously-unsynced game (e.g. Portal 2) shows achievements in the library list

🤖 Generated with [Claude Code](https://claude.com/claude-code)