### PR TITLE
feat(library): pinned (delisted) games support

### DIFF
--- a/app/api/admin/pinned-games/route.ts
+++ b/app/api/admin/pinned-games/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server"
+import { requireAdmin } from "@/app/lib/require-admin"
+import { addPinnedGame, listPinnedGames, removePinnedGame } from "@/lib/server/pinned-games"
+import { logger } from "@/lib/server/logger"
+
+/** GET /api/admin/pinned-games — list globally pinned appids. */
+export async function GET() {
+  try {
+    const admin = await requireAdmin()
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    return NextResponse.json({ pinned: listPinnedGames() })
+  } catch (error) {
+    logger.error({ err: error }, "List pinned games error")
+    return NextResponse.json({ error: "Failed to list pinned games" }, { status: 500 })
+  }
+}
+
+/** POST /api/admin/pinned-games — add an appid to the global pinned list. */
+export async function POST(request: Request) {
+  try {
+    const admin = await requireAdmin()
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const { appid, reason } = (body ?? {}) as { appid?: unknown; reason?: unknown }
+    const appidNum = Number(appid)
+    if (!Number.isInteger(appidNum) || appidNum <= 0) {
+      return NextResponse.json({ error: "Valid appid required" }, { status: 400 })
+    }
+
+    addPinnedGame(appidNum, typeof reason === "string" ? reason : null)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error({ err: error }, "Add pinned game error")
+    return NextResponse.json({ error: "Failed to add pinned game" }, { status: 500 })
+  }
+}
+
+/** DELETE /api/admin/pinned-games — remove an appid from the global pinned list. */
+export async function DELETE(request: Request) {
+  try {
+    const admin = await requireAdmin()
+    if (!admin) return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const { appid } = (body ?? {}) as { appid?: unknown }
+    const appidNum = Number(appid)
+    if (!Number.isInteger(appidNum) || appidNum <= 0) {
+      return NextResponse.json({ error: "Valid appid required" }, { status: 400 })
+    }
+
+    removePinnedGame(appidNum)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    logger.error({ err: error }, "Remove pinned game error")
+    return NextResponse.json({ error: "Failed to remove pinned game" }, { status: 500 })
+  }
+}

--- a/lib/server/pinned-games.ts
+++ b/lib/server/pinned-games.ts
@@ -1,0 +1,84 @@
+import "server-only"
+
+import { getPlayerAchievements } from "@/lib/steam-api"
+import { getSqliteDatabase } from "@/lib/server/sqlite"
+import { nowIso } from "@/lib/server/steam-store-utils"
+import { logger } from "@/lib/server/logger"
+
+export type PinnedGame = {
+  appid: number
+  reason: string | null
+  added_at: string
+}
+
+/** Returns every globally pinned appid. */
+export function listPinnedGames(): PinnedGame[] {
+  const db = getSqliteDatabase()
+  return db.prepare("SELECT appid, reason, added_at FROM pinned_games ORDER BY appid").all() as PinnedGame[]
+}
+
+/** Adds an appid to the global pinned list. Idempotent. */
+export function addPinnedGame(appid: number, reason: string | null) {
+  const db = getSqliteDatabase()
+  db.prepare("INSERT OR IGNORE INTO pinned_games (appid, reason, added_at) VALUES (?, ?, ?)").run(
+    appid,
+    reason,
+    nowIso(),
+  )
+}
+
+/** Removes an appid from the global pinned list. */
+export function removePinnedGame(appid: number) {
+  const db = getSqliteDatabase()
+  db.prepare("DELETE FROM pinned_games WHERE appid = ?").run(appid)
+}
+
+/**
+ * For every globally pinned appid that is NOT in the set of app ids Steam
+ * just returned from GetOwnedGames, attempt to resolve it via
+ * GetPlayerAchievements. If Steam responds with achievements, upsert a
+ * games + user_games row so the rest of the app treats it as owned. If
+ * Steam responds with 400/403 / success=false, leave it alone — the user
+ * doesn't own that pinned appid.
+ *
+ * Intentionally swallows per-appid errors so one bad entry can't abort the
+ * whole sync.
+ */
+export async function ensurePinnedGamesSynced(steamId: string, existingOwnedAppIds: Set<number>) {
+  const pinned = listPinnedGames()
+  if (pinned.length === 0) return
+
+  const db = getSqliteDatabase()
+  const upsertGame = db.prepare(`
+    INSERT INTO games (appid, name, has_community_visible_stats, created_at, updated_at)
+    VALUES (?, ?, 1, ?, ?)
+    ON CONFLICT(appid) DO UPDATE SET
+      name = excluded.name,
+      has_community_visible_stats = 1,
+      updated_at = excluded.updated_at
+  `)
+  const upsertUserGame = db.prepare(`
+    INSERT INTO user_games (
+      steam_id, appid, playtime_forever, owned, last_seen_in_owned_games_at, created_at, updated_at
+    ) VALUES (?, ?, 0, 1, ?, ?, ?)
+    ON CONFLICT(steam_id, appid) DO UPDATE SET
+      owned = 1,
+      last_seen_in_owned_games_at = excluded.last_seen_in_owned_games_at,
+      updated_at = excluded.updated_at
+  `)
+
+  for (const { appid } of pinned) {
+    if (existingOwnedAppIds.has(appid)) continue
+
+    try {
+      const result = await getPlayerAchievements(steamId, appid)
+      if (!result || !result.success) continue
+
+      const now = nowIso()
+      upsertGame.run(appid, result.gameName || `App ${appid}`, now, now)
+      upsertUserGame.run(steamId, appid, now, now, now)
+    } catch (error) {
+      logger.warn({ err: error, appId: appid }, "Pinned game resolution failed — will retry on next sync")
+    }
+  }
+}

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -146,10 +146,37 @@ function createBaseSchema(db: DatabaseSync) {
       FOREIGN KEY (appid) REFERENCES games(appid)
     );
 
+    CREATE TABLE IF NOT EXISTS pinned_games (
+      appid INTEGER PRIMARY KEY,
+      reason TEXT,
+      added_at TEXT NOT NULL
+    );
+
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id ON user_games(steam_id);
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id_owned ON user_games(steam_id, owned);
     CREATE INDEX IF NOT EXISTS idx_stats_snapshot_steam_id ON stats_snapshot(steam_id);
   `)
+}
+
+/**
+ * Seeds pinned_games with known delisted apps that still respond to
+ * GetPlayerAchievements. Idempotent via INSERT OR IGNORE so manual additions
+ * via the admin endpoint are preserved.
+ */
+function seedPinnedGames(db: DatabaseSync) {
+  const now = new Date().toISOString()
+  const insert = db.prepare("INSERT OR IGNORE INTO pinned_games (appid, reason, added_at) VALUES (?, ?, ?)")
+  // Delisted apps that GetOwnedGames hides but GetPlayerAchievements still
+  // honours. Users who own them get them re-added to their library.
+  const defaults: Array<[number, string]> = [
+    [274920, "FaceRig (delisted 2022)"],
+    [245550, "Free to Play (Valve documentary)"],
+    [2158860, "JBMod"],
+    [432150, "They Came From The Moon"],
+  ]
+  for (const [appid, reason] of defaults) {
+    insert.run(appid, reason, now)
+  }
 }
 
 /**
@@ -188,6 +215,7 @@ export function getSqliteDatabase() {
   database = new DatabaseSync(dbPath)
   createBaseSchema(database)
   seedAllowedUsersFromEnv(database)
+  seedPinnedGames(database)
 
   return database
 }

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { getOwnedGames, type SteamGame } from "@/lib/steam-api"
 import { ensureGameImages } from "@/lib/server/steam-images"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
+import { ensurePinnedGamesSynced } from "@/lib/server/pinned-games"
 import {
   nowIso,
   nullIfUndefined,
@@ -224,8 +225,12 @@ export async function ensureOwnedGamesSynced(steamId: string, options?: { forceR
 
   const games = await getOwnedGames(steamId)
   persistOwnedGames(steamId, games)
-  await ensureGameImages(games.map((game) => game.appid))
-  return getStoredOwnedGames(steamId)
+  // Resolve pinned (delisted) games after the main upsert so persistOwnedGames'
+  // markMissingAsUnowned sweep can't flip them back to owned=0.
+  await ensurePinnedGamesSynced(steamId, new Set(games.map((game) => game.appid)))
+  const finalGames = getStoredOwnedGames(steamId)
+  await ensureGameImages(finalGames.map((game) => game.appid))
+  return finalGames
 }
 
 /** Returns all owned games for a user, syncing from Steam if needed. */

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -85,13 +85,16 @@ async function steamAPIRequest(endpoint: string, params: Record<string, string>)
   }
 }
 
-/** Fetches all owned games (including free-to-play) for a Steam user. */
+/** Fetches all owned games (including free-to-play and unvetted playtests) for a Steam user. */
 export async function getOwnedGames(steamId: string): Promise<SteamGame[]> {
   try {
     const data = await steamAPIRequest("/IPlayerService/GetOwnedGames/v1/", {
       steamid: steamId,
       include_appinfo: "1",
       include_played_free_games: "1",
+      // skip_unvetted_apps=0 pulls in playtests and early-access experiments
+      // that Steam normally hides (e.g. SquadBlast Playtest, ForeVR Cornhole).
+      skip_unvetted_apps: "0",
       l: "es",
     })
 

--- a/test/achievements-sync.test.ts
+++ b/test/achievements-sync.test.ts
@@ -48,6 +48,10 @@ async function seedOwnedGames(
   const db = getSqliteDatabase()
   const now = new Date().toISOString()
 
+  // Clear the pinned_games seed so these sync tests can assert exact call
+  // counts without being polluted by the default delisted entries.
+  db.prepare("DELETE FROM pinned_games").run()
+
   db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
 
   for (const entry of entries) {

--- a/test/pinned-games.test.ts
+++ b/test/pinned-games.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-pinned-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.SQLITE_PATH
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const STEAM_ID = "76561198000000001"
+
+async function seedProfile() {
+  const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+  const db = getSqliteDatabase()
+  const now = new Date().toISOString()
+  db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
+  return db
+}
+
+describe("ensurePinnedGamesSynced", () => {
+  it("upserts a pinned appid that Steam confirms ownership of", async () => {
+    const mockGetPlayerAchievements = vi.fn().mockResolvedValue({
+      steamID: STEAM_ID,
+      gameName: "FaceRig",
+      achievements: [{ apiname: "A", achieved: 1, unlocktime: 1 }],
+      success: true,
+    })
+    vi.doMock("@/lib/steam-api", () => ({
+      getPlayerAchievements: mockGetPlayerAchievements,
+    }))
+
+    const db = await seedProfile()
+    // Clear the default seed so we control what's pinned in each test
+    db.prepare("DELETE FROM pinned_games").run()
+    const { addPinnedGame, ensurePinnedGamesSynced } = await import("@/lib/server/pinned-games")
+    addPinnedGame(274920, "FaceRig")
+
+    await ensurePinnedGamesSynced(STEAM_ID, new Set<number>())
+
+    expect(mockGetPlayerAchievements).toHaveBeenCalledWith(STEAM_ID, 274920)
+    const game = db.prepare("SELECT name, has_community_visible_stats FROM games WHERE appid = ?").get(274920) as {
+      name: string
+      has_community_visible_stats: number
+    }
+    expect(game).toEqual({ name: "FaceRig", has_community_visible_stats: 1 })
+
+    const ug = db
+      .prepare("SELECT owned, playtime_forever FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, 274920) as { owned: number; playtime_forever: number }
+    expect(ug).toEqual({ owned: 1, playtime_forever: 0 })
+  })
+
+  it("does nothing when Steam says the user does not own the pinned appid", async () => {
+    const mockGetPlayerAchievements = vi.fn().mockResolvedValue(null)
+    vi.doMock("@/lib/steam-api", () => ({
+      getPlayerAchievements: mockGetPlayerAchievements,
+    }))
+
+    const db = await seedProfile()
+    db.prepare("DELETE FROM pinned_games").run()
+    const { addPinnedGame, ensurePinnedGamesSynced } = await import("@/lib/server/pinned-games")
+    addPinnedGame(999999, "Unowned")
+
+    await ensurePinnedGamesSynced(STEAM_ID, new Set<number>())
+
+    expect(mockGetPlayerAchievements).toHaveBeenCalledWith(STEAM_ID, 999999)
+    const game = db.prepare("SELECT 1 FROM games WHERE appid = ?").get(999999)
+    expect(game).toBeUndefined()
+    const ug = db.prepare("SELECT 1 FROM user_games WHERE steam_id = ? AND appid = ?").get(STEAM_ID, 999999)
+    expect(ug).toBeUndefined()
+  })
+
+  it("skips pinned appids already present in the owned-games response", async () => {
+    const mockGetPlayerAchievements = vi.fn()
+    vi.doMock("@/lib/steam-api", () => ({
+      getPlayerAchievements: mockGetPlayerAchievements,
+    }))
+
+    const db = await seedProfile()
+    db.prepare("DELETE FROM pinned_games").run()
+    const { addPinnedGame, ensurePinnedGamesSynced } = await import("@/lib/server/pinned-games")
+    addPinnedGame(1408720, "Krunker")
+
+    // Steam already returned Krunker in GetOwnedGames
+    await ensurePinnedGamesSynced(STEAM_ID, new Set<number>([1408720]))
+    expect(mockGetPlayerAchievements).not.toHaveBeenCalled()
+  })
+
+  it("swallows per-appid errors so one failure does not abort the sync", async () => {
+    const mockGetPlayerAchievements = vi.fn(async (_steamId: string, appId: number) => {
+      if (appId === 999999) throw new Error("network blip")
+      return {
+        steamID: STEAM_ID,
+        gameName: `App ${appId}`,
+        achievements: [{ apiname: "A", achieved: 1, unlocktime: 1 }],
+        success: true,
+      }
+    })
+    vi.doMock("@/lib/steam-api", () => ({
+      getPlayerAchievements: mockGetPlayerAchievements,
+    }))
+
+    const db = await seedProfile()
+    db.prepare("DELETE FROM pinned_games").run()
+    const { addPinnedGame, ensurePinnedGamesSynced } = await import("@/lib/server/pinned-games")
+    addPinnedGame(999999, "bad")
+    addPinnedGame(274920, "good")
+
+    await ensurePinnedGamesSynced(STEAM_ID, new Set<number>())
+
+    const good = db.prepare("SELECT 1 FROM user_games WHERE steam_id = ? AND appid = ?").get(STEAM_ID, 274920)
+    expect(good).toBeDefined()
+    const bad = db.prepare("SELECT 1 FROM user_games WHERE steam_id = ? AND appid = ?").get(STEAM_ID, 999999)
+    expect(bad).toBeUndefined()
+  })
+})
+
+describe("pinned_games seed", () => {
+  it("seeds the default delisted apps on first db open", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const rows = db.prepare("SELECT appid FROM pinned_games ORDER BY appid").all() as Array<{ appid: number }>
+    const ids = rows.map((r) => r.appid).sort((a, b) => a - b)
+    expect(ids).toEqual([245550, 274920, 432150, 2158860])
+  })
+})


### PR DESCRIPTION
## Summary
Steam's \`GetOwnedGames\` silently drops delisted apps even for accounts that still own them (FaceRig, JBMod, Valve's *Free to Play* documentary, *They Came From The Moon*…). Their achievements still exist and \`GetPlayerAchievements\` still honours ownership, so we can surface them with an opt-in \"pinned\" list.

## Changes
- New \`pinned_games (appid PK, reason, added_at)\` table. **Global**, not per-user — every whitelisted user benefits from a pinned entry, and non-owners are filtered out automatically by Steam's 400/403 response.
- \`lib/server/pinned-games.ts\`: CRUD helpers + \`ensurePinnedGamesSynced\`, which after \`persistOwnedGames\` resolves each pinned appid via \`GetPlayerAchievements\` and upserts a \`games\` + \`user_games\` row when Steam confirms ownership.
- \`ensureOwnedGamesSynced\` calls it **after** \`persistOwnedGames\` so the \`markMissingAsUnowned\` sweep can't flip a pinned game back to \`owned=0\`.
- \`getOwnedGames\` now passes \`skip_unvetted_apps=0\`, pulling in playtests and early-access experiments Steam normally hides (e.g. SquadBlast Playtest).
- Admin endpoints \`GET/POST/DELETE /api/admin/pinned-games\` gated by \`requireAdmin\`, so more delisted appids can be added at runtime without a deploy.
- Seed ships with four verified delisted apps: FaceRig (274920), Free to Play (245550), JBMod (2158860), They Came From The Moon (432150).

## Tests
- Pinned appid Steam confirms → upserts game + user_games
- Pinned appid Steam returns null → no rows inserted
- Pinned appid already in \`GetOwnedGames\` response → skipped (no extra call)
- Per-appid error → swallowed, other pinned entries still process
- Default seed lands the four expected ids on first open

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (116 passed)
- [ ] Restart dev server, click sync — FaceRig, JBMod, *Free to Play*, and *They Came From The Moon* appear in the library with correct unlock counts
- [ ] \`POST /api/admin/pinned-games {\"appid\": X}\` adds new entries, \`DELETE\` removes them

🤖 Generated with [Claude Code](https://claude.com/claude-code)