### PR TITLE
feat(playtime): real playtime for pinned games + first_playtime for everyone

### DIFF
--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -68,6 +68,7 @@ function createBaseSchema(db: DatabaseSync) {
       playtime_forever INTEGER NOT NULL DEFAULT 0,
       playtime_2weeks INTEGER,
       rtime_last_played INTEGER,
+      rtime_first_played INTEGER,
       owned INTEGER NOT NULL DEFAULT 1,
       last_seen_in_owned_games_at TEXT,
       achievements_synced_at TEXT,
@@ -211,6 +212,26 @@ function seedAllowedUsersFromEnv(db: DatabaseSync) {
   }
 }
 
+/**
+ * Additive-only schema evolution: adds a column to an existing table if it's
+ * not already there. Safe on both fresh and existing databases, since the
+ * CREATE TABLE IF NOT EXISTS in createBaseSchema already defines the latest
+ * shape for new installs. This helper handles the "users with old databases"
+ * case without dropping data.
+ */
+function addColumnIfMissing(db: DatabaseSync, table: string, column: string, definition: string) {
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+  if (columns.some((c) => c.name === column)) return
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`)
+}
+
+function applyAdditiveMigrations(db: DatabaseSync) {
+  // Unix timestamp of the first time this user played this game, sourced
+  // from ClientGetLastPlayedTimes. Nullable because older rows may not have
+  // been enriched yet.
+  addColumnIfMissing(db, "user_games", "rtime_first_played", "INTEGER")
+}
+
 export function getSqliteDatabase() {
   if (database) {
     return database
@@ -221,6 +242,7 @@ export function getSqliteDatabase() {
 
   database = new DatabaseSync(dbPath)
   createBaseSchema(database)
+  applyAdditiveMigrations(database)
   seedAllowedUsersFromEnv(database)
   seedPinnedGames(database)
 

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -1,6 +1,6 @@
 import "server-only"
 
-import { getOwnedGames, type SteamGame } from "@/lib/steam-api"
+import { getLastPlayedTimes, getOwnedGames, type LastPlayedGame, type SteamGame } from "@/lib/steam-api"
 import { ensureGameImages } from "@/lib/server/steam-images"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { ensurePinnedGamesSynced } from "@/lib/server/pinned-games"
@@ -22,6 +22,7 @@ export type GameRow = {
   playtime_forever: number
   playtime_2weeks: number | null
   rtime_last_played: number | null
+  rtime_first_played: number | null
   img_icon_url: string | null
   img_logo_url: string | null
   image_icon_url: string | null
@@ -41,6 +42,7 @@ export function mapRowToSteamGame(row: GameRow): SteamGame {
     playtime_forever: row.playtime_forever,
     playtime_2weeks: row.playtime_2weeks ?? undefined,
     rtime_last_played: row.rtime_last_played ?? undefined,
+    rtime_first_played: row.rtime_first_played ?? undefined,
     img_icon_url: row.img_icon_url ?? "",
     img_logo_url: row.img_logo_url ?? "",
     image_icon_url: row.image_icon_url ?? undefined,
@@ -66,6 +68,7 @@ export function getStoredOwnedGames(steamId: string): SteamGame[] {
       ug.playtime_forever,
       ug.playtime_2weeks,
       ug.rtime_last_played,
+      ug.rtime_first_played,
       g.icon_hash AS img_icon_url,
       g.logo_hash AS img_logo_url,
       g.image_icon_url,
@@ -99,6 +102,7 @@ export function getStoredGame(steamId: string, appId: number): SteamGame | null 
       ug.playtime_forever,
       ug.playtime_2weeks,
       ug.rtime_last_played,
+      ug.rtime_first_played,
       g.icon_hash AS img_icon_url,
       g.logo_hash AS img_logo_url,
       g.image_icon_url,
@@ -210,6 +214,45 @@ export function persistOwnedGames(steamId: string, games: SteamGame[]) {
  * @param options.forceRefresh - Skip staleness check and always fetch from Steam API
  * @returns The user's owned games list
  */
+/**
+ * Enriches every user_games row that matches an entry in the
+ * ClientGetLastPlayedTimes response with its real playtime_forever,
+ * rtime_last_played and rtime_first_played. Rows not present in the
+ * response are untouched.
+ *
+ * The endpoint returns every game the account has ever played, including
+ * delisted ones (FaceRig, Free to Play, …) that GetOwnedGames hides, so
+ * pinned games finally get a real playtime instead of the 0 we write
+ * during upsertPinned. It also gives us first_playtime, which isn't
+ * exposed anywhere else in the Web API.
+ */
+export function persistLastPlayedTimes(steamId: string, games: LastPlayedGame[]) {
+  if (games.length === 0) return
+
+  const db = getSqliteDatabase()
+  const now = nowIso()
+  const update = db.prepare(
+    `UPDATE user_games
+     SET playtime_forever = ?,
+         rtime_last_played = COALESCE(?, rtime_last_played),
+         rtime_first_played = COALESCE(?, rtime_first_played),
+         updated_at = ?
+     WHERE steam_id = ? AND appid = ?`,
+  )
+
+  for (const game of games) {
+    if (game.playtime_forever === undefined) continue
+    update.run(
+      game.playtime_forever,
+      nullIfUndefined(game.last_playtime),
+      nullIfUndefined(game.first_playtime),
+      now,
+      steamId,
+      game.appid,
+    )
+  }
+}
+
 export async function ensureOwnedGamesSynced(steamId: string, options?: { forceRefresh?: boolean }) {
   const forceRefresh = options?.forceRefresh ?? false
   upsertProfile(steamId)
@@ -228,6 +271,12 @@ export async function ensureOwnedGamesSynced(steamId: string, options?: { forceR
   // Resolve pinned (delisted) games after the main upsert so persistOwnedGames'
   // markMissingAsUnowned sweep can't flip them back to owned=0.
   await ensurePinnedGamesSynced(steamId, new Set(games.map((game) => game.appid)))
+  // Enrich every matched row with real playtime + first_playtime from the
+  // client-side "last played times" log. Pinned games benefit most from
+  // this (they arrive with playtime=0), but every owned game also gets a
+  // first_playtime value that GetOwnedGames never exposes.
+  const lastPlayed = await getLastPlayedTimes(steamId)
+  persistLastPlayedTimes(steamId, lastPlayed)
   const finalGames = getStoredOwnedGames(steamId)
   await ensureGameImages(finalGames.map((game) => game.appid))
   return finalGames
@@ -252,6 +301,7 @@ export async function getRecentlyPlayedGamesForUser(steamId: string, options?: {
       ug.playtime_forever,
       ug.playtime_2weeks,
       ug.rtime_last_played,
+      ug.rtime_first_played,
       g.icon_hash AS img_icon_url,
       g.logo_hash AS img_logo_url,
       g.image_icon_url,

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -9,6 +9,7 @@ export interface SteamGame {
   image_landscape_url?: string
   image_portrait_url?: string
   rtime_last_played?: number
+  rtime_first_played?: number
   has_community_visible_stats?: boolean
   unlocked_count?: number
   total_count?: number
@@ -150,6 +151,40 @@ export async function getPlayerAchievements(steamId: string, appId: number): Pro
     }
     console.error("Error fetching achievements for app:", appId, error)
     return null
+  }
+}
+
+export interface LastPlayedGame {
+  appid: number
+  playtime_forever?: number
+  playtime_2weeks?: number
+  first_playtime?: number
+  last_playtime?: number
+}
+
+/**
+ * Fetches the "last played times" log for a Steam user via the undocumented
+ * `IPlayerService/ClientGetLastPlayedTimes/v1/` endpoint.
+ *
+ * This returns playtime data for **every** game the account has ever played —
+ * including delisted apps (FaceRig, Free to Play, …) that `GetOwnedGames`
+ * silently drops. Unlike `GetOwnedGames`, the response also contains
+ * `first_playtime`, which isn't exposed anywhere else in the Web API.
+ */
+export async function getLastPlayedTimes(steamId: string): Promise<LastPlayedGame[]> {
+  try {
+    const data = (await steamAPIRequest("/IPlayerService/ClientGetLastPlayedTimes/v1/", {
+      steamid: steamId,
+      min_last_played: "0",
+    })) as { response?: { games?: LastPlayedGame[] } }
+
+    return data.response?.games ?? []
+  } catch (error) {
+    if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
+      return []
+    }
+    console.error("Error fetching last played times:", error)
+    return []
   }
 }
 

--- a/test/achievements-sync-gaps.test.ts
+++ b/test/achievements-sync-gaps.test.ts
@@ -64,6 +64,7 @@ function mockSteamApi(mocks: {
     getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
     getPlayerAchievements: mocks.getPlayerAchievements ?? vi.fn().mockResolvedValue(null),
     getGameSchema: mocks.getGameSchema ?? vi.fn().mockResolvedValue(null),
+    getLastPlayedTimes: vi.fn().mockResolvedValue([]),
   }))
   vi.doMock("@/lib/server/steam-images", () => ({
     ensureGameImages: vi.fn().mockResolvedValue(undefined),

--- a/test/achievements-sync.test.ts
+++ b/test/achievements-sync.test.ts
@@ -101,6 +101,7 @@ describe("syncAchievementsForStats (per-game)", () => {
       getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: mockGetGameSchema,
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -148,6 +149,7 @@ describe("syncAchievementsForStats (per-game)", () => {
       getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn(),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -179,6 +181,7 @@ describe("syncAchievementsForStats (per-game)", () => {
       getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn().mockResolvedValue(null),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -214,6 +217,7 @@ describe("syncAchievementsForStats (per-game)", () => {
       getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn().mockResolvedValue(null),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -244,6 +248,7 @@ describe("syncAchievementsForStats (incremental filter)", () => {
       getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn().mockResolvedValue(null),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),

--- a/test/last-played-times.test.ts
+++ b/test/last-played-times.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const ORIGINAL_FETCH = globalThis.fetch
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-last-played-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  process.env.STEAM_API_KEY = "fake-key"
+  vi.resetModules()
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  delete process.env.SQLITE_PATH
+  delete process.env.STEAM_API_KEY
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const STEAM_ID = "76561198023709299"
+
+describe("getLastPlayedTimes (Steam API wrapper)", () => {
+  it("returns the games array on success", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        response: {
+          games: [
+            { appid: 274920, playtime_forever: 569, first_playtime: 1415148326, last_playtime: 1748176523 },
+            { appid: 620, playtime_forever: 3000, first_playtime: 1300000000, last_playtime: 1700000000 },
+          ],
+        },
+      }),
+    })) as unknown as typeof fetch
+    const { getLastPlayedTimes } = await import("@/lib/steam-api")
+    const games = await getLastPlayedTimes(STEAM_ID)
+    expect(games).toHaveLength(2)
+    expect(games[0].appid).toBe(274920)
+    expect(games[0].playtime_forever).toBe(569)
+  })
+
+  it("passes steamid and min_last_played=0 as query parameters", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ response: { games: [] } }),
+    }))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const { getLastPlayedTimes } = await import("@/lib/steam-api")
+    await getLastPlayedTimes(STEAM_ID)
+    const calledWith = (fetchMock as unknown as { mock: { calls: [[string, unknown]] } }).mock.calls[0][0]
+    expect(calledWith).toContain("ClientGetLastPlayedTimes")
+    expect(calledWith).toContain(`steamid=${STEAM_ID}`)
+    expect(calledWith).toContain("min_last_played=0")
+  })
+
+  it("returns [] silently on a 400 (account with nothing played)", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({}),
+    })) as unknown as typeof fetch
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { getLastPlayedTimes } = await import("@/lib/steam-api")
+    expect(await getLastPlayedTimes(STEAM_ID)).toEqual([])
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
+  it("returns [] and logs on network failure", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNRESET")
+    }) as unknown as typeof fetch
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { getLastPlayedTimes } = await import("@/lib/steam-api")
+    expect(await getLastPlayedTimes(STEAM_ID)).toEqual([])
+    expect(consoleSpy).toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+})
+
+describe("persistLastPlayedTimes", () => {
+  async function seed() {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const now = new Date().toISOString()
+    db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (620, 'Portal 2', ?, ?)`).run(now, now)
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (274920, 'FaceRig', ?, ?)`).run(now, now)
+    // Portal 2: already has some playtime and rtime_last_played
+    db.prepare(
+      `INSERT INTO user_games (steam_id, appid, playtime_forever, rtime_last_played, owned, created_at, updated_at)
+       VALUES (?, 620, 100, 1600000000, 1, ?, ?)`,
+    ).run(STEAM_ID, now, now)
+    // FaceRig: pinned, playtime=0 placeholder
+    db.prepare(
+      `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+       VALUES (?, 274920, 0, 1, ?, ?)`,
+    ).run(STEAM_ID, now, now)
+    return db
+  }
+
+  it("enriches existing rows with playtime_forever, last_playtime and first_playtime", async () => {
+    const db = await seed()
+    const { persistLastPlayedTimes } = await import("@/lib/server/steam-games-sync")
+
+    persistLastPlayedTimes(STEAM_ID, [
+      { appid: 274920, playtime_forever: 569, first_playtime: 1415148326, last_playtime: 1748176523 },
+      { appid: 620, playtime_forever: 3000, first_playtime: 1300000000, last_playtime: 1700000000 },
+    ])
+
+    const facerig = db
+      .prepare("SELECT playtime_forever, rtime_first_played, rtime_last_played FROM user_games WHERE appid = 274920")
+      .get() as { playtime_forever: number; rtime_first_played: number; rtime_last_played: number }
+    expect(facerig.playtime_forever).toBe(569)
+    expect(facerig.rtime_first_played).toBe(1415148326)
+    expect(facerig.rtime_last_played).toBe(1748176523)
+
+    const portal2 = db
+      .prepare("SELECT playtime_forever, rtime_first_played, rtime_last_played FROM user_games WHERE appid = 620")
+      .get() as { playtime_forever: number; rtime_first_played: number; rtime_last_played: number }
+    expect(portal2.playtime_forever).toBe(3000)
+    expect(portal2.rtime_first_played).toBe(1300000000)
+    expect(portal2.rtime_last_played).toBe(1700000000)
+  })
+
+  it("ignores appids not present in user_games (no new rows created)", async () => {
+    const db = await seed()
+    const { persistLastPlayedTimes } = await import("@/lib/server/steam-games-sync")
+
+    persistLastPlayedTimes(STEAM_ID, [{ appid: 999999, playtime_forever: 100, first_playtime: 1, last_playtime: 2 }])
+
+    const row = db.prepare("SELECT 1 FROM user_games WHERE steam_id = ? AND appid = 999999").get(STEAM_ID)
+    expect(row).toBeUndefined()
+  })
+
+  it("preserves the existing rtime_last_played when last_playtime is undefined", async () => {
+    const db = await seed()
+    const { persistLastPlayedTimes } = await import("@/lib/server/steam-games-sync")
+
+    persistLastPlayedTimes(STEAM_ID, [{ appid: 620, playtime_forever: 200 }])
+
+    const row = db.prepare("SELECT playtime_forever, rtime_last_played FROM user_games WHERE appid = 620").get() as {
+      playtime_forever: number
+      rtime_last_played: number
+    }
+    expect(row.playtime_forever).toBe(200)
+    expect(row.rtime_last_played).toBe(1600000000) // unchanged
+  })
+
+  it("is a no-op when called with an empty list", async () => {
+    const db = await seed()
+    const { persistLastPlayedTimes } = await import("@/lib/server/steam-games-sync")
+    persistLastPlayedTimes(STEAM_ID, [])
+    const row = db.prepare("SELECT playtime_forever FROM user_games WHERE appid = 274920").get() as {
+      playtime_forever: number
+    }
+    expect(row.playtime_forever).toBe(0) // unchanged
+  })
+
+  it("skips entries with undefined playtime_forever", async () => {
+    const db = await seed()
+    const { persistLastPlayedTimes } = await import("@/lib/server/steam-games-sync")
+    persistLastPlayedTimes(STEAM_ID, [{ appid: 274920, first_playtime: 1415148326 }])
+    const row = db.prepare("SELECT playtime_forever FROM user_games WHERE appid = 274920").get() as {
+      playtime_forever: number
+    }
+    expect(row.playtime_forever).toBe(0) // unchanged because we skipped
+  })
+})

--- a/test/stats-compute-gaps.test.ts
+++ b/test/stats-compute-gaps.test.ts
@@ -52,6 +52,7 @@ function mockSteamApi() {
     getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
     getPlayerAchievements: vi.fn().mockResolvedValue(null),
     getGameSchema: vi.fn().mockResolvedValue(null),
+    getLastPlayedTimes: vi.fn().mockResolvedValue([]),
   }))
   vi.doMock("@/lib/server/steam-images", () => ({
     ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -145,6 +146,7 @@ describe("synchronizeUserData", () => {
         achievements: [{ apiname: "ACH_ONE", achieved: 1, unlocktime: 1 }],
       }),
       getGameSchema: vi.fn().mockResolvedValue(null),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),

--- a/test/steam-games-sync.test.ts
+++ b/test/steam-games-sync.test.ts
@@ -51,6 +51,7 @@ function mockSteamApi(
     getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
     getPlayerAchievements: vi.fn().mockResolvedValue(null),
     getGameSchema: vi.fn().mockResolvedValue(null),
+    getLastPlayedTimes: vi.fn().mockResolvedValue([]),
   }))
   vi.doMock("@/lib/server/steam-images", () => ({
     ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -87,6 +88,7 @@ describe("ensureOwnedGamesSynced", () => {
       getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: vi.fn().mockResolvedValue(null),
       getGameSchema: vi.fn().mockResolvedValue(null),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -147,6 +149,7 @@ describe("ensureOwnedGamesSynced", () => {
       getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: vi.fn().mockResolvedValue(null),
       getGameSchema: vi.fn().mockResolvedValue(null),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
     }))
     vi.doMock("@/lib/server/steam-images", () => ({
       ensureGameImages: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
Uses the undocumented \`IPlayerService/ClientGetLastPlayedTimes/v1/\` endpoint to enrich every user_games row with real playtime data.

### Why
Pinned/delisted games (FaceRig, Free to Play, JBMod, They Came From The Moon, Grind Zones, Qubburo 2) come from \`GetPlayerAchievements\`, which gives us unlocks but no playtime. We were writing \`playtime_forever = 0\` at pin time, and \`GetOwnedGames\` didn't return them either. Result: they showed as \"0h played\" everywhere, even though the user clearly played them.

\`ClientGetLastPlayedTimes\` returns playtime for **every** game the account has ever played — including delisted ones — and additionally exposes \`first_playtime\` (when you first launched the game), which is not available from \`GetOwnedGames\` at all. Verified against the real account: **1169 games** returned (vs 629 from GetOwnedGames), and every pinned appid comes back with real hours.

### Changes

**API wrapper** — \`lib/steam-api.ts\`
- New \`getLastPlayedTimes()\` + \`LastPlayedGame\` interface. Silently handles 400/403 like the other wrappers.
- \`SteamGame\` type now carries an optional \`rtime_first_played\`.

**Schema** — \`lib/server/sqlite.ts\`
- New \`rtime_first_played INTEGER\` column in \`user_games\`.
- New \`addColumnIfMissing\` helper that checks \`PRAGMA table_info\` before running \`ALTER TABLE\`. Non-destructive for existing databases; fresh installs get the column in \`CREATE TABLE\` directly.

**Sync pipeline** — \`lib/server/steam-games-sync.ts\`
- \`GameRow\` + the three SELECT queries + \`mapRowToSteamGame\` now carry \`rtime_first_played\`.
- New \`persistLastPlayedTimes(steamId, games)\` — updates any existing user_games row whose appid matches. Uses \`COALESCE\` so a missing \`last_playtime\` / \`first_playtime\` doesn't overwrite what we already have. **Deliberately does not insert new rows** — the ~540 extra refunded / family-shared entries in the response are out of scope.
- \`ensureOwnedGamesSynced\` now calls \`getLastPlayedTimes\` → \`persistLastPlayedTimes\` right after \`ensurePinnedGamesSynced\`, so pinned games go from \`0h\` to their real playtime in the same sync pass.

### Deliberately out of scope
- UI for \"first played\" (we persist it, but no component reads it yet — easy follow-up).
- Per-OS playtime breakdowns (Windows/Mac/Linux/Deck). The endpoint exposes them but we'd need a donut component and 8 more columns; not worth it until there's a concrete UI request.
- The ~540 games in \`ClientGetLastPlayedTimes\` but not in \`GetOwnedGames\` (refunds, family shares). We'd need explicit product decisions about how to surface \"games you used to own\".

### Tests
- \`test/last-played-times.test.ts\`: wrapper (happy path, param shape, 400 silent, network error) + \`persistLastPlayedTimes\` (enriches matched rows, ignores unknown appids, preserves unset columns via COALESCE, no-op on empty list, skips entries missing \`playtime_forever\`).
- All four existing test files that mock \`@/lib/steam-api\` now include \`getLastPlayedTimes\` in the mock shape (otherwise \`ensureOwnedGamesSynced\` crashes).

### Verified on real account
\`\`\`
FaceRig (274920):   9.5h   first=2014-11-05  last=2025-05-25
Free to Play:       5 min
JBMod:              4 min
They Came…:         4.6h
Qubburo 2:          2.5h
Grind Zones:        2.9h
\`\`\`

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (345 passing)
- [x] \`pnpm test:coverage\` — global 91.09% lines (above threshold)
- [ ] Restart dev server + sync on the real account → pinned games show real hours in library list and are correctly counted in the *Played* donut slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)