### PR TITLE
feat(pinned-games): seed Grind Zones (327680)

### DIFF
--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -175,6 +175,7 @@ const DEFAULT_PINNED_GAMES: ReadonlyArray<readonly [number, string]> = [
   [2158860, "JBMod"],
   [432150, "They Came From The Moon"],
   [344040, "Qubburo 2 (appid recycled to Voxelized in current schema)"],
+  [327680, "Grind Zones (delisted)"],
 ]
 
 function seedPinnedGames(db: DatabaseSync) {

--- a/test/pinned-games.test.ts
+++ b/test/pinned-games.test.ts
@@ -146,6 +146,6 @@ describe("pinned_games seed", () => {
     const db = getSqliteDatabase()
     const rows = db.prepare("SELECT appid FROM pinned_games ORDER BY appid").all() as Array<{ appid: number }>
     const ids = rows.map((r) => r.appid).sort((a, b) => a - b)
-    expect(ids).toEqual([245550, 274920, 344040, 432150, 2158860])
+    expect(ids).toEqual([245550, 274920, 327680, 344040, 432150, 2158860])
   })
 })


### PR DESCRIPTION
## Summary
Adds \`327680 → Grind Zones\` to \`DEFAULT_PINNED_GAMES\`. Verified via \`GetPlayerAchievements\` — Steam returns \`gameName: \"Grind Zones\"\` with 11/11 unlocks for the test account. Delisted and hidden from \`GetOwnedGames\` like the other pinned entries.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (116 passed; seed assertion updated)
- [ ] Restart dev server → Grind Zones appears in the library with 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)