### PR TITLE
fix(dashboard): silence recharts 'width(-1)/height(-1)' warning

### DIFF
--- a/components/dashboard/dashboard-insights.tsx
+++ b/components/dashboard/dashboard-insights.tsx
@@ -101,7 +101,10 @@ function InsightCard({
         </div>
         <div className="h-56 min-h-0 min-w-0">
           {!loading ? (
-            <ResponsiveContainer width="100%" height="100%">
+            // Explicit pixel height avoids recharts' "width(-1) and height(-1)"
+            // warning on first render — ResponsiveContainer only needs to
+            // measure the (stable) horizontal axis of the parent.
+            <ResponsiveContainer width="100%" height={224}>
               {chartKind === "bars" ? (
                 <BarChart data={chartData} layout="vertical" margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
                   <XAxis type="number" hide />


### PR DESCRIPTION
## Summary
The insights donut/bar charts in \`components/dashboard/dashboard-insights.tsx\` log this on every dashboard load:

\`\`\`
The width(-1) and height(-1) of chart should be greater than 0, please check the style of container, or the props width(100%) and height(100%) …
\`\`\`

\`ResponsiveContainer\` with both dimensions at \`100%\` occasionally fails to measure its parent on first render (React Strict Mode's double render, hydration, the loading→loaded state flip) and falls back to \`-1\`. The parent \`<div>\` is already \`h-56\` (224px), so we can just pass that pixel height directly to \`ResponsiveContainer\` — it only needs to measure the horizontal axis, which is always stable.

Purely a warning-silencing change, no visual or behavioural difference.

## Test plan
- [x] \`pnpm lint\`
- [ ] Load \`/dashboard\`, confirm no warning in dev server terminal and charts render identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)