### PR TITLE
test(api): routes + app/lib full coverage + real steam id in mocks

### DIFF
--- a/test/achievements-normalized-reads.test.ts
+++ b/test/achievements-normalized-reads.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-const STEAM_ID = "76561198000000001"
+const STEAM_ID = "76561198023709299"
 const APPID_A = 730
 const APPID_B = 440
 

--- a/test/achievements-persist.test.ts
+++ b/test/achievements-persist.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-const STEAM_ID = "76561198000000001"
+const STEAM_ID = "76561198023709299"
 const APPID = 730
 
 async function seedProfileAndGame() {

--- a/test/achievements-sync-gaps.test.ts
+++ b/test/achievements-sync-gaps.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-const STEAM_ID = "76561198000000001"
+const STEAM_ID = "76561198023709299"
 const APPID = 620
 
 async function seedProfileAndGame() {

--- a/test/achievements-sync.test.ts
+++ b/test/achievements-sync.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-const STEAM_ID = "76561198000000001"
+const STEAM_ID = "76561198023709299"
 
 async function seedOwnedGames(
   entries: Array<{

--- a/test/admin-and-stats-wrappers.test.ts
+++ b/test/admin-and-stats-wrappers.test.ts
@@ -23,7 +23,7 @@ describe("isAdmin", () => {
     }))
     delete process.env.ADMIN_STEAM_ID
     const { isAdmin } = await import("@/lib/server/admin")
-    expect(isAdmin("76561198000000001")).toBe(false)
+    expect(isAdmin("76561198023709299")).toBe(false)
   })
 
   it("returns true only when the id matches exactly", async () => {
@@ -37,9 +37,9 @@ describe("isAdmin", () => {
         },
       ),
     }))
-    process.env.ADMIN_STEAM_ID = "76561198000000001"
+    process.env.ADMIN_STEAM_ID = "76561198023709299"
     const { isAdmin } = await import("@/lib/server/admin")
-    expect(isAdmin("76561198000000001")).toBe(true)
+    expect(isAdmin("76561198023709299")).toBe(true)
     expect(isAdmin("76561198000000002")).toBe(false)
   })
 })
@@ -62,7 +62,7 @@ describe("getUserStats (lib/steam-stats.ts wrapper)", () => {
       logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     }))
     const { getUserStats } = await import("@/lib/steam-stats")
-    const stats = await getUserStats("76561198000000001")
+    const stats = await getUserStats("76561198023709299")
     expect(stats.totalGames).toBe(10)
     expect(stats.averageCompletion).toBe(42)
   })
@@ -76,7 +76,7 @@ describe("getUserStats (lib/steam-stats.ts wrapper)", () => {
       logger: { info: vi.fn(), warn: vi.fn(), error: errorSpy, debug: vi.fn() },
     }))
     const { getUserStats } = await import("@/lib/steam-stats")
-    const stats = await getUserStats("76561198000000001")
+    const stats = await getUserStats("76561198023709299")
     expect(stats).toEqual({
       totalGames: 0,
       gamesWithAchievements: 0,
@@ -106,7 +106,7 @@ describe("getUserStats (lib/steam-stats.ts wrapper)", () => {
       logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     }))
     const { getUserStats } = await import("@/lib/steam-stats")
-    await getUserStats("76561198000000001", { forceRefresh: true })
-    expect(getStatsSpy).toHaveBeenCalledWith("76561198000000001", { forceRefresh: true })
+    await getUserStats("76561198023709299", { forceRefresh: true })
+    expect(getStatsSpy).toHaveBeenCalledWith("76561198023709299", { forceRefresh: true })
   })
 })

--- a/test/api-achievements-routes.test.ts
+++ b/test/api-achievements-routes.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("@/app/lib/server-auth", () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+vi.mock("@/lib/server/steam-store", () => ({
+  getAchievementsForGame: vi.fn(),
+  getBatchStoredAchievements: vi.fn(),
+}))
+
+import { GET as singleGet } from "@/app/api/steam/achievements/route"
+import { GET as batchGet } from "@/app/api/steam/achievements/batch/route"
+import { getCurrentUser } from "@/app/lib/server-auth"
+import { getAchievementsForGame, getBatchStoredAchievements } from "@/lib/server/steam-store"
+
+const mockUser = {
+  steamId: "76561198000000001",
+  displayName: "Tester",
+  avatar: "",
+  profileUrl: "",
+}
+
+function makeRequest(url: string) {
+  return new Request(url) as unknown as Parameters<typeof singleGet>[0]
+}
+
+beforeEach(() => {
+  vi.mocked(getCurrentUser).mockReset()
+  vi.mocked(getAchievementsForGame).mockReset()
+  vi.mocked(getBatchStoredAchievements).mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("GET /api/steam/achievements", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    const res = await singleGet(makeRequest("http://localhost/api/steam/achievements?appId=620"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 when appId is missing", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await singleGet(makeRequest("http://localhost/api/steam/achievements"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when appId is not a positive number", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await singleGet(makeRequest("http://localhost/api/steam/achievements?appId=abc"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 404 when the game has no achievements / is not owned", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getAchievementsForGame).mockResolvedValue(null)
+    const res = await singleGet(makeRequest("http://localhost/api/steam/achievements?appId=620"))
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 200 with the achievements payload on success", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getAchievementsForGame).mockResolvedValue({
+      steamID: "76561198000000001",
+      gameName: "Portal 2",
+      achievements: [],
+      success: true,
+    })
+    const res = await singleGet(makeRequest("http://localhost/api/steam/achievements?appId=620"))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.gameName).toBe("Portal 2")
+  })
+
+  it("forwards ?refresh=1 as forceRefresh=true", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getAchievementsForGame).mockResolvedValue({
+      steamID: "76561198000000001",
+      gameName: "Portal 2",
+      achievements: [],
+      success: true,
+    })
+    await singleGet(makeRequest("http://localhost/api/steam/achievements?appId=620&refresh=1"))
+    expect(getAchievementsForGame).toHaveBeenCalledWith(mockUser.steamId, 620, { forceRefresh: true })
+  })
+
+  it("forwards ?force=1 as forceRefresh=true (alias)", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getAchievementsForGame).mockResolvedValue({
+      steamID: "76561198000000001",
+      gameName: "Portal 2",
+      achievements: [],
+      success: true,
+    })
+    await singleGet(makeRequest("http://localhost/api/steam/achievements?appId=620&force=1"))
+    expect(getAchievementsForGame).toHaveBeenCalledWith(mockUser.steamId, 620, { forceRefresh: true })
+  })
+
+  it("returns 500 if getAchievementsForGame throws", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getAchievementsForGame).mockRejectedValue(new Error("boom"))
+    const res = await singleGet(makeRequest("http://localhost/api/steam/achievements?appId=620"))
+    expect(res.status).toBe(500)
+  })
+})
+
+describe("GET /api/steam/achievements/batch", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    const res = await batchGet(makeRequest("http://localhost/api/steam/achievements/batch?appIds=1,2"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 when appIds query parameter is missing", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await batchGet(makeRequest("http://localhost/api/steam/achievements/batch"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when every appId is invalid", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await batchGet(makeRequest("http://localhost/api/steam/achievements/batch?appIds=abc,-1,0"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns the achievementsMap for valid app IDs", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getBatchStoredAchievements).mockReturnValue({
+      620: [],
+      440: [],
+    })
+    const res = await batchGet(makeRequest("http://localhost/api/steam/achievements/batch?appIds=620,440"))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(new Set(Object.keys(body.achievementsMap))).toEqual(new Set(["620", "440"]))
+  })
+
+  it("silently filters invalid ids out of a mixed list", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getBatchStoredAchievements).mockReturnValue({ 620: [] })
+    const res = await batchGet(makeRequest("http://localhost/api/steam/achievements/batch?appIds=620,abc,-5"))
+    expect(res.status).toBe(200)
+    expect(getBatchStoredAchievements).toHaveBeenCalledWith(mockUser.steamId, [620])
+  })
+
+  it("caps the batch at 200 app IDs", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getBatchStoredAchievements).mockReturnValue({})
+    const ids = Array.from({ length: 250 }, (_, i) => String(i + 1)).join(",")
+    await batchGet(makeRequest(`http://localhost/api/steam/achievements/batch?appIds=${ids}`))
+    const calledWith = vi.mocked(getBatchStoredAchievements).mock.calls[0]?.[1] as number[]
+    expect(calledWith.length).toBe(200)
+  })
+
+  it("returns 500 if getBatchStoredAchievements throws", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getBatchStoredAchievements).mockImplementation(() => {
+      throw new Error("boom")
+    })
+    const res = await batchGet(makeRequest("http://localhost/api/steam/achievements/batch?appIds=620"))
+    expect(res.status).toBe(500)
+  })
+})

--- a/test/api-achievements-routes.test.ts
+++ b/test/api-achievements-routes.test.ts
@@ -31,7 +31,7 @@ import { getCurrentUser } from "@/app/lib/server-auth"
 import { getAchievementsForGame, getBatchStoredAchievements } from "@/lib/server/steam-store"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "Tester",
   avatar: "",
   profileUrl: "",
@@ -80,7 +80,7 @@ describe("GET /api/steam/achievements", () => {
   it("returns 200 with the achievements payload on success", async () => {
     vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
     vi.mocked(getAchievementsForGame).mockResolvedValue({
-      steamID: "76561198000000001",
+      steamID: "76561198023709299",
       gameName: "Portal 2",
       achievements: [],
       success: true,
@@ -94,7 +94,7 @@ describe("GET /api/steam/achievements", () => {
   it("forwards ?refresh=1 as forceRefresh=true", async () => {
     vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
     vi.mocked(getAchievementsForGame).mockResolvedValue({
-      steamID: "76561198000000001",
+      steamID: "76561198023709299",
       gameName: "Portal 2",
       achievements: [],
       success: true,
@@ -106,7 +106,7 @@ describe("GET /api/steam/achievements", () => {
   it("forwards ?force=1 as forceRefresh=true (alias)", async () => {
     vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
     vi.mocked(getAchievementsForGame).mockResolvedValue({
-      steamID: "76561198000000001",
+      steamID: "76561198023709299",
       gameName: "Portal 2",
       achievements: [],
       success: true,

--- a/test/api-admin-pinned-games-route.test.ts
+++ b/test/api-admin-pinned-games-route.test.ts
@@ -31,7 +31,7 @@ import { requireAdmin } from "@/app/lib/require-admin"
 import { listPinnedGames, addPinnedGame, removePinnedGame } from "@/lib/server/pinned-games"
 
 const mockAdmin = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "admin",
   avatar: "",
   profileUrl: "",

--- a/test/api-admin-pinned-games-route.test.ts
+++ b/test/api-admin-pinned-games-route.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("@/app/lib/require-admin", () => ({
+  requireAdmin: vi.fn(),
+}))
+
+vi.mock("@/lib/server/pinned-games", () => ({
+  listPinnedGames: vi.fn(),
+  addPinnedGame: vi.fn(),
+  removePinnedGame: vi.fn(),
+}))
+
+import { GET, POST, DELETE } from "@/app/api/admin/pinned-games/route"
+import { requireAdmin } from "@/app/lib/require-admin"
+import { listPinnedGames, addPinnedGame, removePinnedGame } from "@/lib/server/pinned-games"
+
+const mockAdmin = {
+  steamId: "76561198000000001",
+  displayName: "admin",
+  avatar: "",
+  profileUrl: "",
+}
+
+function jsonRequest(method: string, body: unknown) {
+  return new Request("http://localhost/api/admin/pinned-games", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  })
+}
+
+describe("GET /api/admin/pinned-games", () => {
+  it("returns 403 when not admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null)
+    const res = await GET()
+    expect(res.status).toBe(403)
+  })
+
+  it("returns the pinned list for an admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    vi.mocked(listPinnedGames).mockReturnValue([{ appid: 274920, reason: "FaceRig", added_at: "2026-04-11" }])
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.pinned).toHaveLength(1)
+    expect(body.pinned[0].appid).toBe(274920)
+  })
+
+  it("returns 500 if listPinnedGames throws", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    vi.mocked(listPinnedGames).mockImplementation(() => {
+      throw new Error("db closed")
+    })
+    const res = await GET()
+    expect(res.status).toBe(500)
+  })
+})
+
+describe("POST /api/admin/pinned-games", () => {
+  it("returns 403 when not admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null)
+    const res = await POST(jsonRequest("POST", { appid: 274920 }))
+    expect(res.status).toBe(403)
+  })
+
+  it("returns 400 on invalid JSON body", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await POST(jsonRequest("POST", "{not json"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when appid is missing", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await POST(jsonRequest("POST", { reason: "x" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when appid is not a positive integer", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await POST(jsonRequest("POST", { appid: -5 }))
+    expect(res.status).toBe(400)
+  })
+
+  it("calls addPinnedGame and returns success for valid input", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    vi.mocked(addPinnedGame).mockClear()
+    const res = await POST(jsonRequest("POST", { appid: 274920, reason: "FaceRig" }))
+    expect(res.status).toBe(200)
+    expect(addPinnedGame).toHaveBeenCalledWith(274920, "FaceRig")
+  })
+
+  it("accepts a missing reason and stores null", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    vi.mocked(addPinnedGame).mockClear()
+    const res = await POST(jsonRequest("POST", { appid: 432150 }))
+    expect(res.status).toBe(200)
+    expect(addPinnedGame).toHaveBeenCalledWith(432150, null)
+  })
+
+  it("returns 500 if addPinnedGame throws", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    vi.mocked(addPinnedGame).mockImplementation(() => {
+      throw new Error("db closed")
+    })
+    const res = await POST(jsonRequest("POST", { appid: 274920 }))
+    expect(res.status).toBe(500)
+  })
+})
+
+describe("DELETE /api/admin/pinned-games", () => {
+  it("returns 403 when not admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null)
+    const res = await DELETE(jsonRequest("DELETE", { appid: 274920 }))
+    expect(res.status).toBe(403)
+  })
+
+  it("returns 400 on invalid JSON body", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await DELETE(jsonRequest("DELETE", "not json"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 when appid is not a positive integer", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await DELETE(jsonRequest("DELETE", { appid: "abc" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("calls removePinnedGame and returns success", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    vi.mocked(removePinnedGame).mockClear()
+    const res = await DELETE(jsonRequest("DELETE", { appid: 274920 }))
+    expect(res.status).toBe(200)
+    expect(removePinnedGame).toHaveBeenCalledWith(274920)
+  })
+
+  it("returns 500 if removePinnedGame throws", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    vi.mocked(removePinnedGame).mockImplementation(() => {
+      throw new Error("db closed")
+    })
+    const res = await DELETE(jsonRequest("DELETE", { appid: 274920 }))
+    expect(res.status).toBe(500)
+  })
+})

--- a/test/api-admin-users-route.test.ts
+++ b/test/api-admin-users-route.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("@/lib/env", () => ({
   env: new Proxy(
@@ -21,14 +21,24 @@ vi.mock("@/app/lib/require-admin", () => ({
 }))
 
 const mockDb = {
-  prepare: vi.fn().mockReturnValue({ all: vi.fn().mockReturnValue([]), run: vi.fn() }),
+  prepare: vi.fn().mockReturnValue({
+    all: vi.fn().mockReturnValue([]),
+    run: vi.fn(),
+    get: vi.fn().mockReturnValue({ 1: 1 }),
+  }),
 }
 vi.mock("@/lib/server/sqlite", () => ({
   getSqliteDatabase: () => mockDb,
 }))
 
-import { GET, POST, DELETE } from "@/app/api/admin/users/route"
+vi.mock("@/lib/server/steam-store-utils", () => ({
+  upsertProfile: vi.fn(),
+}))
+
+import { GET, POST, DELETE, PATCH } from "@/app/api/admin/users/route"
 import { requireAdmin } from "@/app/lib/require-admin"
+
+const ORIGINAL_FETCH = globalThis.fetch
 
 const mockAdmin = { steamId: "76561198000000001", displayName: "admin", avatar: "", profileUrl: "" }
 
@@ -138,5 +148,111 @@ describe("DELETE /api/admin/users", () => {
       }),
     )
     expect(res.status).toBe(200)
+  })
+})
+
+describe("PATCH /api/admin/users", () => {
+  function patchReq(body: unknown) {
+    return new Request("http://localhost/api/admin/users", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    })
+  }
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH
+  })
+
+  it("returns 403 when not admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(null)
+    const res = await PATCH(patchReq({ steamId: "76561198000000099" }))
+    expect(res.status).toBe(403)
+  })
+
+  it("returns 400 on malformed JSON", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await PATCH(patchReq("{not json"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 400 for invalid Steam ID", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    const res = await PATCH(patchReq({ steamId: "abc" }))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 404 when the user is not in the allowed list", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    mockDb.prepare.mockReturnValueOnce({
+      all: vi.fn(),
+      run: vi.fn(),
+      get: vi.fn().mockReturnValue(undefined),
+    } as unknown as ReturnType<typeof mockDb.prepare>)
+    const res = await PATCH(patchReq({ steamId: "76561198000000099" }))
+    expect(res.status).toBe(404)
+  })
+
+  it("returns 502 when Steam profile fetch fails (non-ok)", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    mockDb.prepare.mockReturnValueOnce({
+      all: vi.fn(),
+      run: vi.fn(),
+      get: vi.fn().mockReturnValue({ 1: 1 }),
+    } as unknown as ReturnType<typeof mockDb.prepare>)
+    globalThis.fetch = vi.fn(
+      async () => ({ ok: false, status: 500, json: async () => ({}) }) as Response,
+    ) as typeof fetch
+    process.env.STEAM_API_KEY = "fake"
+    const res = await PATCH(patchReq({ steamId: "76561198000000099" }))
+    expect(res.status).toBe(502)
+  })
+
+  it("returns 502 when Steam profile fetch rejects", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    mockDb.prepare.mockReturnValueOnce({
+      all: vi.fn(),
+      run: vi.fn(),
+      get: vi.fn().mockReturnValue({ 1: 1 }),
+    } as unknown as ReturnType<typeof mockDb.prepare>)
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network")
+    }) as typeof fetch
+    process.env.STEAM_API_KEY = "fake"
+    const res = await PATCH(patchReq({ steamId: "76561198000000099" }))
+    expect(res.status).toBe(502)
+  })
+
+  it("returns 200 with the profile on success", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(mockAdmin)
+    mockDb.prepare.mockReturnValueOnce({
+      all: vi.fn(),
+      run: vi.fn(),
+      get: vi.fn().mockReturnValue({ 1: 1 }),
+    } as unknown as ReturnType<typeof mockDb.prepare>)
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            response: {
+              players: [
+                {
+                  personaname: "Tester",
+                  avatarfull: "https://example.com/a.jpg",
+                  profileurl: "https://steamcommunity.com/id/tester",
+                },
+              ],
+            },
+          }),
+        }) as Response,
+    ) as typeof fetch
+    process.env.STEAM_API_KEY = "fake"
+    const res = await PATCH(patchReq({ steamId: "76561198000000099" }))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { success: boolean; profile: { persona_name: string } }
+    expect(body.success).toBe(true)
+    expect(body.profile.persona_name).toBe("Tester")
   })
 })

--- a/test/api-admin-users-route.test.ts
+++ b/test/api-admin-users-route.test.ts
@@ -40,7 +40,7 @@ import { requireAdmin } from "@/app/lib/require-admin"
 
 const ORIGINAL_FETCH = globalThis.fetch
 
-const mockAdmin = { steamId: "76561198000000001", displayName: "admin", avatar: "", profileUrl: "" }
+const mockAdmin = { steamId: "76561198023709299", displayName: "admin", avatar: "", profileUrl: "" }
 
 describe("GET /api/admin/users", () => {
   it("returns 403 when not admin", async () => {

--- a/test/api-auth-routes.test.ts
+++ b/test/api-auth-routes.test.ts
@@ -41,7 +41,7 @@ import { GET as steamGet } from "@/app/api/auth/steam/route"
 import { getCurrentUser } from "@/app/lib/server-auth"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "Tester",
   avatar: "https://example.com/a.jpg",
   profileUrl: "https://steamcommunity.com/id/tester",
@@ -70,7 +70,7 @@ describe("GET /api/auth/me", () => {
     const res = await authMeGet()
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.user?.steamId).toBe("76561198000000001")
+    expect(body.user?.steamId).toBe("76561198023709299")
   })
 })
 

--- a/test/api-auth-routes.test.ts
+++ b/test/api-auth-routes.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const cookieStore = {
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+}
+vi.mock("next/headers", () => ({
+  cookies: async () => cookieStore,
+}))
+
+vi.mock("@/app/lib/server-auth", () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+// rate-limit is real — we control it via the same in-process map by reset
+vi.mock("@/lib/server/rate-limit", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/server/rate-limit")>("@/lib/server/rate-limit")
+  return actual
+})
+
+import { GET as authMeGet } from "@/app/api/auth/me/route"
+import { POST as logoutPost } from "@/app/api/auth/logout/route"
+import { GET as steamGet } from "@/app/api/auth/steam/route"
+import { getCurrentUser } from "@/app/lib/server-auth"
+
+const mockUser = {
+  steamId: "76561198000000001",
+  displayName: "Tester",
+  avatar: "https://example.com/a.jpg",
+  profileUrl: "https://steamcommunity.com/id/tester",
+}
+
+beforeEach(() => {
+  cookieStore.get.mockReset()
+  cookieStore.set.mockReset()
+  cookieStore.delete.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("GET /api/auth/me", () => {
+  it("returns { user: null } when no session", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    const res = await authMeGet()
+    const body = await res.json()
+    expect(body).toEqual({ user: null })
+  })
+
+  it("returns the user object when authenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await authMeGet()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.user?.steamId).toBe("76561198000000001")
+  })
+})
+
+describe("POST /api/auth/logout", () => {
+  it("deletes the steam_user cookie and returns success", async () => {
+    const res = await logoutPost()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(cookieStore.delete).toHaveBeenCalledWith("steam_user")
+  })
+})
+
+describe("GET /api/auth/steam", () => {
+  function makeRequest(ip = "198.51.100.1") {
+    return new Request("http://localhost/api/auth/steam", {
+      headers: { "x-forwarded-for": ip },
+    }) as unknown as Parameters<typeof steamGet>[0]
+  }
+
+  it("sets a nonce cookie and redirects to Steam's OpenID login", async () => {
+    const res = await steamGet(makeRequest("198.51.100.10"))
+    expect(res.status).toBeGreaterThanOrEqual(300)
+    expect(res.status).toBeLessThan(400)
+    const location = res.headers.get("location")
+    expect(location).toContain("steamcommunity.com/openid/login")
+    expect(location).toContain("openid.mode=checkid_setup")
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      "steam_openid_nonce",
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, sameSite: "lax" }),
+    )
+  })
+
+  it("returns 429 when the rate limit is exhausted", async () => {
+    // Hammer the endpoint 11 times from the same IP; the 11th should trip
+    // the default 10-req-per-60s limit.
+    const hammerIp = "198.51.100.200"
+    for (let i = 0; i < 10; i++) await steamGet(makeRequest(hammerIp))
+    const res = await steamGet(makeRequest(hammerIp))
+    expect(res.status).toBe(429)
+  })
+})

--- a/test/api-game-route.test.ts
+++ b/test/api-game-route.test.ts
@@ -29,7 +29,7 @@ import { getCurrentUser } from "@/app/lib/server-auth"
 import { getStoredGameForUser } from "@/lib/server/steam-store"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "test",
   avatar: "",
   profileUrl: "",

--- a/test/api-game-sync-route.test.ts
+++ b/test/api-game-sync-route.test.ts
@@ -39,7 +39,7 @@ import { getAchievementsForGame } from "@/lib/server/steam-achievements-sync"
 import { rateLimit } from "@/lib/server/rate-limit"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "test",
   avatar: "",
   profileUrl: "",

--- a/test/api-games-route.test.ts
+++ b/test/api-games-route.test.ts
@@ -90,4 +90,12 @@ describe("GET /api/steam/games", () => {
     expect(response.status).toBe(200)
     expect(getRecentlyPlayedGamesForUser).toHaveBeenCalledWith(mockUser.steamId, { forceRefresh: true })
   })
+
+  it("returns 500 when the underlying store call throws", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getRecentlyPlayedGamesForUser).mockRejectedValue(new Error("db down"))
+    const request = new NextRequest("http://localhost/api/steam/games")
+    const response = await GET(request)
+    expect(response.status).toBe(500)
+  })
 })

--- a/test/api-games-route.test.ts
+++ b/test/api-games-route.test.ts
@@ -31,7 +31,7 @@ import { getCurrentUser } from "@/app/lib/server-auth"
 import { getOwnedGamesForUser, getRecentlyPlayedGamesForUser } from "@/lib/server/steam-store"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "test",
   avatar: "",
   profileUrl: "",

--- a/test/api-hide-route.test.ts
+++ b/test/api-hide-route.test.ts
@@ -134,4 +134,36 @@ describe("DELETE /api/steam/games/hide", () => {
     )
     expect(res.status).toBe(200)
   })
+
+  it("returns 500 when the db throws on hide", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    mockDb.prepare.mockReturnValueOnce({
+      run: vi.fn().mockImplementation(() => {
+        throw new Error("db down")
+      }),
+    } as unknown as ReturnType<typeof mockDb.prepare>)
+    const res = await POST(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "POST",
+        body: JSON.stringify({ appId: 730 }),
+      }),
+    )
+    expect(res.status).toBe(500)
+  })
+
+  it("returns 500 when the db throws on unhide", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    mockDb.prepare.mockReturnValueOnce({
+      run: vi.fn().mockImplementation(() => {
+        throw new Error("db down")
+      }),
+    } as unknown as ReturnType<typeof mockDb.prepare>)
+    const res = await DELETE(
+      new Request("http://localhost/api/steam/games/hide", {
+        method: "DELETE",
+        body: JSON.stringify({ appId: 730 }),
+      }),
+    )
+    expect(res.status).toBe(500)
+  })
 })

--- a/test/api-hide-route.test.ts
+++ b/test/api-hide-route.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/lib/server/sqlite", () => ({
 import { POST, DELETE } from "@/app/api/steam/games/hide/route"
 import { getCurrentUser } from "@/app/lib/server-auth"
 
-const mockUser = { steamId: "76561198000000001", displayName: "test", avatar: "", profileUrl: "" }
+const mockUser = { steamId: "76561198023709299", displayName: "test", avatar: "", profileUrl: "" }
 
 describe("POST /api/steam/games/hide", () => {
   it("returns 401 when not authenticated", async () => {

--- a/test/api-stats-route.test.ts
+++ b/test/api-stats-route.test.ts
@@ -26,7 +26,7 @@ describe("GET /api/steam/stats", () => {
 
   it("forwards force refresh option when refresh query is present", async () => {
     vi.mocked(getCurrentUser).mockResolvedValue({
-      steamId: "76561198000000001",
+      steamId: "76561198023709299",
       displayName: "test",
       avatar: "",
       profileUrl: "",
@@ -45,7 +45,7 @@ describe("GET /api/steam/stats", () => {
     const response = await GET(new Request("http://localhost/api/steam/stats?refresh=1"))
 
     expect(response.status).toBe(200)
-    expect(getUserStats).toHaveBeenCalledWith("76561198000000001", { forceRefresh: true })
+    expect(getUserStats).toHaveBeenCalledWith("76561198023709299", { forceRefresh: true })
   })
 
   it("returns stats data in response body", async () => {
@@ -61,7 +61,7 @@ describe("GET /api/steam/stats", () => {
     }
 
     vi.mocked(getCurrentUser).mockResolvedValue({
-      steamId: "76561198000000001",
+      steamId: "76561198023709299",
       displayName: "test",
       avatar: "",
       profileUrl: "",
@@ -77,7 +77,7 @@ describe("GET /api/steam/stats", () => {
 
   it("returns 500 when getUserStats throws", async () => {
     vi.mocked(getCurrentUser).mockResolvedValue({
-      steamId: "76561198000000001",
+      steamId: "76561198023709299",
       displayName: "test",
       avatar: "",
       profileUrl: "",

--- a/test/api-stats-route.test.ts
+++ b/test/api-stats-route.test.ts
@@ -74,4 +74,21 @@ describe("GET /api/steam/stats", () => {
     expect(response.status).toBe(200)
     expect(body).toEqual(expectedStats)
   })
+
+  it("returns 500 when getUserStats throws", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      steamId: "76561198000000001",
+      displayName: "test",
+      avatar: "",
+      profileUrl: "",
+    })
+    vi.mocked(getUserStats).mockRejectedValue(new Error("db down"))
+
+    vi.doMock("@/lib/server/logger", () => ({
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    }))
+
+    const response = await GET(new Request("http://localhost/api/steam/stats"))
+    expect(response.status).toBe(500)
+  })
 })

--- a/test/api-sync-route.test.ts
+++ b/test/api-sync-route.test.ts
@@ -35,7 +35,7 @@ import { rateLimit } from "@/lib/server/rate-limit"
 import { getUserSyncStatus, synchronizeUserData } from "@/lib/server/steam-store"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "test",
   avatar: "",
   profileUrl: "",

--- a/test/api-sync-route.test.ts
+++ b/test/api-sync-route.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/server/steam-store", () => ({
 import { GET, POST } from "@/app/api/steam/sync/route"
 import { getCurrentUser } from "@/app/lib/server-auth"
 import { rateLimit } from "@/lib/server/rate-limit"
-import { synchronizeUserData } from "@/lib/server/steam-store"
+import { getUserSyncStatus, synchronizeUserData } from "@/lib/server/steam-store"
 
 const mockUser = {
   steamId: "76561198000000001",
@@ -50,6 +50,28 @@ describe("GET /api/steam/sync", () => {
 
     expect(response.status).toBe(401)
     expect(body.error).toBe("Unauthorized")
+  })
+
+  it("returns the sync status when authenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getUserSyncStatus).mockReturnValue({
+      lastOwnedGamesSyncAt: "2026-04-11T10:00:00.000Z",
+      lastRecentGamesSyncAt: null,
+      lastStatsSyncAt: null,
+    })
+    const response = await GET()
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { lastOwnedGamesSyncAt: string }
+    expect(body.lastOwnedGamesSyncAt).toBe("2026-04-11T10:00:00.000Z")
+  })
+
+  it("returns 500 if getUserSyncStatus throws", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getUserSyncStatus).mockImplementation(() => {
+      throw new Error("db closed")
+    })
+    const response = await GET()
+    expect(response.status).toBe(500)
   })
 })
 
@@ -87,5 +109,13 @@ describe("POST /api/steam/sync", () => {
     expect(response.status).toBe(200)
     expect(body).toEqual(syncResult)
     expect(synchronizeUserData).toHaveBeenCalledWith(mockUser.steamId)
+  })
+
+  it("returns 500 when synchronizeUserData throws", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(rateLimit).mockReturnValue({ success: true, remaining: 4 })
+    vi.mocked(synchronizeUserData).mockRejectedValue(new Error("upstream down"))
+    const response = await POST()
+    expect(response.status).toBe(500)
   })
 })

--- a/test/app-lib-auth.test.ts
+++ b/test/app-lib-auth.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const cookieStore = {
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+}
+vi.mock("next/headers", () => ({
+  cookies: async () => cookieStore,
+}))
+
+vi.mock("@/lib/whitelist", () => ({
+  isSteamIdWhitelisted: vi.fn(),
+}))
+
+import { getCurrentUser, requireAuth } from "@/app/lib/server-auth"
+import { isSteamIdWhitelisted } from "@/lib/whitelist"
+
+const mockUser = {
+  steamId: "76561198000000001",
+  displayName: "Tester",
+  avatar: "https://example.com/a.jpg",
+  profileUrl: "https://steamcommunity.com/id/tester",
+}
+
+beforeEach(() => {
+  cookieStore.get.mockReset()
+  cookieStore.delete.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("getCurrentUser", () => {
+  it("returns null when no cookie is present", async () => {
+    cookieStore.get.mockReturnValue(undefined)
+    const user = await getCurrentUser()
+    expect(user).toBeNull()
+  })
+
+  it("returns null and does not throw when the cookie has no value", async () => {
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: "" })
+    const user = await getCurrentUser()
+    expect(user).toBeNull()
+  })
+
+  it("returns the user when the cookie JSON is valid and id is whitelisted", async () => {
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
+    const user = await getCurrentUser()
+    expect(user?.steamId).toBe("76561198000000001")
+  })
+
+  it("clears the cookie and returns null when the id is NOT whitelisted", async () => {
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    vi.mocked(isSteamIdWhitelisted).mockReturnValue(false)
+    const user = await getCurrentUser()
+    expect(user).toBeNull()
+    expect(cookieStore.delete).toHaveBeenCalledWith("steam_user")
+  })
+
+  it("returns null when the cookie JSON is malformed (swallows the parse error)", async () => {
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: "{not json" })
+    const user = await getCurrentUser()
+    expect(user).toBeNull()
+  })
+})
+
+describe("requireAuth", () => {
+  it("returns the user when authenticated", async () => {
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
+    const user = await requireAuth()
+    expect(user.steamId).toBe("76561198000000001")
+  })
+
+  it("throws 'Authentication required' when there is no session", async () => {
+    cookieStore.get.mockReturnValue(undefined)
+    await expect(requireAuth()).rejects.toThrow("Authentication required")
+  })
+})

--- a/test/app-lib-auth.test.ts
+++ b/test/app-lib-auth.test.ts
@@ -33,7 +33,7 @@ import { getCurrentUser, requireAuth } from "@/app/lib/server-auth"
 import { isSteamIdWhitelisted } from "@/lib/whitelist"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "Tester",
   avatar: "https://example.com/a.jpg",
   profileUrl: "https://steamcommunity.com/id/tester",
@@ -65,7 +65,7 @@ describe("getCurrentUser", () => {
     cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
     vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
     const user = await getCurrentUser()
-    expect(user?.steamId).toBe("76561198000000001")
+    expect(user?.steamId).toBe("76561198023709299")
   })
 
   it("clears the cookie and returns null when the id is NOT whitelisted", async () => {
@@ -88,7 +88,7 @@ describe("requireAuth", () => {
     cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
     vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
     const user = await requireAuth()
-    expect(user.steamId).toBe("76561198000000001")
+    expect(user.steamId).toBe("76561198023709299")
   })
 
   it("throws 'Authentication required' when there is no session", async () => {

--- a/test/app-lib-require-admin.test.ts
+++ b/test/app-lib-require-admin.test.ts
@@ -29,7 +29,7 @@ import { getCurrentUser } from "@/app/lib/server-auth"
 import { isAdmin } from "@/lib/server/admin"
 
 const mockUser = {
-  steamId: "76561198000000001",
+  steamId: "76561198023709299",
   displayName: "admin",
   avatar: "",
   profileUrl: "",
@@ -60,6 +60,6 @@ describe("requireAdmin", () => {
     vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
     vi.mocked(isAdmin).mockReturnValue(true)
     const result = await requireAdmin()
-    expect(result?.steamId).toBe("76561198000000001")
+    expect(result?.steamId).toBe("76561198023709299")
   })
 })

--- a/test/app-lib-require-admin.test.ts
+++ b/test/app-lib-require-admin.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("@/app/lib/server-auth", () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+vi.mock("@/lib/server/admin", () => ({
+  isAdmin: vi.fn(),
+}))
+
+import { requireAdmin } from "@/app/lib/require-admin"
+import { getCurrentUser } from "@/app/lib/server-auth"
+import { isAdmin } from "@/lib/server/admin"
+
+const mockUser = {
+  steamId: "76561198000000001",
+  displayName: "admin",
+  avatar: "",
+  profileUrl: "",
+}
+
+beforeEach(() => {
+  vi.mocked(getCurrentUser).mockReset()
+  vi.mocked(isAdmin).mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("requireAdmin", () => {
+  it("returns null when unauthenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    expect(await requireAdmin()).toBeNull()
+  })
+
+  it("returns null when the user is not admin", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(isAdmin).mockReturnValue(false)
+    expect(await requireAdmin()).toBeNull()
+  })
+
+  it("returns the user when they are admin", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(isAdmin).mockReturnValue(true)
+    const result = await requireAdmin()
+    expect(result?.steamId).toBe("76561198000000001")
+  })
+})

--- a/test/auth-callback-route.test.ts
+++ b/test/auth-callback-route.test.ts
@@ -46,7 +46,7 @@ describe("GET /api/auth/steam/callback", () => {
 
   it("redirects non-whitelisted user to not_whitelisted error", async () => {
     process.env.NEXTAUTH_URL = "https://example.com"
-    process.env.STEAM_WHITELIST_IDS = "76561198000000001"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
 
     mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
 
@@ -69,14 +69,14 @@ describe("GET /api/auth/steam/callback", () => {
 
   it("redirects to auth_failed when nonce does not match cookie", async () => {
     process.env.NEXTAUTH_URL = "https://example.com"
-    process.env.STEAM_WHITELIST_IDS = "76561198000000001"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
 
     // Cookie has a different nonce than the query param
     const wrongNonce = "b".repeat(64)
     mockCookieStore.get.mockReturnValue({ value: wrongNonce })
 
     const request = new NextRequest(
-      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198000000001&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
+      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
     )
 
     const response = await GET(request)
@@ -87,7 +87,7 @@ describe("GET /api/auth/steam/callback", () => {
 
   it("redirects to auth_failed when Steam ID format is invalid", async () => {
     process.env.NEXTAUTH_URL = "https://example.com"
-    process.env.STEAM_WHITELIST_IDS = "76561198000000001"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
 
     mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
 
@@ -111,7 +111,7 @@ describe("GET /api/auth/steam/callback", () => {
 
   it("redirects to auth_failed when Steam verification rejects", async () => {
     process.env.NEXTAUTH_URL = "https://example.com"
-    process.env.STEAM_WHITELIST_IDS = "76561198000000001"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
 
     mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
 
@@ -123,7 +123,7 @@ describe("GET /api/auth/steam/callback", () => {
     )
 
     const request = new NextRequest(
-      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198000000001&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
+      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
     )
 
     const response = await GET(request)
@@ -145,7 +145,7 @@ describe("GET /api/auth/steam/callback", () => {
     )
 
     const request = new NextRequest(
-      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://evil.com/openid/id/76561198000000001&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
+      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://evil.com/openid/id/76561198023709299&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
     )
 
     const response = await GET(request)
@@ -156,7 +156,7 @@ describe("GET /api/auth/steam/callback", () => {
 
   it("redirects to auth_failed when return_to does not match realm", async () => {
     process.env.NEXTAUTH_URL = "https://example.com"
-    process.env.STEAM_WHITELIST_IDS = "76561198000000001"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
 
     mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
 
@@ -168,7 +168,7 @@ describe("GET /api/auth/steam/callback", () => {
     )
 
     const request = new NextRequest(
-      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198000000001&openid.return_to=https://evil.com/callback`,
+      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=https://evil.com/callback`,
     )
 
     const response = await GET(request)
@@ -178,7 +178,7 @@ describe("GET /api/auth/steam/callback", () => {
   })
 
   it("redirects whitelisted user to dashboard with session cookie", async () => {
-    const steamId = "76561198000000001"
+    const steamId = "76561198023709299"
     process.env.NEXTAUTH_URL = "https://example.com"
     process.env.STEAM_WHITELIST_IDS = steamId
     process.env.STEAM_API_KEY = "test-api-key"
@@ -230,7 +230,7 @@ describe("GET /api/auth/steam/callback", () => {
   })
 
   it("includes steam level and badges in session cookie", async () => {
-    const steamId = "76561198000000001"
+    const steamId = "76561198023709299"
     process.env.NEXTAUTH_URL = "https://example.com"
     process.env.STEAM_WHITELIST_IDS = steamId
     process.env.STEAM_API_KEY = "test-api-key"
@@ -297,7 +297,7 @@ describe("GET /api/auth/steam/callback", () => {
 
   it("handles auth error gracefully", async () => {
     process.env.NEXTAUTH_URL = "https://example.com"
-    process.env.STEAM_WHITELIST_IDS = "76561198000000001"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
     process.env.STEAM_API_KEY = "test-api-key"
 
     mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
@@ -314,7 +314,7 @@ describe("GET /api/auth/steam/callback", () => {
     )
 
     const request = new NextRequest(
-      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198000000001&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
+      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}`,
     )
 
     const response = await GET(request)

--- a/test/pinned-games.test.ts
+++ b/test/pinned-games.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-const STEAM_ID = "76561198000000001"
+const STEAM_ID = "76561198023709299"
 
 async function seedProfile() {
   const { getSqliteDatabase } = await import("@/lib/server/sqlite")

--- a/test/stats-compute-gaps.test.ts
+++ b/test/stats-compute-gaps.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-const STEAM_ID = "76561198000000001"
+const STEAM_ID = "76561198023709299"
 
 async function seedFreshProfile(iso?: string) {
   const { getSqliteDatabase } = await import("@/lib/server/sqlite")

--- a/test/steam-games-sync.test.ts
+++ b/test/steam-games-sync.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true })
 })
 
-const STEAM_ID = "76561198000000001"
+const STEAM_ID = "76561198023709299"
 
 function mockSteamApi(
   ownedGames: Array<{ appid: number; name: string; playtime_forever?: number; rtime_last_played?: number }>,

--- a/test/steam-store-utils.test.ts
+++ b/test/steam-store-utils.test.ts
@@ -107,7 +107,7 @@ describe("upsertProfile", () => {
     const { upsertProfile, getProfileSync } = await import("@/lib/server/steam-store-utils")
     const { getSqliteDatabase } = await import("@/lib/server/sqlite")
 
-    upsertProfile("76561198000000001", {
+    upsertProfile("76561198023709299", {
       personaName: "Tester",
       avatarUrl: "https://example.com/a.jpg",
       profileUrl: "https://example.com/profile",
@@ -117,25 +117,25 @@ describe("upsertProfile", () => {
     const db = getSqliteDatabase()
     const row = db
       .prepare("SELECT persona_name, avatar_url FROM steam_profile WHERE steam_id = ?")
-      .get("76561198000000001") as { persona_name: string; avatar_url: string } | undefined
+      .get("76561198023709299") as { persona_name: string; avatar_url: string } | undefined
     expect(row?.persona_name).toBe("Tester")
     expect(row?.avatar_url).toBe("https://example.com/a.jpg")
 
     // Initial sync columns are null
-    expect(getProfileSync("76561198000000001")?.last_owned_games_sync_at).toBeNull()
+    expect(getProfileSync("76561198023709299")?.last_owned_games_sync_at).toBeNull()
   })
 
   it("preserves existing fields on update when the new value is undefined (COALESCE)", async () => {
     const { upsertProfile } = await import("@/lib/server/steam-store-utils")
     const { getSqliteDatabase } = await import("@/lib/server/sqlite")
 
-    upsertProfile("76561198000000001", { personaName: "Original", avatarUrl: "https://example.com/a.jpg" })
-    upsertProfile("76561198000000001", { personaName: "Updated" })
+    upsertProfile("76561198023709299", { personaName: "Original", avatarUrl: "https://example.com/a.jpg" })
+    upsertProfile("76561198023709299", { personaName: "Updated" })
 
     const db = getSqliteDatabase()
     const row = db
       .prepare("SELECT persona_name, avatar_url FROM steam_profile WHERE steam_id = ?")
-      .get("76561198000000001") as { persona_name: string; avatar_url: string }
+      .get("76561198023709299") as { persona_name: string; avatar_url: string }
     expect(row.persona_name).toBe("Updated")
     expect(row.avatar_url).toBe("https://example.com/a.jpg")
   })

--- a/test/whitelist.test.ts
+++ b/test/whitelist.test.ts
@@ -29,12 +29,12 @@ describe("whitelist", () => {
   })
 
   it("parses ids from comma-separated env value", () => {
-    process.env.STEAM_WHITELIST_IDS = "76561198000000000, 76561198000000001, ,"
+    process.env.STEAM_WHITELIST_IDS = "76561198000000000, 76561198023709299, ,"
 
     const whitelist = getSteamWhitelist()
 
     expect(whitelist.has("76561198000000000")).toBe(true)
-    expect(whitelist.has("76561198000000001")).toBe(true)
+    expect(whitelist.has("76561198023709299")).toBe(true)
     expect(whitelist.size).toBe(2)
   })
 
@@ -45,7 +45,7 @@ describe("whitelist", () => {
   })
 
   it("allows whitelisted user", () => {
-    process.env.STEAM_WHITELIST_IDS = "76561198000000000,76561198000000001"
+    process.env.STEAM_WHITELIST_IDS = "76561198000000000,76561198023709299"
 
     expect(isSteamIdWhitelisted("76561198000000000")).toBe(true)
   })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,10 +40,10 @@ export default defineConfig({
       // coverage PR ratchets these up; CI fails if a PR regresses below
       // the current floor.
       thresholds: {
-        lines: 45,
-        statements: 44,
-        branches: 43,
-        functions: 37,
+        lines: 55,
+        statements: 54,
+        branches: 52,
+        functions: 42,
       },
     },
   },


### PR DESCRIPTION
## Summary
Closes the API-route gap. Every route except \`/api/auth/steam/callback\` (already 96%) is now at 100% or near it.

### New test files
- **\`api-admin-pinned-games-route\`** — GET/POST/DELETE for the endpoint added in #118: auth gate, invalid body, invalid appid, happy paths, error bubbles.
- **\`api-auth-routes\`** — \`/api/auth/me\` (null + authed), \`/api/auth/logout\` (cookie delete), \`/api/auth/steam\` (redirect + nonce cookie + 429 rate limit). Uses the real rate-limit module to actually exhaust the window.
- **\`api-achievements-routes\`** — \`/api/steam/achievements\` (single) + \`/api/steam/achievements/batch\`: 401, every validation branch, happy paths, \`?refresh=1\` / \`?force=1\` aliases, 200-cap on batch, 500 bubbles.
- **\`app-lib-auth\`** — \`getCurrentUser\` (no cookie, empty value, whitelisted, not-whitelisted with cookie delete, malformed JSON) + \`requireAuth\` (ok + throws).
- **\`app-lib-require-admin\`** — unauthenticated / non-admin / admin paths.

### Extensions to existing files
- **\`api-admin-users\`** — new PATCH suite: requireAdmin gate, invalid body, 404 not-in-allowed-users, 502 Steam fetch fail (both \`ok:false\` and network reject), 200 with parsed profile.
- **\`api-sync\`** — GET happy path + \`getUserSyncStatus\` throw → 500, POST \`synchronizeUserData\` throw → 500.
- **\`api-games\`** — store call throw → 500.
- **\`api-stats\`** — \`getUserStats\` throw → 500.
- **\`api-hide\`** — db throw on both POST and DELETE → 500.

### Real steam id across the mock-user fixtures
Sweeping replace of the \`76561198000000001\` placeholder with \`76561198023709299\`, so anyone reading a failing test can tell at a glance which id represents *the current user* vs a deliberately-fake secondary id in multi-user flows. Test DB isolation is per-tmpdir, so there's no cross-test contamination.

## Coverage delta
| | before | after |
|---|---|---|
| \`app/lib/\` | 0% | **100%** |
| \`app/api/admin/pinned-games\` | 0% | **100%** stmts / 90% branches |
| \`app/api/auth/me\` | 0% | **100%** |
| \`app/api/auth/logout\` | 0% | **100%** |
| \`app/api/auth/steam\` | 0% | **100%** (71% branches — prod-only cookie flag) |
| \`app/api/steam/achievements\` | 0% | **100%** |
| \`app/api/steam/achievements/batch\` | 0% | **100%** |
| \`app/api/admin/users\` | 48% | **84.7%** / 90.9% branches |
| \`app/api/steam/{sync,games,stats,games/hide}\` | 72–88% | ~100% each |
| **global** | 45.23 / 44.67 / 38.11 / 45.91 | **55.56 / 52.89 / 42.34 / 56.73** |

Thresholds ratcheted to \`lines:55 / stmts:54 / branches:52 / funcs:42\`.

## What's still untouched
- \`hooks/**\` — 0%
- \`components/dashboard/**\` — 0%

Next PR picks those up.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (252 passed)
- [x] \`pnpm test:coverage\` (all thresholds met)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)