### PR TITLE
feat(pinned-games): seed Qubburo 2, document default list as code constant

### DIFF
--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -160,21 +160,27 @@ function createBaseSchema(db: DatabaseSync) {
 
 /**
  * Seeds pinned_games with known delisted apps that still respond to
- * GetPlayerAchievements. Idempotent via INSERT OR IGNORE so manual additions
- * via the admin endpoint are preserved.
+ * GetPlayerAchievements.
+ *
+ * Runs on every database open. INSERT OR IGNORE means editing this list is
+ * additive: new entries land on the next startup in both local and
+ * production databases without a migration, and existing rows (including
+ * any added manually via the admin endpoint) are untouched. Remove an
+ * entry here only if you also want it gone in production — the runtime
+ * won't re-add it, but it won't delete pre-existing rows either.
  */
+const DEFAULT_PINNED_GAMES: ReadonlyArray<readonly [number, string]> = [
+  [274920, "FaceRig (delisted 2022)"],
+  [245550, "Free to Play (Valve documentary)"],
+  [2158860, "JBMod"],
+  [432150, "They Came From The Moon"],
+  [344040, "Qubburo 2 (appid recycled to Voxelized in current schema)"],
+]
+
 function seedPinnedGames(db: DatabaseSync) {
   const now = new Date().toISOString()
   const insert = db.prepare("INSERT OR IGNORE INTO pinned_games (appid, reason, added_at) VALUES (?, ?, ?)")
-  // Delisted apps that GetOwnedGames hides but GetPlayerAchievements still
-  // honours. Users who own them get them re-added to their library.
-  const defaults: Array<[number, string]> = [
-    [274920, "FaceRig (delisted 2022)"],
-    [245550, "Free to Play (Valve documentary)"],
-    [2158860, "JBMod"],
-    [432150, "They Came From The Moon"],
-  ]
-  for (const [appid, reason] of defaults) {
+  for (const [appid, reason] of DEFAULT_PINNED_GAMES) {
     insert.run(appid, reason, now)
   }
 }

--- a/test/pinned-games.test.ts
+++ b/test/pinned-games.test.ts
@@ -146,6 +146,6 @@ describe("pinned_games seed", () => {
     const db = getSqliteDatabase()
     const rows = db.prepare("SELECT appid FROM pinned_games ORDER BY appid").all() as Array<{ appid: number }>
     const ids = rows.map((r) => r.appid).sort((a, b) => a - b)
-    expect(ids).toEqual([245550, 274920, 432150, 2158860])
+    expect(ids).toEqual([245550, 274920, 344040, 432150, 2158860])
   })
 })


### PR DESCRIPTION
## Summary
Move the hard-coded delisted appids into a top-level \`DEFAULT_PINNED_GAMES\` constant in \`lib/server/sqlite.ts\` and document how the list is intended to grow.

The seed still runs on every DB open with \`INSERT OR IGNORE\`, so editing \`DEFAULT_PINNED_GAMES\` is additive:

- New entries land on the next startup in **both local and production** databases without a migration.
- Existing rows — including anything added manually via the admin endpoint or a previous seed — stay untouched.
- Removing an entry here does *not* delete pre-existing rows; the admin \`DELETE\` endpoint is the way to do that.

Adds appid **344040 (Qubburo 2)**. Odd detail worth noting for future debugging: \`GetPlayerAchievements(344040)\` returns \`gameName: \"Qubburo 2\"\`, but \`GetSchemaForGame(344040)\` returns \`gameName: \"Voxelized\"\` — Steam appears to have recycled the appid. Our pin logic uses the player-achievements name so the library renders it as Qubburo 2.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (116 passed; seed test updated to expect the new id)
- [ ] Restart dev server on a real account — Qubburo 2 shows up with 1/1 unlocks
- [ ] Adding future entries: append a tuple to \`DEFAULT_PINNED_GAMES\` and redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)