### PR TITLE
feat(achievements): incremental sync based on rtime_last_played

### DIFF
--- a/lib/server/steam-stats-compute.ts
+++ b/lib/server/steam-stats-compute.ts
@@ -147,17 +147,33 @@ export function getStoredStatsSnapshot(steamId: string) {
 async function syncAchievementsForStats(steamId: string, forceRefresh: boolean) {
   const ownedGames = await ensureOwnedGamesSynced(steamId, { forceRefresh })
 
-  // Candidate set: games with community stats that aren't already known-broken
-  // (synced once and confirmed to have 0 achievements), and whose stored
-  // unlock state is either missing or stale.
+  // Incremental filter: we only hit Steam for games where unlocks could
+  // plausibly have changed since our last sync. The goal is to keep a full
+  // refresh cheap even for 1000-game libraries.
   const stale = ownedGames.filter((game) => {
+    // No community stats → cannot have achievements, skip forever.
     if (!game.has_community_visible_stats) return false
+
     const stored = getStoredAchievements(steamId, game.appid)
+
+    // Known-broken: first sync reported 0 achievements (stats-only game,
+    // retired game, private profile, etc). Don't keep retrying.
     if (stored?.achievements_synced_at && (stored.total_count ?? 0) === 0) return false
-    if (!forceRefresh && stored && !isStale(stored.achievements_synced_at, ACHIEVEMENTS_STALE_MS)) {
-      return false
-    }
-    return true
+
+    // Never synced → always include (covers first sync and new purchases).
+    if (!stored?.achievements_synced_at) return true
+
+    // Weekly safety floor: re-sync anything older than ACHIEVEMENTS_STALE_MS
+    // regardless of playtime, to catch edge cases like community-event
+    // unlocks that don't move rtime_last_played.
+    if (isStale(stored.achievements_synced_at, ACHIEVEMENTS_STALE_MS)) return true
+
+    // Incremental: only re-sync if the game was actually played after our
+    // last successful sync. rtime_last_played is Unix seconds, synced_at is
+    // an ISO timestamp.
+    const syncedAtMs = Date.parse(stored.achievements_synced_at)
+    const playedAtMs = (game.rtime_last_played ?? 0) * 1000
+    return playedAtMs > syncedAtMs
   })
 
   if (stale.length === 0) return

--- a/test/achievements-sync.test.ts
+++ b/test/achievements-sync.test.ts
@@ -35,7 +35,14 @@ afterEach(() => {
 const STEAM_ID = "76561198000000001"
 
 async function seedOwnedGames(
-  entries: Array<{ appid: number; name: string; hasStats?: boolean; syncedAt?: string | null; totalCount?: number }>,
+  entries: Array<{
+    appid: number
+    name: string
+    hasStats?: boolean
+    syncedAt?: string | null
+    totalCount?: number
+    rtimeLastPlayed?: number | null
+  }>,
 ) {
   const { getSqliteDatabase } = await import("@/lib/server/sqlite")
   const db = getSqliteDatabase()
@@ -51,10 +58,10 @@ async function seedOwnedGames(
 
     db.prepare(
       `INSERT INTO user_games (
-        steam_id, appid, playtime_forever, owned, achievements_synced_at,
+        steam_id, appid, playtime_forever, rtime_last_played, owned, achievements_synced_at,
         unlocked_count, total_count, perfect_game, created_at, updated_at
-      ) VALUES (?, ?, 0, 1, ?, 0, ?, 0, ?, ?)`,
-    ).run(STEAM_ID, entry.appid, entry.syncedAt ?? null, entry.totalCount ?? 0, now, now)
+      ) VALUES (?, ?, 0, ?, 1, ?, 0, ?, 0, ?, ?)`,
+    ).run(STEAM_ID, entry.appid, entry.rtimeLastPlayed ?? null, entry.syncedAt ?? null, entry.totalCount ?? 0, now, now)
   }
 
   return db
@@ -222,5 +229,128 @@ describe("syncAchievementsForStats (per-game)", () => {
     expect(row.unlocked_count).toBe(0)
     expect(row.total_count).toBe(0)
     expect(row.achievements_synced_at).not.toBeNull()
+  })
+})
+
+describe("syncAchievementsForStats (incremental filter)", () => {
+  function mockSteamApi(mockGetPlayerAchievements: ReturnType<typeof vi.fn>) {
+    vi.doMock("@/lib/steam-api", () => ({
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
+      getPlayerAchievements: mockGetPlayerAchievements,
+      getGameSchema: vi.fn().mockResolvedValue(null),
+    }))
+    vi.doMock("@/lib/server/steam-images", () => ({
+      ensureGameImages: vi.fn().mockResolvedValue(undefined),
+    }))
+  }
+
+  it("re-syncs a game whose rtime_last_played is newer than its achievements_synced_at", async () => {
+    const mockGetPlayerAchievements = vi.fn().mockResolvedValue({
+      steamID: STEAM_ID,
+      gameName: "CS2",
+      achievements: [{ apiname: "ACH_NEW", achieved: 1, unlocktime: 1_800_000_100 }],
+      success: true,
+    })
+    mockSteamApi(mockGetPlayerAchievements)
+
+    const syncedAtIso = new Date(1_800_000_000 * 1000).toISOString()
+    const db = await seedOwnedGames([
+      {
+        appid: 730,
+        name: "CS2",
+        syncedAt: syncedAtIso,
+        totalCount: 5,
+        rtimeLastPlayed: 1_800_000_050, // played AFTER syncedAt
+      },
+    ])
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(now, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+    await getStatsForUser(STEAM_ID, { forceRefresh: false })
+
+    expect(mockGetPlayerAchievements).toHaveBeenCalledWith(STEAM_ID, 730)
+  })
+
+  it("skips a game that has not been played since its last sync (even on forceRefresh)", async () => {
+    const mockGetPlayerAchievements = vi.fn()
+    mockSteamApi(mockGetPlayerAchievements)
+
+    // syncedAt is "today" (fresh), rtime was two days before — no replay
+    const syncedAtIso = new Date().toISOString()
+    const twoDaysAgoSeconds = Math.floor((Date.now() - 2 * 24 * 60 * 60 * 1000) / 1000)
+    const db = await seedOwnedGames([
+      {
+        appid: 730,
+        name: "CS2",
+        syncedAt: syncedAtIso,
+        totalCount: 5,
+        rtimeLastPlayed: twoDaysAgoSeconds,
+      },
+    ])
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(syncedAtIso, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+    await getStatsForUser(STEAM_ID, { forceRefresh: true })
+
+    expect(mockGetPlayerAchievements).not.toHaveBeenCalled()
+  })
+
+  it("weekly safety floor re-syncs untouched games once ACHIEVEMENTS_STALE_MS has elapsed", async () => {
+    const mockGetPlayerAchievements = vi.fn().mockResolvedValue({
+      steamID: STEAM_ID,
+      gameName: "CS2",
+      achievements: [{ apiname: "A", achieved: 1, unlocktime: 1 }],
+      success: true,
+    })
+    mockSteamApi(mockGetPlayerAchievements)
+
+    // synced_at is 8 days ago, game never played
+    const eightDaysAgoIso = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    const db = await seedOwnedGames([
+      {
+        appid: 730,
+        name: "CS2",
+        syncedAt: eightDaysAgoIso,
+        totalCount: 5,
+        rtimeLastPlayed: null,
+      },
+    ])
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(now, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+    await getStatsForUser(STEAM_ID, { forceRefresh: false })
+
+    expect(mockGetPlayerAchievements).toHaveBeenCalledWith(STEAM_ID, 730)
+  })
+
+  it("never-played game is synced once (first sync) then skipped forever after", async () => {
+    const mockGetPlayerAchievements = vi.fn().mockResolvedValue({
+      steamID: STEAM_ID,
+      gameName: "CS2",
+      achievements: [{ apiname: "A", achieved: 0, unlocktime: 0 }],
+      success: true,
+    })
+    mockSteamApi(mockGetPlayerAchievements)
+
+    // Never synced, never played: synced_at NULL, rtime_last_played NULL
+    const db = await seedOwnedGames([{ appid: 730, name: "CS2", rtimeLastPlayed: null }])
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(now, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+
+    // First sync: hits Steam
+    await getStatsForUser(STEAM_ID, { forceRefresh: false })
+    expect(mockGetPlayerAchievements).toHaveBeenCalledTimes(1)
+
+    // Force the stats_snapshot cache to expire so syncAchievementsForStats runs again
+    db.prepare(`DELETE FROM stats_snapshot WHERE steam_id = ?`).run(STEAM_ID)
+
+    // Second sync: never played since, should be skipped by the incremental filter
+    await getStatsForUser(STEAM_ID, { forceRefresh: false })
+    expect(mockGetPlayerAchievements).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
A forced achievement sync currently fans out a per-game request for every game with community stats (~450 on this account, ~90s). Most of those games haven't been touched since the last sync, so the requests are wasted.

Replace the flat staleness check in \`syncAchievementsForStats\` with an incremental filter:

1. No community stats → skip forever
2. Known-broken (synced once, 0 achievements) → skip forever
3. Never synced → include (first sync, new purchases)
4. >7d since last sync → include (weekly safety floor for things like community-event unlocks that don't move rtime)
5. \`rtime_last_played > achievements_synced_at\` → include

forceRefresh still pulls fresh owned-games data from Steam so \`rtime_last_played\` is current when the filter runs; the filter logic itself is the same on both paths.

## Tests
Four new cases in \`test/achievements-sync.test.ts\`:
- re-syncs a game whose rtime > synced_at
- skips a game not played since its last sync (even on forceRefresh)
- weekly safety floor re-syncs untouched games after 7d
- never-played game is synced on first call then skipped thereafter

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (110 passed)
- [ ] Click header sync on a real account — the first sync after today's cleanup still fans out (most data will be within 7d but not yet per-game fresh), subsequent clicks should be near-instant

## Known gap
No UI escape hatch for \"force a full re-sync because data looks corrupted\". The 7-day floor heals that case on its own; we can add an admin button later if it becomes a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)