### PR TITLE
test(hooks): 0% → 89% coverage for use-current-user, use-steam-data, use-mobile

### DIFF
--- a/test/use-current-user.test.tsx
+++ b/test/use-current-user.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const toastSpy = vi.fn()
+vi.mock("@/hooks/use-toast", () => ({ toast: toastSpy }))
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+const MOCK_USER = {
+  steamId: "76561198023709299",
+  displayName: "Tester",
+  avatar: "",
+  profileUrl: "",
+}
+
+function mockFetch(handler: () => Promise<Response>) {
+  globalThis.fetch = vi.fn().mockImplementation(handler) as unknown as typeof fetch
+}
+
+function okResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response
+}
+
+function errorResponse(status: number) {
+  return {
+    ok: false,
+    status,
+    json: async () => ({}),
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  toastSpy.mockClear()
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  vi.clearAllMocks()
+})
+
+describe("useCurrentUser", () => {
+  it("returns user on successful fetch", async () => {
+    mockFetch(async () => okResponse({ user: MOCK_USER }))
+    const { useCurrentUser } = await import("@/hooks/use-current-user")
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.user?.steamId).toBe("76561198023709299")
+  })
+
+  it("shows an authentication-error toast on 5xx", async () => {
+    mockFetch(async () => errorResponse(500))
+    const { useCurrentUser } = await import("@/hooks/use-current-user")
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Authentication error", variant: "destructive" }),
+    )
+    expect(result.current.user).toBeNull()
+  })
+
+  it("silently flips loading=false on 4xx (unauthenticated)", async () => {
+    mockFetch(async () => errorResponse(401))
+    const { useCurrentUser } = await import("@/hooks/use-current-user")
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(toastSpy).not.toHaveBeenCalled()
+    expect(result.current.user).toBeNull()
+  })
+
+  it("shows a network-error toast when fetch rejects", async () => {
+    mockFetch(async () => {
+      throw new Error("boom")
+    })
+    const { useCurrentUser } = await import("@/hooks/use-current-user")
+    const { result } = renderHook(() => useCurrentUser())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(toastSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Network error", variant: "destructive" }))
+  })
+
+  it("clearCurrentUser wipes the cached state", async () => {
+    mockFetch(async () => okResponse({ user: MOCK_USER }))
+    const { useCurrentUser, clearCurrentUser } = await import("@/hooks/use-current-user")
+    const { result } = renderHook(() => useCurrentUser())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.user).not.toBeNull()
+
+    act(() => {
+      clearCurrentUser()
+    })
+    expect(result.current.user).toBeNull()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it("revalidates on visibilitychange back to 'visible'", async () => {
+    let calls = 0
+    mockFetch(async () => {
+      calls++
+      return okResponse({ user: MOCK_USER })
+    })
+    const { useCurrentUser } = await import("@/hooks/use-current-user")
+    const { result } = renderHook(() => useCurrentUser())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const initialCalls = calls
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" })
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+    await waitFor(() => expect(calls).toBeGreaterThan(initialCalls))
+  })
+
+  it("ignores visibilitychange when the tab is hidden", async () => {
+    let calls = 0
+    mockFetch(async () => {
+      calls++
+      return okResponse({ user: MOCK_USER })
+    })
+    const { useCurrentUser } = await import("@/hooks/use-current-user")
+    renderHook(() => useCurrentUser())
+    await waitFor(() => expect(calls).toBe(1))
+
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" })
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"))
+    })
+    // Give microtasks a chance to flush
+    await new Promise((r) => setTimeout(r, 10))
+    expect(calls).toBe(1)
+  })
+})

--- a/test/use-mobile.test.tsx
+++ b/test/use-mobile.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import { useIsMobile } from "@/hooks/use-mobile"
+
+function setWindowWidth(px: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: px })
+}
+
+const originalMatchMedia = window.matchMedia
+type MqlListener = (e: MediaQueryListEvent) => void
+let triggerChange: (() => void) | null = null
+
+beforeEach(() => {
+  const listeners: MqlListener[] = []
+  triggerChange = () => {
+    listeners.forEach((l) => l({} as MediaQueryListEvent))
+  }
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: window.innerWidth < 768,
+    media: query,
+    onchange: null,
+    addEventListener: (_event: string, handler: MqlListener) => listeners.push(handler),
+    removeEventListener: (_event: string, handler: MqlListener) => {
+      const idx = listeners.indexOf(handler)
+      if (idx >= 0) listeners.splice(idx, 1)
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as typeof window.matchMedia
+})
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia
+})
+
+describe("useIsMobile", () => {
+  it("returns true when window width is below 768px", () => {
+    setWindowWidth(500)
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+  })
+
+  it("returns false when window width is 768px or greater", () => {
+    setWindowWidth(1024)
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+  })
+
+  it("reacts to viewport changes via matchMedia", () => {
+    setWindowWidth(1024)
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      setWindowWidth(400)
+      triggerChange?.()
+    })
+    expect(result.current).toBe(true)
+  })
+})

--- a/test/use-steam-data.test.tsx
+++ b/test/use-steam-data.test.tsx
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+function mockFetchSequence(handler: (url: string) => Promise<Response>) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => handler(String(input))) as unknown as typeof fetch
+}
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function err(status: number) {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  vi.clearAllMocks()
+})
+
+describe("invalidateSteamData", () => {
+  it("dispatches the custom event when called in the browser", async () => {
+    const spy = vi.fn()
+    window.addEventListener("steam-data-invalidated", spy)
+    const { invalidateSteamData } = await import("@/hooks/use-steam-data")
+    invalidateSteamData()
+    expect(spy).toHaveBeenCalled()
+    window.removeEventListener("steam-data-invalidated", spy)
+  })
+})
+
+describe("useSteamGames", () => {
+  it("loads games on mount and exposes loading → loaded transition", async () => {
+    mockFetchSequence(async () => ok({ games: [{ appid: 620, name: "Portal 2", playtime_forever: 100 }] }))
+    const { useSteamGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamGames("recent"))
+    expect(result.current.loading).toBe(true)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.games).toHaveLength(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("sets error when the API responds with !ok", async () => {
+    mockFetchSequence(async () => err(500))
+    const { useSteamGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamGames("recent"))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Failed to fetch games")
+    expect(result.current.games).toEqual([])
+  })
+
+  it("sets error when the response shape is invalid", async () => {
+    mockFetchSequence(async () => ok({ unexpected: "shape" }))
+    const { useSteamGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamGames("recent"))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Invalid games response")
+  })
+
+  it("refetch calls the endpoint with refresh=1", async () => {
+    const urls: string[] = []
+    mockFetchSequence(async (url) => {
+      urls.push(url)
+      return ok({ games: [] })
+    })
+    const { useSteamGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamGames("all"))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.refetch()
+    })
+    expect(urls.some((u) => u.includes("refresh=1"))).toBe(true)
+    expect(urls.some((u) => u.includes("type=all"))).toBe(true)
+  })
+
+  it("re-fetches when the steam-data-invalidated event is dispatched", async () => {
+    let calls = 0
+    mockFetchSequence(async () => {
+      calls++
+      return ok({ games: [] })
+    })
+    const { useSteamGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamGames("recent"))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const initial = calls
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steam-data-invalidated"))
+    })
+    await waitFor(() => expect(calls).toBeGreaterThan(initial))
+  })
+})
+
+describe("useSteamAchievementsBatch", () => {
+  it("returns an empty map for an empty appIds list without calling fetch", async () => {
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    const { useSteamAchievementsBatch } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievementsBatch([]))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.achievementsMap).toEqual({})
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("fetches and maps keyed-by-number achievement entries", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        achievementsMap: {
+          "620": [
+            {
+              apiname: "A",
+              achieved: 1,
+              unlocktime: 1,
+              name: "A",
+              description: "",
+              displayName: "A",
+              icon: "",
+              icongray: "",
+            },
+          ],
+          "440": [],
+        },
+      }),
+    )
+    const { useSteamAchievementsBatch } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievementsBatch([620, 440]))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.achievementsMap[620]).toHaveLength(1)
+    expect(result.current.achievementsMap[440]).toEqual([])
+  })
+
+  it("sets error on fetch failure", async () => {
+    mockFetchSequence(async () => err(500))
+    const { useSteamAchievementsBatch } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievementsBatch([620]))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Failed to fetch achievements batch")
+  })
+})
+
+describe("useSteamStats", () => {
+  const sampleStats = {
+    totalGames: 10,
+    gamesWithAchievements: 5,
+    totalAchievements: 20,
+    pendingAchievements: 15,
+    startedGames: 3,
+    averageCompletion: 42,
+    totalPlaytime: 100,
+    perfectGames: 1,
+  }
+
+  it("loads stats on mount", async () => {
+    mockFetchSequence(async () => ok(sampleStats))
+    const { useSteamStats } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamStats())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.stats?.totalGames).toBe(10)
+  })
+
+  it("sets error on 500", async () => {
+    mockFetchSequence(async () => err(500))
+    const { useSteamStats } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamStats())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Failed to fetch stats")
+    expect(result.current.stats).toBeNull()
+  })
+
+  it("sets error when response shape is invalid", async () => {
+    mockFetchSequence(async () => ok({ bogus: true }))
+    const { useSteamStats } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamStats())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Invalid stats response")
+  })
+
+  it("refetch with force appends ?refresh=1", async () => {
+    const urls: string[] = []
+    mockFetchSequence(async (url) => {
+      urls.push(url)
+      return ok(sampleStats)
+    })
+    const { useSteamStats } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamStats())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await act(async () => {
+      await result.current.refetch({ force: true })
+    })
+    expect(urls.some((u) => u.includes("refresh=1"))).toBe(true)
+  })
+})
+
+describe("useSteamAchievements", () => {
+  it("returns empty + loading=false when appId is null", async () => {
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    const { useSteamAchievements } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievements(null))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.achievements).toEqual([])
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("loads achievements for a valid appId", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        steamID: "76561198023709299",
+        gameName: "Portal 2",
+        achievements: [
+          {
+            apiname: "A",
+            achieved: 1,
+            unlocktime: 1,
+            name: "A",
+            description: "",
+            displayName: "A",
+            icon: "",
+            icongray: "",
+          },
+        ],
+        success: true,
+      }),
+    )
+    const { useSteamAchievements } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievements(620))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.achievements).toHaveLength(1)
+  })
+
+  it("sets error on non-ok response", async () => {
+    mockFetchSequence(async () => err(404))
+    const { useSteamAchievements } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievements(620))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Failed to fetch achievements")
+  })
+
+  it("sets error when response shape is invalid", async () => {
+    mockFetchSequence(async () => ok({ bogus: 1 }))
+    const { useSteamAchievements } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievements(620))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Invalid achievements response")
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
         "app/**/global-error.tsx",
         // shadcn/ui primitives are generated wrappers; upstream tests them.
         "components/ui/**",
+        // shadcn's toast hook is copied from the CLI template, not original code.
+        "hooks/use-toast.ts",
         // Type-only / re-export barrels
         "lib/types/**",
         "lib/server/steam-store.ts",
@@ -40,10 +42,10 @@ export default defineConfig({
       // coverage PR ratchets these up; CI fails if a PR regresses below
       // the current floor.
       thresholds: {
-        lines: 55,
-        statements: 54,
-        branches: 52,
-        functions: 42,
+        lines: 75,
+        statements: 73,
+        branches: 62,
+        functions: 58,
       },
     },
   },


### PR DESCRIPTION
## Summary
Three new test files push the \`hooks/\` directory from 0% to ~90% coverage. Global jumps **+18 points** because the hook modules are a large chunk of what we hadn't been measuring.

### New test files
- **\`use-mobile\`** — below / at breakpoint, and reacts to a \`matchMedia\` change event (custom stub captures listeners so the resize path actually runs).
- **\`use-current-user\`** — happy path, 5xx triggers destructive toast, 4xx is silent, \`fetch\` reject triggers network-error toast, \`clearCurrentUser\` wipes state, \`visibilitychange=visible\` revalidates while \`=hidden\` does not. Uses \`vi.resetModules\` per test so the module-level singleton state is fresh each time.
- **\`use-steam-data\`** — all four hooks (\`useSteamGames\`, \`useSteamAchievementsBatch\`, \`useSteamStats\`, \`useSteamAchievements\`) plus \`invalidateSteamData\`. Happy paths, fetch-error / invalid-shape errors, refresh aliases, empty \`appIds\` skipping fetch, \`null\` appId in \`useSteamAchievements\`, custom-event re-fetch.

### Coverage-config change
Excludes \`hooks/use-toast.ts\` from the denominator. It's a direct copy of the shadcn CLI template, same reasoning as \`components/ui/**\`.

## Coverage delta
| | before | after |
|---|---|---|
| \`hooks/\` | 0% | **89.51% / 76.34% / 75.47% / 92.54%** |
| **global** | 55.56 / 52.89 / 42.34 / 56.73 | **73.93 / 62.55 / 58.82 / 76.37** |

Thresholds ratcheted to \`lines:75 / stmts:73 / branches:62 / funcs:58\`.

## What's still untouched
- \`components/dashboard/**\` — the only 0% area left.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (279 passed)
- [x] \`pnpm test:coverage\` (all thresholds met)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)