### PR TITLE
chore(test): honest coverage baseline + CI thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,16 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Test
-        run: pnpm test
+      - name: Test (with coverage)
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
 
       - name: Build
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format:check": "prettier --check .",
     "lint": "pnpm exec eslint . && pnpm typecheck",
     "test": "pnpm exec vitest run",
+    "test:coverage": "pnpm exec vitest run --coverage",
     "typecheck": "pnpm exec next typegen && pnpm exec tsc --noEmit",
     "prepare": "husky",
     "start": "node .next/standalone/server.js"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,10 +11,10 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json-summary"],
-      // Measure the whole source tree, not just files a test happens to
-      // import. Without `all: true` the denominator silently ignores any
-      // untested module, producing an inflated percentage.
-      all: true,
+      // The `include` glob forces v8 to measure every matching file in
+      // the denominator, even ones no test happens to import. Without
+      // this, untested modules are silently dropped and the percentage
+      // is inflated.
       include: ["lib/**/*.{ts,tsx}", "app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}", "hooks/**/*.{ts,tsx}"],
       exclude: [
         // Test infra

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,41 @@ export default defineConfig({
     setupFiles: ["./test/setup.ts"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "html"],
+      reporter: ["text", "html", "json-summary"],
+      // Measure the whole source tree, not just files a test happens to
+      // import. Without `all: true` the denominator silently ignores any
+      // untested module, producing an inflated percentage.
+      all: true,
+      include: ["lib/**/*.{ts,tsx}", "app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}", "hooks/**/*.{ts,tsx}"],
+      exclude: [
+        // Test infra
+        "test/**",
+        "**/*.d.ts",
+        "**/*.config.*",
+        // Next.js App Router boilerplate — composition of already-tested
+        // hooks and components; unit-testing them needs so much mocking
+        // that a Playwright E2E would pay off more.
+        "app/**/page.tsx",
+        "app/**/layout.tsx",
+        "app/**/loading.tsx",
+        "app/**/error.tsx",
+        "app/**/not-found.tsx",
+        "app/**/global-error.tsx",
+        // shadcn/ui primitives are generated wrappers; upstream tests them.
+        "components/ui/**",
+        // Type-only / re-export barrels
+        "lib/types/**",
+        "lib/server/steam-store.ts",
+      ],
+      // Baseline thresholds locked to the current honest numbers. Each
+      // coverage PR ratchets these up; CI fails if a PR regresses below
+      // the current floor.
+      thresholds: {
+        lines: 34,
+        statements: 33,
+        branches: 30,
+        functions: 25,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
v8 coverage was only measuring files that a test happened to import, so every untouched module was silently dropped from the denominator. The 68.98% we were seeing was inflated — **the real baseline is ~35%.**

This PR doesn't add tests. It sets the plumbing so the next ones have accurate numbers and CI blocks regressions.

## Changes
- \`vitest.config.ts\`: \`all: true\`, \`include\` lib/app/components/hooks, \`exclude\` test/d.ts/configs + \`app/**/page.tsx|layout.tsx|error.tsx|loading.tsx|not-found.tsx|global-error.tsx\` + \`components/ui/**\` (shadcn primitives) + \`lib/types/**\` + \`lib/server/steam-store.ts\` (barrel re-export).
- Threshold floors locked to the current honest numbers: lines 34, stmts 33, branches 30, funcs 25. Future coverage PRs ratchet these up.
- New \`pnpm test:coverage\` script.
- CI now runs \`test:coverage\` instead of \`test\` and uploads \`coverage/\` as an artifact (14-day retention).

## Baseline (from this PR's run)
\`\`\`
All files    34.37% stmts  /  31.71% branches  /  26.71% funcs  /  35.02% lines
\`\`\`

### What's hiding in the 65% we don't cover yet
- \`hooks/**\` — 0% (use-current-user, use-steam-data, use-mobile, use-toast)
- \`components/dashboard/**\` — 0% (insights, library-overview, recent-games, user-profile, header, sync-status-button)
- \`lib/steam-api.ts\` — 2% (the wrapper that has caused most of this session's bugs)
- \`lib/server/steam-images.ts\` — 3.6%
- Several API routes (\`pinned-games\`, \`auth/me\`, \`auth/logout\`, \`auth/steam\`, \`achievements\`, \`achievements/batch\`) — 0%

Upcoming PRs pick these off in the order discussed: steam-api → remaining server/lib → admin routes → hooks → dashboard components → CI threshold ratchet.

## Why exclude \`app/**/page.tsx\` and friends?
They're mostly composition of hooks + components that *are* tested. Unit-testing them forces mocking out every hook they read, for little extra confidence. If we want to catch integration bugs, Playwright/E2E is the right tool — I'll propose that as a separate track once unit coverage is in place.

## Test plan
- [x] \`pnpm test:coverage\` passes locally (exit 0, all thresholds met)
- [ ] CI green on the PR
- [ ] \`coverage-report\` artifact visible in the Actions run

🤖 Generated with [Claude Code](https://claude.com/claude-code)