### PR TITLE
fix(dashboard): count games with unlocks as 'played' even when playtime=0

### DIFF
--- a/components/dashboard/dashboard-insights.tsx
+++ b/components/dashboard/dashboard-insights.tsx
@@ -218,7 +218,11 @@ export function DashboardInsights({ stats, loading = false }: DashboardInsightsP
       }
     }
 
-    const played = allGames.filter((game) => game.playtime_forever > 0).length
+    // "Played" counts any game with either logged playtime OR at least one
+    // unlocked achievement — matches the library-overview filter and keeps
+    // delisted/pinned games (FaceRig, Free to Play, …) out of the unplayed
+    // bucket even though GetOwnedGames reports 0 playtime for them.
+    const played = allGames.filter((game) => game.playtime_forever > 0 || (game.unlocked_count ?? 0) > 0).length
     const unplayed = Math.max(allGames.length - played, 0)
 
     return {

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -190,11 +190,14 @@ export function LibraryOverview({
         break
     }
 
-    // Played filter
+    // Played filter: a game counts as "played" if Steam reports any playtime
+    // OR if at least one achievement has been unlocked. The second clause is
+    // necessary for delisted/pinned games (FaceRig, Free to Play, …) where
+    // GetPlayerAchievements still honours unlocks but there's no playtime.
     if (playedFilter === "played") {
-      filtered = filtered.filter((game) => game.playtime > 0)
+      filtered = filtered.filter((game) => game.playtime > 0 || game.unlockedAchievements > 0)
     } else if (playedFilter === "notplayed") {
-      filtered = filtered.filter((game) => game.playtime === 0)
+      filtered = filtered.filter((game) => game.playtime === 0 && game.unlockedAchievements === 0)
     }
 
     // Hide locally hidden games

--- a/test/dashboard-insights.test.tsx
+++ b/test/dashboard-insights.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/components/ui/animated-number", () => ({
 import { DashboardInsights } from "@/components/dashboard/dashboard-insights"
 import type { SteamStatsResponse } from "@/lib/types/steam"
 
-function hookReturn(games: Array<{ playtime_forever: number }> = []) {
+function hookReturn(games: Array<{ playtime_forever: number; unlocked_count?: number }> = []) {
   return {
     games: games.map((g, i) => ({
       appid: 100 + i,
@@ -43,6 +43,7 @@ function hookReturn(games: Array<{ playtime_forever: number }> = []) {
       playtime_forever: g.playtime_forever,
       img_icon_url: "",
       img_logo_url: "",
+      unlocked_count: g.unlocked_count,
     })),
     loading: false,
     isRefreshing: false,
@@ -120,6 +121,21 @@ describe("DashboardInsights", () => {
     )
     render(<DashboardInsights stats={baseStats} />)
     expect(screen.getByText("Library State")).toBeInTheDocument()
+    expect(screen.getByText(/2 of 3 games have been launched/)).toBeInTheDocument()
+  })
+
+  it("counts pinned games with unlocks as 'played' in the library-state insight", () => {
+    // Regression: a FaceRig-style entry with 0 playtime but unlocked
+    // achievements must still be counted as played, not dumped into the
+    // 'unplayed' slice of the donut.
+    useSteamGamesMock.mockReturnValue(
+      hookReturn([
+        { playtime_forever: 0, unlocked_count: 37 }, // FaceRig — pinned
+        { playtime_forever: 0, unlocked_count: 0 }, // genuine shelf-dust
+        { playtime_forever: 100, unlocked_count: 0 }, // played, no unlocks yet
+      ]),
+    )
+    render(<DashboardInsights stats={baseStats} />)
     expect(screen.getByText(/2 of 3 games have been launched/)).toBeInTheDocument()
   })
 

--- a/test/library-overview.test.tsx
+++ b/test/library-overview.test.tsx
@@ -241,6 +241,43 @@ describe("LibraryOverview", () => {
     expect(screen.queryByText("Never Played")).not.toBeInTheDocument()
   })
 
+  it("counts pinned games with unlocks as 'played' even when playtime is 0", () => {
+    // Regression: FaceRig & friends have playtime=0 because GetOwnedGames
+    // doesn't return them, but we know they've been played because there
+    // are unlocked achievements. They must not fall into "not played".
+    useSteamGamesMock.mockReturnValue({
+      games: [
+        buildGame({ appid: 1, name: "FaceRig", playtime_forever: 0, unlocked_count: 37, total_count: 37 }),
+        buildGame({ appid: 2, name: "Unplayed Shelf-Dust", playtime_forever: 0, unlocked_count: 0, total_count: 10 }),
+      ],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview initialPlayed="played" />)
+    expect(screen.getByText("FaceRig")).toBeInTheDocument()
+    expect(screen.queryByText("Unplayed Shelf-Dust")).not.toBeInTheDocument()
+  })
+
+  it("excludes pinned games with unlocks from 'not played'", () => {
+    useSteamGamesMock.mockReturnValue({
+      games: [
+        buildGame({ appid: 1, name: "FaceRig", playtime_forever: 0, unlocked_count: 37, total_count: 37 }),
+        buildGame({ appid: 2, name: "Unplayed Shelf-Dust", playtime_forever: 0, unlocked_count: 0, total_count: 10 }),
+      ],
+      loading: false,
+      isRefreshing: false,
+      lastUpdated: null,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<LibraryOverview initialPlayed="notplayed" />)
+    expect(screen.queryByText("FaceRig")).not.toBeInTheDocument()
+    expect(screen.getByText("Unplayed Shelf-Dust")).toBeInTheDocument()
+  })
+
   it("falls back to default when an invalid initial filter is passed", () => {
     useSteamGamesMock.mockReturnValue({
       games: [buildGame({ appid: 1, name: "Only Game", playtime_forever: 1 })],


### PR DESCRIPTION
## Summary
Pinned/delisted games (FaceRig, Free to Play, JBMod, They Came From The Moon, Grind Zones) come from \`GetPlayerAchievements\`, not \`GetOwnedGames\`, so there's no playtime for them — we persist \`playtime_forever = 0\` at pin-resolution time. That meant they were falling into the **not played** bucket in both the library filter and the *Library State* donut, even though they have unlocked achievements (which is proof the user has actually played them).

Fix: treat a game as *played* when Steam reports playtime > 0 **or** at least one achievement has been unlocked. Mirrored in the two places that make the split:

- \`library-overview.tsx\` — Played / Not Played filter
- \`dashboard-insights.tsx\` — Library State insight sentence + donut slice

Regression tests added for both: a pinned-style row (\`playtime=0\`, \`unlocks>0\`) is counted as played in the library filter, excluded from *not played*, and included in the insight's played count.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (345 passed)
- [x] \`pnpm test:coverage\` (all thresholds met, global still >91% lines)
- [ ] On a real account: FaceRig / Free to Play / JBMod appear under Library filter *Played = Played* and in the dashboard's *Played* donut slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)