### PR TITLE
fix(achievements): include games where has_community_visible_stats is NULL

### DIFF
--- a/lib/server/steam-stats-compute.ts
+++ b/lib/server/steam-stats-compute.ts
@@ -151,8 +151,13 @@ async function syncAchievementsForStats(steamId: string, forceRefresh: boolean) 
   // plausibly have changed since our last sync. The goal is to keep a full
   // refresh cheap even for 1000-game libraries.
   const stale = ownedGames.filter((game) => {
-    // No community stats → cannot have achievements, skip forever.
-    if (!game.has_community_visible_stats) return false
+    // Skip only when Steam has *explicitly* told us the game has no community
+    // stats. The flag is often missing entirely on older titles (Assassin's
+    // Creed, BioShock, Call of Duty, …) — we can't use undefined/null as a
+    // "no achievements" signal, so we include those games and let the first
+    // GetPlayerAchievements call decide (a null response marks the game as
+    // known-broken via the total_count === 0 rule below).
+    if (game.has_community_visible_stats === false) return false
 
     const stored = getStoredAchievements(steamId, game.appid)
 

--- a/test/achievements-sync.test.ts
+++ b/test/achievements-sync.test.ts
@@ -38,7 +38,7 @@ async function seedOwnedGames(
   entries: Array<{
     appid: number
     name: string
-    hasStats?: boolean
+    hasStats?: boolean | null
     syncedAt?: string | null
     totalCount?: number
     rtimeLastPlayed?: number | null
@@ -51,10 +51,11 @@ async function seedOwnedGames(
   db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
 
   for (const entry of entries) {
+    const statsFlag = entry.hasStats === null ? null : entry.hasStats === false ? 0 : 1
     db.prepare(
       `INSERT INTO games (appid, name, has_community_visible_stats, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?)`,
-    ).run(entry.appid, entry.name, entry.hasStats === false ? 0 : 1, now, now)
+    ).run(entry.appid, entry.name, statsFlag, now, now)
 
     db.prepare(
       `INSERT INTO user_games (
@@ -324,6 +325,39 @@ describe("syncAchievementsForStats (incremental filter)", () => {
     await getStatsForUser(STEAM_ID, { forceRefresh: false })
 
     expect(mockGetPlayerAchievements).toHaveBeenCalledWith(STEAM_ID, 730)
+  })
+
+  it("includes games with NULL has_community_visible_stats (Steam omits the flag for older titles)", async () => {
+    const mockGetPlayerAchievements = vi.fn().mockResolvedValue({
+      steamID: STEAM_ID,
+      gameName: "Assassin's Creed",
+      achievements: [
+        { apiname: "ACH_ONE", achieved: 1, unlocktime: 1 },
+        { apiname: "ACH_TWO", achieved: 1, unlocktime: 2 },
+      ],
+      success: true,
+    })
+    mockSteamApi(mockGetPlayerAchievements)
+
+    const db = await seedOwnedGames([
+      { appid: 15100, name: "Assassin's Creed", hasStats: null },
+      { appid: 999, name: "No Stats Game", hasStats: false },
+    ])
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(now, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+    await getStatsForUser(STEAM_ID, { forceRefresh: false })
+
+    // NULL flag → included (Steam just didn't tell us; we ask directly)
+    expect(mockGetPlayerAchievements).toHaveBeenCalledWith(STEAM_ID, 15100)
+    // Explicit false → still skipped
+    expect(mockGetPlayerAchievements).not.toHaveBeenCalledWith(STEAM_ID, 999)
+
+    const row = db
+      .prepare("SELECT unlocked_count, total_count FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, 15100) as { unlocked_count: number; total_count: number }
+    expect(row).toEqual({ unlocked_count: 2, total_count: 2 })
   })
 
   it("never-played game is synced once (first sync) then skipped forever after", async () => {


### PR DESCRIPTION
## Summary
Steam's \`GetOwnedGames\` sometimes omits the \`has_community_visible_stats\` field entirely on older titles (Assassin's Creed, BioShock, Call of Duty, …). The sync filter treated \`!game.has_community_visible_stats\` as \"no stats\", which silently excluded **182 games — roughly 14k achievements worth** for this account.

Only skip when Steam has *explicitly* told us the flag is \`false\`. \`null\`/\`undefined\` means \"Steam didn't say\", so we include the game and let the first \`GetPlayerAchievements\` call decide. A \`null\` Steam response is already persisted as \`total_count = 0\` and captured by the known-broken rule, so the cost is one wasted API call per non-achievement game on the first sync. After that, the incremental filter skips them forever.

## Why not check \`GetSchemaForGame\` instead?
No other \`GetOwnedGames\` parameter exposes a reliable \"has achievements\" bit or a count — the response is fixed to \`{appid, name, playtime_forever, playtime_2weeks, rtime_last_played, img_icon_url, img_logo_url, has_community_visible_stats}\` (and that last field is optional). \`GetSchemaForGame\` would tell us, but we'd have to call it *before* filtering, which defeats the purpose. Letting \`GetPlayerAchievements\` be the source of truth is simpler and self-healing.

## Tests
- New: \"includes games with NULL has_community_visible_stats\" — seeds a game with NULL flag + a game with explicit false, asserts the first is queried and the second is skipped.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (111 passed)
- [ ] Click sync on a real account — total achievements should jump from ~3.7k toward ~18k as the 182 previously-excluded games are picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)