### PR TITLE
fix(steam-api): silence 400/403 'no stats' noise from per-game endpoints

### DIFF
--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -138,6 +138,13 @@ export async function getPlayerAchievements(steamId: string, appId: number): Pro
       success: data.playerstats.success,
     }
   } catch (error) {
+    // Steam returns 400/403 for games that simply don't publish stats (very
+    // common for older titles, DLC-only entries, stats-only games, etc).
+    // That's the signal the caller expects — a null return value — so don't
+    // spam the console with "errors" for the normal case.
+    if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
+      return null
+    }
     console.error("Error fetching achievements for app:", appId, error)
     return null
   }
@@ -152,6 +159,12 @@ export async function getGameSchema(appId: number): Promise<unknown> {
 
     return data.game || null
   } catch (error) {
+    // Same story as getPlayerAchievements: 400/403 just means the app has no
+    // publishable schema. Let the caller treat it as an empty schema without
+    // lighting up the console.
+    if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
+      return null
+    }
     console.error("Error fetching game schema for app:", appId, error)
     return null
   }


### PR DESCRIPTION
## Summary
\`GetPlayerAchievements\` and \`GetSchemaForGame\` return 400/403 for any app that simply doesn't publish stats — older titles, DLC-only entries, stats-only games, etc. That's a normal signal the caller already handles as a \`null\` return, but the wrappers were logging every one as \"Error fetching achievements for app: …\". After a fresh full sync on a 600-game library, that's ~200 scary red lines in the dev server terminal for a non-issue.

Treat 400/403 from these two endpoints as \"no stats\" and return \`null\` silently. Other statuses (429 rate limits, 500s, network errors) still log.

## Context
Diagnosed while reading through a fresh full sync on a real account — the sync succeeded (17,964 unlocks synced), but the terminal was flooded with these benign errors and made it look like something was broken. This is purely a logging fix, no behavior change.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (111 passed)
- [ ] Restart dev server, re-sync, confirm the terminal is quiet for no-stats games

🤖 Generated with [Claude Code](https://claude.com/claude-code)