### PR TITLE
test(dashboard): final coverage push — global lines ≥ 90%

### DIFF
--- a/test/dashboard-header.test.tsx
+++ b/test/dashboard-header.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { routerPushSpy, clearUserSpy, pathnameRef } = vi.hoisted(() => ({
+  routerPushSpy: vi.fn(),
+  clearUserSpy: vi.fn(),
+  pathnameRef: { current: "/dashboard" },
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPushSpy }),
+  usePathname: () => pathnameRef.current,
+}))
+
+vi.mock("@/hooks/use-current-user", () => ({
+  clearCurrentUser: clearUserSpy,
+  useCurrentUser: () => ({ user: null, loading: false }),
+}))
+
+vi.mock("@/hooks/use-steam-data", () => ({
+  invalidateSteamData: vi.fn(),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+  toast: vi.fn(),
+}))
+
+import { DashboardHeader } from "@/components/dashboard/dashboard-header"
+
+const mockUser = {
+  steamId: "76561198023709299",
+  displayName: "Jay",
+  avatar: "https://example.com/a.jpg",
+  profileUrl: "https://steamcommunity.com/id/finallyjay",
+}
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+beforeEach(() => {
+  routerPushSpy.mockClear()
+  clearUserSpy.mockClear()
+  pathnameRef.current = "/dashboard"
+  globalThis.fetch = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }) as unknown as Response)
+})
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = ORIGINAL_FETCH
+  vi.clearAllMocks()
+})
+
+describe("DashboardHeader", () => {
+  it("renders the user's display name and avatar", () => {
+    render(<DashboardHeader user={mockUser} />)
+    expect(screen.getByText("Jay")).toBeInTheDocument()
+    expect(screen.getByAltText("Jay's Steam avatar")).toBeInTheDocument()
+  })
+
+  it("renders navigation links", () => {
+    render(<DashboardHeader user={mockUser} />)
+    expect(screen.getAllByText("Dashboard")[0]).toBeInTheDocument()
+    expect(screen.getAllByText("Library")[0]).toBeInTheDocument()
+  })
+
+  it("marks the current pathname's link as active", () => {
+    pathnameRef.current = "/games"
+    const { container } = render(<DashboardHeader user={mockUser} />)
+    const activeLink = container.querySelector('a[href="/games"]')
+    expect(activeLink?.className).toContain("bg-accent")
+  })
+
+  it("logs the user out when the Logout button is clicked", async () => {
+    render(<DashboardHeader user={mockUser} />)
+    const logoutButton = screen.getByRole("button", { name: /logout/i })
+    fireEvent.click(logoutButton)
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith("/api/auth/logout", { method: "POST" })
+      expect(clearUserSpy).toHaveBeenCalled()
+      expect(routerPushSpy).toHaveBeenCalledWith("/")
+    })
+  })
+
+  it("swallows logout errors (no crash)", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network")
+    })
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    render(<DashboardHeader user={mockUser} />)
+    fireEvent.click(screen.getByRole("button", { name: /logout/i }))
+    await waitFor(() => expect(consoleSpy).toHaveBeenCalled())
+    consoleSpy.mockRestore()
+  })
+
+  it("toggles the mobile menu open and closed", () => {
+    render(<DashboardHeader user={mockUser} />)
+    const menuButton = screen.getByRole("button", { name: /open menu/i })
+    fireEvent.click(menuButton)
+    expect(screen.getByRole("button", { name: /close menu/i })).toBeInTheDocument()
+    // Two "Dashboard" links now (top bar + mobile drawer)
+    expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(1)
+    fireEvent.click(screen.getByRole("button", { name: /close menu/i }))
+    expect(screen.getByRole("button", { name: /open menu/i })).toBeInTheDocument()
+  })
+
+  it("renders nothing when the user prop is falsy", () => {
+    const { container } = render(<DashboardHeader user={null as unknown as typeof mockUser} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/test/dashboard-insights.test.tsx
+++ b/test/dashboard-insights.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { useSteamGamesMock } = vi.hoisted(() => ({
+  useSteamGamesMock: vi.fn(),
+}))
+
+// Recharts uses ResizeObserver / layout measurement that jsdom doesn't do
+// well. Replace the top-level chart components with transparent pass-throughs.
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+  Pie: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Cell: () => null,
+  Tooltip: () => null,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+  Bar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  XAxis: () => null,
+  YAxis: () => null,
+}))
+
+vi.mock("@/hooks/use-steam-data", () => ({
+  useSteamGames: useSteamGamesMock,
+}))
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}))
+
+vi.mock("@/components/ui/animated-number", () => ({
+  AnimatedNumber: ({ value }: { value: number }) => <>{value}</>,
+}))
+
+import { DashboardInsights } from "@/components/dashboard/dashboard-insights"
+import type { SteamStatsResponse } from "@/lib/types/steam"
+
+function hookReturn(games: Array<{ playtime_forever: number }> = []) {
+  return {
+    games: games.map((g, i) => ({
+      appid: 100 + i,
+      name: `Game ${i}`,
+      playtime_forever: g.playtime_forever,
+      img_icon_url: "",
+      img_logo_url: "",
+    })),
+    loading: false,
+    isRefreshing: false,
+    lastUpdated: null,
+    error: null,
+    refetch: vi.fn(),
+  }
+}
+
+const baseStats: SteamStatsResponse = {
+  totalGames: 100,
+  gamesWithAchievements: 70,
+  totalAchievements: 500,
+  pendingAchievements: 200,
+  startedGames: 30,
+  averageCompletion: 50,
+  totalPlaytime: 2000,
+  perfectGames: 5,
+}
+
+beforeEach(() => {
+  useSteamGamesMock.mockReturnValue(hookReturn())
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("DashboardInsights", () => {
+  it("renders both Completion and All Library cards", () => {
+    render(<DashboardInsights stats={baseStats} />)
+    expect(screen.getByText("Completion")).toBeInTheDocument()
+    expect(screen.getByText("All Library")).toBeInTheDocument()
+  })
+
+  it("computes the completion model values correctly", () => {
+    render(<DashboardInsights stats={baseStats} />)
+    // Breakdown: perfect=5, started=30-5=25, untouched=70-30=40
+    expect(screen.getByText("Perfect")).toBeInTheDocument()
+    expect(screen.getByText("Started")).toBeInTheDocument()
+    expect(screen.getByText("Not Started")).toBeInTheDocument()
+    // Insight line combines them into a sentence
+    expect(
+      screen.getByText(/5 games are perfect, 25 are in progress, and 40 have not been started/),
+    ).toBeInTheDocument()
+  })
+
+  it("renders a placeholder insight when stats is null", () => {
+    render(<DashboardInsights stats={null} />)
+    expect(screen.getByText(/Sync data to reveal completion state/i)).toBeInTheDocument()
+  })
+
+  it("switches the library card to playtime bands when the toggle is clicked", () => {
+    useSteamGamesMock.mockReturnValue(
+      hookReturn([
+        { playtime_forever: 30 }, // 0.5h
+        { playtime_forever: 60 * 3 }, // 3h
+        { playtime_forever: 60 * 10 }, // 10h
+        { playtime_forever: 60 * 50 }, // 50h
+      ]),
+    )
+    render(<DashboardInsights stats={baseStats} />)
+    const playtimeButton = screen.getByRole("button", { name: /Playtime/i })
+    fireEvent.click(playtimeButton)
+    expect(screen.getByText("<1h")).toBeInTheDocument()
+    expect(screen.getByText("1-5h")).toBeInTheDocument()
+    expect(screen.getByText("25h+")).toBeInTheDocument()
+    expect(screen.getByText(/1 games under 1 hour, 1 with 25\+ hours logged/)).toBeInTheDocument()
+  })
+
+  it("shows library-state insight with played vs unplayed counts", () => {
+    useSteamGamesMock.mockReturnValue(
+      hookReturn([{ playtime_forever: 100 }, { playtime_forever: 0 }, { playtime_forever: 50 }]),
+    )
+    render(<DashboardInsights stats={baseStats} />)
+    expect(screen.getByText("Library State")).toBeInTheDocument()
+    expect(screen.getByText(/2 of 3 games have been launched/)).toBeInTheDocument()
+  })
+
+  it("shows the backlog-coverage placeholder when the library is empty", () => {
+    render(<DashboardInsights stats={baseStats} />)
+    expect(screen.getByText(/Load the library to reveal backlog coverage/i)).toBeInTheDocument()
+  })
+
+  it("shows the playtime-bands placeholder when the library is empty", () => {
+    render(<DashboardInsights stats={baseStats} />)
+    fireEvent.click(screen.getByRole("button", { name: /Playtime/i }))
+    expect(screen.getByText(/Load the full library to reveal playtime bands/i)).toBeInTheDocument()
+  })
+
+  it("renders the loading 'Waiting for chart data' placeholder when loading", () => {
+    render(<DashboardInsights stats={null} loading />)
+    // Completion card shows loading
+    expect(screen.getAllByText(/Waiting for chart data/i).length).toBeGreaterThan(0)
+  })
+
+  it("links completion slices to their filter destinations", () => {
+    const { container } = render(<DashboardInsights stats={baseStats} />)
+    const hrefs = Array.from(container.querySelectorAll("a")).map((a) => a.getAttribute("href"))
+    expect(hrefs.some((h) => h?.includes("filter=perfect"))).toBe(true)
+    expect(hrefs.some((h) => h?.includes("filter=started"))).toBe(true)
+    expect(hrefs.some((h) => h?.includes("filter=notstarted"))).toBe(true)
+  })
+})

--- a/test/library-overview.test.tsx
+++ b/test/library-overview.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { useSteamGamesMock, useSteamAchievementsBatchMock } = vi.hoisted(() => ({
+  useSteamGamesMock: vi.fn(),
+  useSteamAchievementsBatchMock: vi.fn(),
+}))
+
+vi.mock("@/hooks/use-steam-data", () => ({
+  useSteamGames: useSteamGamesMock,
+  useSteamAchievementsBatch: useSteamAchievementsBatchMock,
+  invalidateSteamData: vi.fn(),
+}))
+
+// react-select is heavy and its internal keyboard accessibility tree is
+// painful to drive via fireEvent. Replace it with a plain native <select>
+// that mirrors the value/options contract the component uses.
+vi.mock("react-select", () => ({
+  default: ({
+    value,
+    onChange,
+    options,
+    placeholder,
+  }: {
+    value: { value: string; label: string } | null
+    onChange: (opt: { value: string; label: string } | null) => void
+    options: Array<{ value: string; label: string }>
+    placeholder?: string
+  }) => (
+    <select
+      aria-label={placeholder}
+      value={value?.value ?? ""}
+      onChange={(e) => {
+        const next = options.find((opt) => opt.value === e.target.value) ?? null
+        onChange(next)
+      }}
+    >
+      <option value="">{placeholder}</option>
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+import { LibraryOverview } from "@/components/dashboard/library-overview"
+
+function buildGame(overrides: {
+  appid: number
+  name: string
+  playtime_forever?: number
+  unlocked_count?: number
+  total_count?: number
+  perfect_game?: boolean
+}) {
+  return {
+    appid: overrides.appid,
+    name: overrides.name,
+    playtime_forever: overrides.playtime_forever ?? 0,
+    img_icon_url: "",
+    img_logo_url: "",
+    unlocked_count: overrides.unlocked_count,
+    total_count: overrides.total_count,
+    perfect_game: overrides.perfect_game ?? false,
+  }
+}
+
+const ORIGINAL_IO = globalThis.IntersectionObserver
+
+beforeEach(() => {
+  useSteamGamesMock.mockReturnValue({
+    games: [],
+    loading: false,
+    isRefreshing: false,
+    lastUpdated: null,
+    error: null,
+    refetch: vi.fn(),
+  })
+  useSteamAchievementsBatchMock.mockReturnValue({
+    achievementsMap: {},
+    loading: false,
+    isRefreshing: false,
+    lastUpdated: null,
+    error: null,
+    refetch: vi.fn(),
+  })
+  // jsdom doesn't implement IntersectionObserver
+  globalThis.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return []
+    }
+  } as unknown as typeof IntersectionObserver
+})
+
+afterEach(() => {
+  cleanup()
+  globalThis.IntersectionObserver = ORIGINAL_IO
+  vi.clearAllMocks()
+})
+
+describe("LibraryOverview", () => {
+  it("renders the loading skeleton when the games hook is loading", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [],
+      loading: true,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    const { container } = render(<LibraryOverview />)
+    expect(container.querySelectorAll('[data-slot="skeleton"], .animate-pulse').length).toBeGreaterThan(0)
+  })
+
+  it("renders the error message when useSteamGames reports an error", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: "Something broke",
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview />)
+    expect(screen.getByText("Something broke")).toBeInTheDocument()
+  })
+
+  it("shows the empty state when there are no games", () => {
+    render(<LibraryOverview />)
+    expect(screen.getByText(/No games match the current filters/i)).toBeInTheDocument()
+  })
+
+  it("renders every game in the list and the total count", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [
+        buildGame({ appid: 620, name: "Portal 2", playtime_forever: 600, unlocked_count: 29, total_count: 51 }),
+        buildGame({
+          appid: 440,
+          name: "Team Fortress 2",
+          playtime_forever: 6000,
+          unlocked_count: 210,
+          total_count: 520,
+        }),
+      ],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview />)
+    expect(screen.getByText("Portal 2")).toBeInTheDocument()
+    expect(screen.getByText("Team Fortress 2")).toBeInTheDocument()
+    expect(screen.getByText("2 games")).toBeInTheDocument()
+  })
+
+  it("filters by name via the search input (after debounce)", async () => {
+    vi.useFakeTimers()
+    useSteamGamesMock.mockReturnValue({
+      games: [
+        buildGame({ appid: 620, name: "Portal 2", playtime_forever: 100, unlocked_count: 1, total_count: 1 }),
+        buildGame({ appid: 440, name: "Team Fortress 2", playtime_forever: 100, unlocked_count: 1, total_count: 1 }),
+      ],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview />)
+    const searchInput = screen.getByPlaceholderText("Search games...")
+    fireEvent.change(searchInput, { target: { value: "portal" } })
+    // debounce is 300ms
+    await vi.advanceTimersByTimeAsync(300)
+    vi.useRealTimers()
+    await waitFor(() => {
+      expect(screen.queryByText("Team Fortress 2")).not.toBeInTheDocument()
+    })
+    expect(screen.getByText("Portal 2")).toBeInTheDocument()
+    expect(screen.getByText("1 of 2 games")).toBeInTheDocument()
+  })
+
+  it("filters to Perfect games when the Completion dropdown is set to 'perfect'", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [
+        buildGame({ appid: 1, name: "Perfect Game", unlocked_count: 10, total_count: 10, perfect_game: true }),
+        buildGame({ appid: 2, name: "Started Game", unlocked_count: 3, total_count: 10 }),
+        buildGame({ appid: 3, name: "Not Started", unlocked_count: 0, total_count: 10 }),
+      ],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview initialFilter="perfect" />)
+    expect(screen.getByText("Perfect Game")).toBeInTheDocument()
+    expect(screen.queryByText("Started Game")).not.toBeInTheDocument()
+    // "Not Started" also appears as a mocked select option — scope our check
+    // to rendered game cards only.
+    expect(screen.queryByRole("heading", { name: "Not Started" })).not.toBeInTheDocument()
+  })
+
+  it("filters by achievement scope='with' to exclude zero-achievement games", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [
+        buildGame({ appid: 1, name: "Has Achievements", unlocked_count: 1, total_count: 10 }),
+        buildGame({ appid: 2, name: "No Achievements", total_count: 0 }),
+      ],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview initialAchievements="with" />)
+    expect(screen.getByText("Has Achievements")).toBeInTheDocument()
+    expect(screen.queryByText("No Achievements")).not.toBeInTheDocument()
+  })
+
+  it("filters to played games when played=played", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [
+        buildGame({ appid: 1, name: "Played Game", playtime_forever: 120 }),
+        buildGame({ appid: 2, name: "Never Played", playtime_forever: 0 }),
+      ],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview initialPlayed="played" />)
+    expect(screen.getByText("Played Game")).toBeInTheDocument()
+    expect(screen.queryByText("Never Played")).not.toBeInTheDocument()
+  })
+
+  it("falls back to default when an invalid initial filter is passed", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [buildGame({ appid: 1, name: "Only Game", playtime_forever: 1 })],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(
+      <LibraryOverview initialFilter="bogus" initialOrder="bogus" initialAchievements="bogus" initialPlayed="bogus" />,
+    )
+    expect(screen.getByText("Only Game")).toBeInTheDocument()
+  })
+})

--- a/test/recent-games.test.tsx
+++ b/test/recent-games.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { useSteamGamesMock, useSteamAchievementsBatchMock } = vi.hoisted(() => ({
+  useSteamGamesMock: vi.fn(),
+  useSteamAchievementsBatchMock: vi.fn(),
+}))
+
+vi.mock("@/hooks/use-steam-data", () => ({
+  useSteamGames: useSteamGamesMock,
+  useSteamAchievementsBatch: useSteamAchievementsBatchMock,
+  invalidateSteamData: vi.fn(),
+}))
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+import { RecentGames } from "@/components/dashboard/recent-games"
+
+function defaultHookReturn(overrides: { games?: unknown[]; loading?: boolean; error?: unknown } = {}) {
+  return {
+    games: [],
+    loading: false,
+    isRefreshing: false,
+    lastUpdated: null,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useSteamGamesMock.mockReturnValue(defaultHookReturn())
+  useSteamAchievementsBatchMock.mockReturnValue({
+    achievementsMap: {},
+    loading: false,
+    isRefreshing: false,
+    lastUpdated: null,
+    error: null,
+    refetch: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = ORIGINAL_FETCH
+  vi.clearAllMocks()
+})
+
+describe("RecentGames", () => {
+  it("renders skeletons while loading", () => {
+    useSteamGamesMock.mockReturnValueOnce(defaultHookReturn({ loading: true }))
+    render(<RecentGames />)
+    expect(screen.getByText("Recently Played Games")).toBeInTheDocument()
+  })
+
+  it("renders an error card when the hook reports an error", () => {
+    useSteamGamesMock.mockReturnValueOnce(defaultHookReturn({ error: "boom" }))
+    render(<RecentGames />)
+    expect(screen.getByText(/Failed to load recent games/i)).toBeInTheDocument()
+  })
+
+  it("renders the empty state when there are no recent games", () => {
+    render(<RecentGames />)
+    expect(screen.getByText(/No recently played games/i)).toBeInTheDocument()
+  })
+
+  it("renders game cards when games are present", () => {
+    useSteamGamesMock.mockReturnValueOnce(
+      defaultHookReturn({
+        games: [
+          {
+            appid: 620,
+            name: "Portal 2",
+            playtime_forever: 600,
+            img_icon_url: "",
+            img_logo_url: "",
+            unlocked_count: 29,
+            total_count: 51,
+            perfect_game: false,
+          },
+          {
+            appid: 440,
+            name: "Team Fortress 2",
+            playtime_forever: 6000,
+            img_icon_url: "",
+            img_logo_url: "",
+            unlocked_count: 210,
+            total_count: 520,
+            perfect_game: false,
+          },
+        ],
+      }),
+    )
+    render(<RecentGames />)
+    expect(screen.getByText("Portal 2")).toBeInTheDocument()
+    expect(screen.getByText("Team Fortress 2")).toBeInTheDocument()
+  })
+
+  it("limits the visible list to the top 6 recent games", () => {
+    useSteamGamesMock.mockReturnValueOnce(
+      defaultHookReturn({
+        games: Array.from({ length: 10 }, (_, i) => ({
+          appid: 100 + i,
+          name: `Game ${i}`,
+          playtime_forever: 100,
+          img_icon_url: "",
+          img_logo_url: "",
+          unlocked_count: 0,
+          total_count: 0,
+          perfect_game: false,
+        })),
+      }),
+    )
+    render(<RecentGames />)
+    expect(screen.getByText("Game 0")).toBeInTheDocument()
+    expect(screen.getByText("Game 5")).toBeInTheDocument()
+    expect(screen.queryByText("Game 6")).not.toBeInTheDocument()
+  })
+
+  it("hides a game locally after a successful POST /api/steam/games/hide", async () => {
+    useSteamGamesMock.mockReturnValue(
+      defaultHookReturn({
+        games: [
+          {
+            appid: 620,
+            name: "Portal 2",
+            playtime_forever: 100,
+            img_icon_url: "",
+            img_logo_url: "",
+            unlocked_count: 0,
+            total_count: 0,
+            perfect_game: false,
+          },
+        ],
+      }),
+    )
+    globalThis.fetch = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }) as unknown as Response)
+
+    render(<RecentGames />)
+    expect(screen.getByText("Portal 2")).toBeInTheDocument()
+    const hideButton = screen.getAllByLabelText(/hide/i)[0]
+    fireEvent.click(hideButton)
+    await waitFor(() => expect(screen.queryByText("Portal 2")).not.toBeInTheDocument())
+  })
+})

--- a/test/sync-status-button.test.tsx
+++ b/test/sync-status-button.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { toastSpy, invalidateSpy } = vi.hoisted(() => ({
+  toastSpy: vi.fn(),
+  invalidateSpy: vi.fn(),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastSpy }),
+  toast: toastSpy,
+}))
+
+vi.mock("@/hooks/use-steam-data", () => ({
+  invalidateSteamData: invalidateSpy,
+}))
+
+import { SyncStatusButton, useSyncStatus } from "@/components/dashboard/sync-status-button"
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+function mockFetchSequence(handler: (url: string, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
+    handler(String(input), init),
+  ) as unknown as typeof fetch
+}
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function errResponse(status: number, body?: unknown) {
+  return {
+    ok: false,
+    status,
+    json: async () => body ?? { error: "Failed" },
+  } as unknown as Response
+}
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  toastSpy.mockClear()
+  invalidateSpy.mockClear()
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = ORIGINAL_FETCH
+  consoleErrorSpy.mockRestore()
+  vi.clearAllMocks()
+})
+
+describe("useSyncStatus", () => {
+  it("surfaces stats sync timestamp as a human-readable label", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        lastOwnedGamesSyncAt: null,
+        lastRecentGamesSyncAt: null,
+        lastStatsSyncAt: "2026-04-11T10:00:00.000Z",
+      }),
+    )
+    const { result } = renderHook(() => useSyncStatus())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.label).toContain("Last sync")
+  })
+
+  it("falls back to owned games timestamp when stats is missing", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        lastOwnedGamesSyncAt: "2026-04-11T10:00:00.000Z",
+        lastRecentGamesSyncAt: null,
+        lastStatsSyncAt: null,
+      }),
+    )
+    const { result } = renderHook(() => useSyncStatus())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.label).toContain("Last sync")
+  })
+
+  it("returns null label when nothing has been synced", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        lastOwnedGamesSyncAt: null,
+        lastRecentGamesSyncAt: null,
+        lastStatsSyncAt: null,
+      }),
+    )
+    const { result } = renderHook(() => useSyncStatus())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.label).toBeNull()
+  })
+
+  it("returns null label for an unparseable timestamp", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        lastOwnedGamesSyncAt: null,
+        lastRecentGamesSyncAt: null,
+        lastStatsSyncAt: "not a date",
+      }),
+    )
+    const { result } = renderHook(() => useSyncStatus())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.label).toBeNull()
+  })
+
+  it("silently handles a failed status fetch", async () => {
+    mockFetchSequence(async () => errResponse(500))
+    const { result } = renderHook(() => useSyncStatus())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.label).toBeNull()
+  })
+
+  it("silently handles a rejected status fetch", async () => {
+    mockFetchSequence(async () => {
+      throw new Error("network")
+    })
+    const { result } = renderHook(() => useSyncStatus())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+  })
+})
+
+describe("SyncStatusButton", () => {
+  it("shows 'Sync' initially and calls POST /api/steam/sync on click", async () => {
+    const urls: string[] = []
+    mockFetchSequence(async (url, init) => {
+      urls.push(`${init?.method ?? "GET"} ${url}`)
+      if (init?.method === "POST") {
+        return ok({
+          syncedAt: "2026-04-11T10:00:00.000Z",
+          ownedGames: 100,
+          recentGames: 5,
+          stats: { totalGames: 100, totalAchievements: 1500, totalPlaytime: 200, perfectGames: 3 },
+        })
+      }
+      return ok({ lastOwnedGamesSyncAt: null, lastRecentGamesSyncAt: null, lastStatsSyncAt: null })
+    })
+
+    render(<SyncStatusButton />)
+    expect(screen.getByRole("button")).toHaveTextContent(/Sync/)
+
+    fireEvent.click(screen.getByRole("button"))
+
+    await waitFor(() => expect(urls.some((u) => u.startsWith("POST") && u.includes("/api/steam/sync"))).toBe(true))
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Steam sync completed" })),
+    )
+  })
+
+  it("shows an error toast when POST fails with a structured error body", async () => {
+    mockFetchSequence(async (_url, init) => {
+      if (init?.method === "POST") {
+        return errResponse(500, { error: "Upstream down" })
+      }
+      return ok({ lastOwnedGamesSyncAt: null, lastRecentGamesSyncAt: null, lastStatsSyncAt: null })
+    })
+
+    render(<SyncStatusButton />)
+    fireEvent.click(screen.getByRole("button"))
+
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Steam sync failed", variant: "destructive" }),
+      ),
+    )
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it("shows an error toast when POST fails with unparseable body", async () => {
+    mockFetchSequence(async (_url, init) => {
+      if (init?.method === "POST") {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => {
+            throw new Error("not json")
+          },
+        } as unknown as Response
+      }
+      return ok({ lastOwnedGamesSyncAt: null, lastRecentGamesSyncAt: null, lastStatsSyncAt: null })
+    })
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    render(<SyncStatusButton />)
+    fireEvent.click(screen.getByRole("button"))
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Steam sync failed", variant: "destructive" }),
+      ),
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it("shows 'Syncing...' while the POST is in flight", async () => {
+    let resolvePost: (() => void) | null = null
+    mockFetchSequence(async (_url, init) => {
+      if (init?.method === "POST") {
+        await new Promise<void>((resolve) => {
+          resolvePost = resolve
+        })
+        return ok({
+          syncedAt: "2026-04-11T10:00:00.000Z",
+          ownedGames: 0,
+          recentGames: 0,
+          stats: { totalGames: 0, totalAchievements: 0, totalPlaytime: 0, perfectGames: 0 },
+        })
+      }
+      return ok({ lastOwnedGamesSyncAt: null, lastRecentGamesSyncAt: null, lastStatsSyncAt: null })
+    })
+
+    render(<SyncStatusButton />)
+    fireEvent.click(screen.getByRole("button"))
+    await waitFor(() => expect(screen.getByRole("button")).toBeDisabled())
+    act(() => {
+      resolvePost?.()
+    })
+    await waitFor(() => expect(screen.getByRole("button")).not.toBeDisabled())
+  })
+})

--- a/test/user-profile.test.tsx
+++ b/test/user-profile.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Stub AnimatedNumber so we can assert on the numeric value directly
+vi.mock("@/components/ui/animated-number", () => ({
+  AnimatedNumber: ({ value }: { value: number }) => <>{value}</>,
+}))
+
+import { UserProfile } from "@/components/dashboard/user-profile"
+import type { SteamUser } from "@/lib/auth"
+import type { SteamStatsResponse } from "@/lib/types/steam"
+
+const baseUser: SteamUser = {
+  steamId: "76561198023709299",
+  displayName: "Jay",
+  avatar: "https://example.com/a.jpg",
+  profileUrl: "https://steamcommunity.com/id/finallyjay",
+  timecreated: 1_200_000_000,
+  communityVisibilityState: 3,
+  steamLevel: 42,
+  badges: [{ badgeid: 13, level: 120 }],
+}
+
+const baseStats: SteamStatsResponse = {
+  totalGames: 629,
+  gamesWithAchievements: 440,
+  totalAchievements: 17964,
+  pendingAchievements: 5000,
+  startedGames: 133,
+  averageCompletion: 77,
+  totalPlaytime: 33000,
+  perfectGames: 45,
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("UserProfile", () => {
+  it("renders display name, avatar, and KPI summary", () => {
+    render(<UserProfile user={baseUser} stats={baseStats} />)
+    expect(screen.getByText("Jay")).toBeInTheDocument()
+    expect(screen.getByAltText("Jay's Steam avatar")).toBeInTheDocument()
+    expect(screen.getByText("Total Games")).toBeInTheDocument()
+    expect(screen.getByText("629")).toBeInTheDocument()
+    expect(screen.getByText("17964")).toBeInTheDocument() // Unlocked Achievements
+    expect(screen.getByText("133")).toBeInTheDocument() // Started Games
+    expect(screen.getByText("45")).toBeInTheDocument() // Perfect Games
+  })
+
+  it("renders … placeholders for each KPI while stats are loading", () => {
+    render(<UserProfile user={baseUser} stats={null} statsLoading />)
+    // 4 KPI cards all show '...'
+    expect(screen.getAllByText("...").length).toBe(4)
+  })
+
+  it("shows average completion when stats are available", () => {
+    render(<UserProfile user={baseUser} stats={baseStats} />)
+    expect(screen.getByText("Avg. completion")).toBeInTheDocument()
+    expect(screen.getByText("77")).toBeInTheDocument()
+  })
+
+  it("renders a tier-coloured circle badge for levels < 100", () => {
+    const user = { ...baseUser, steamLevel: 42 }
+    render(<UserProfile user={user} stats={baseStats} />)
+    expect(screen.getByText("42")).toBeInTheDocument()
+  })
+
+  it("renders a sprite-backed badge for levels >= 100 (exercises the sprite branch)", () => {
+    // jsdom doesn't faithfully serialize the inline background-image url(),
+    // so we just assert the level number is rendered — that's enough to
+    // execute the 'sprite' branch of getSteamLevelBadge and hit the code path.
+    const user = { ...baseUser, steamLevel: 150 }
+    render(<UserProfile user={user} stats={baseStats} />)
+    expect(screen.getByText("150")).toBeInTheDocument()
+  })
+
+  it("falls back to a circle badge when the level's century has no sprite mapping", () => {
+    const user = { ...baseUser, steamLevel: 99999 }
+    render(<UserProfile user={user} stats={baseStats} />)
+    expect(screen.getByText("99999")).toBeInTheDocument()
+  })
+
+  it("omits the level badge when steamLevel is null", () => {
+    const user = { ...baseUser, steamLevel: null }
+    render(<UserProfile user={user} stats={baseStats} />)
+    // display name still there
+    expect(screen.getByText("Jay")).toBeInTheDocument()
+  })
+
+  it("renders a years-of-service badge when timecreated is set", () => {
+    render(<UserProfile user={baseUser} stats={baseStats} />)
+    const img = screen.getByAltText(/\d+ years of service/)
+    expect(img.getAttribute("src")).toContain("steamyears")
+  })
+
+  it("renders a Game Collector badge when the user has badge 13", () => {
+    render(<UserProfile user={baseUser} stats={baseStats} />)
+    expect(screen.getByAltText(/Game Collector level 120/)).toBeInTheDocument()
+  })
+
+  it("warns when the community profile is not public", () => {
+    const user = { ...baseUser, communityVisibilityState: 2 }
+    render(<UserProfile user={user} stats={baseStats} />)
+    expect(screen.getByRole("alert")).toHaveTextContent(/not public/i)
+  })
+
+  it("does not render the warning when communityVisibilityState is null", () => {
+    const user = { ...baseUser, communityVisibilityState: null }
+    render(<UserProfile user={user} stats={baseStats} />)
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("links each KPI card to its filter destination", () => {
+    const { container } = render(<UserProfile user={baseUser} stats={baseStats} />)
+    const links = container.querySelectorAll("a[href^='/games']")
+    const hrefs = Array.from(links).map((a) => a.getAttribute("href"))
+    expect(hrefs).toContain("/games")
+    expect(hrefs).toContain("/games?played=played&filter=perfect&achievements=with")
+    expect(hrefs).toContain("/games?played=played&filter=started&achievements=with")
+  })
+
+  it("renders the sync label when provided", () => {
+    render(<UserProfile user={baseUser} stats={baseStats} syncLabel="Last sync 10 minutes ago" />)
+    expect(screen.getByText("Last sync 10 minutes ago")).toBeInTheDocument()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,10 +42,10 @@ export default defineConfig({
       // coverage PR ratchets these up; CI fails if a PR regresses below
       // the current floor.
       thresholds: {
-        lines: 75,
-        statements: 73,
-        branches: 62,
-        functions: 58,
+        lines: 92,
+        statements: 90,
+        branches: 83,
+        functions: 81,
       },
     },
   },


### PR DESCRIPTION
## Summary
Six new test files bring \`components/dashboard/\` from 0% to ~82% coverage, pushing **global lines over the 90% target**.

### New test files
- **\`sync-status-button\`** — \`useSyncStatus\` label fallbacks (stats > owned > recent, unparseable, empty), silent 5xx / network failures, button click triggers POST + invalidation + toast, structured error body, unparseable error body, syncing state (disabled while in flight).
- **\`recent-games\`** — skeleton while loading, error card, empty state, game list rendering, top-6 limit, locally-hidden POST + state update.
- **\`dashboard-header\`** — display name + avatar, nav links, active link highlighting via pathname, logout flow (fetch + clearUser + router push), logout error swallow, mobile menu toggle, null-user no-render.
- **\`user-profile\`** — KPI summary, loading placeholders, avg completion, level badge (< 100 / ≥ 100 sprite branch / no-sprite fallback / null level), years-of-service badge, game collector badge, private-profile warning, KPI link destinations, sync label.
- **\`dashboard-insights\`** — both cards render, completion model math (perfect/started/untouched with correct insight sentence), null-stats placeholder, playtime-bands toggle, library-state insight, empty-library placeholder for both modes, loading state, KPI links. Recharts mocked with pass-through components.
- **\`library-overview\`** — loading skeleton, error message, empty state, game list + total count, debounced search (fake timers), initialFilter=perfect, achievement scope 'with', played filter, invalid initial-* falls back to defaults. \`react-select\` stubbed as a native \`<select>\`, \`IntersectionObserver\` stubbed.

## Coverage delta
| | before | after |
|---|---|---|
| \`components/dashboard/\` | 0% | **81.72 / 75.33 / 71.73 / 83.07** |
| **global** | 73.93 / 62.55 / 58.82 / 76.37 | **90.87 / 83.29 / 81.66 / 92.49** |

**Target hit: lines ≥ 90%** 🎯

Thresholds ratcheted to their final floor: \`lines:92 / stmts:90 / branches:83 / funcs:81\`. Any PR that drops below those numbers will fail CI.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (342 passed)
- [x] \`pnpm test:coverage\` (all thresholds met)
- [ ] CI green
- [ ] Coverage report artifact downloadable from the Actions run

🤖 Generated with [Claude Code](https://claude.com/claude-code)