### PR TITLE
feat(extras): dedicated /extras page for played-but-unowned games

### DIFF
--- a/app/api/steam/extras/route.ts
+++ b/app/api/steam/extras/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+import { getCurrentUser } from "@/app/lib/server-auth"
+import { getExtraGamesForUser } from "@/lib/server/extra-games"
+import { logger } from "@/lib/server/logger"
+
+/**
+ * GET /api/steam/extras
+ *
+ * Returns the authenticated user's "extras" — games they've played at least
+ * once (per ClientGetLastPlayedTimes) but don't own in the main library.
+ * Sourced from the dedicated `extra_games` table, never from user_games, so
+ * the payload can never contaminate library stats.
+ *
+ * @returns {{ games: ExtraGame[] }} ordered by playtime_forever DESC
+ * @throws 401 - Unauthorized
+ * @throws 500 - Server error
+ */
+export async function GET() {
+  try {
+    const user = await getCurrentUser()
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const games = getExtraGamesForUser(user.steamId)
+    return NextResponse.json({ games })
+  } catch (error) {
+    logger.error({ err: error, endpoint: "steam/extras" }, "Steam extras API error")
+    return NextResponse.json({ error: "Failed to fetch extras" }, { status: 500 })
+  }
+}

--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
+import { AlertCircle, Search } from "lucide-react"
+
+import { useCurrentUser } from "@/hooks/use-current-user"
+import { useSteamExtras } from "@/hooks/use-steam-data"
+import { PageContainer } from "@/components/ui/page-container"
+import { LoadingMessage } from "@/components/ui/loading-message"
+import { formatPlaytime } from "@/lib/utils"
+
+function formatDate(unixSeconds: number | null) {
+  if (!unixSeconds) return "—"
+  const d = new Date(unixSeconds * 1000)
+  if (Number.isNaN(d.getTime())) return "—"
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
+}
+
+export default function ExtrasPage() {
+  const { user, loading: loadingUser } = useCurrentUser()
+  const router = useRouter()
+  const { games, loading: loadingGames, error } = useSteamExtras()
+  const [search, setSearch] = useState("")
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
+  useEffect(() => {
+    if (!loadingUser && !user) {
+      router.push("/")
+    }
+  }, [loadingUser, router, user])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return games
+    return games.filter((g) => (g.name ?? `app #${g.appid}`).toLowerCase().includes(q))
+  }, [games, search])
+
+  if (loadingUser) return <LoadingMessage />
+  if (!user) return null
+
+  return (
+    <PageContainer>
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Extras</h1>
+          <p className="text-muted-foreground max-w-2xl text-sm">
+            Games Steam remembers you played at some point but that aren&apos;t in your main library: refunded,
+            family-shared, delisted, or otherwise removed. These <strong>don&apos;t count</strong> in your library
+            stats, insights, or KPIs — they&apos;re tracked separately so you can still see them without contaminating
+            anything else.
+          </p>
+        </div>
+
+        <div className="border-surface-4 bg-surface-1 focus-within:border-accent flex h-9 items-center gap-2 rounded-lg border px-3">
+          <Search className="text-muted-foreground h-4 w-4 shrink-0" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search extras…"
+            className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
+          />
+          <span className="text-muted-foreground shrink-0 text-sm">
+            {loadingGames ? "Loading…" : `${filtered.length} of ${games.length}`}
+          </span>
+        </div>
+
+        {error ? (
+          <div className="border-destructive/40 bg-destructive/5 flex items-start gap-3 rounded-lg border px-4 py-3">
+            <AlertCircle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
+            <div className="text-sm">
+              <p className="text-destructive font-medium">Could not load extras</p>
+              <p className="text-muted-foreground">{error}</p>
+            </div>
+          </div>
+        ) : loadingGames ? (
+          <p className="text-muted-foreground py-8 text-center text-sm">Loading extras…</p>
+        ) : filtered.length === 0 ? (
+          <div className="border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center">
+            <p className="text-muted-foreground">No extras yet.</p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              After syncing, games Steam remembers you played but no longer own will show up here.
+            </p>
+          </div>
+        ) : (
+          <div className="border-surface-4 bg-surface-1 overflow-hidden rounded-lg border">
+            <table className="w-full text-sm">
+              <thead className="text-muted-foreground border-surface-4 border-b text-left text-xs tracking-wider uppercase">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Game</th>
+                  <th className="px-4 py-2 font-medium">Playtime</th>
+                  <th className="hidden px-4 py-2 font-medium md:table-cell">First played</th>
+                  <th className="hidden px-4 py-2 font-medium md:table-cell">Last played</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((game) => (
+                  <tr key={game.appid} className="border-surface-4/50 hover:bg-surface-2 border-t">
+                    <td className="px-4 py-2.5">
+                      <a
+                        href={`https://store.steampowered.com/app/${game.appid}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-accent text-foreground"
+                      >
+                        {game.name ?? `App #${game.appid}`}
+                      </a>
+                    </td>
+                    <td className="text-muted-foreground px-4 py-2.5 tabular-nums">
+                      {formatPlaytime(game.playtime_forever / 60)}
+                    </td>
+                    <td className="text-muted-foreground hidden px-4 py-2.5 tabular-nums md:table-cell">
+                      {formatDate(game.rtime_first_played)}
+                    </td>
+                    <td className="text-muted-foreground hidden px-4 py-2.5 tabular-nums md:table-cell">
+                      {formatDate(game.rtime_last_played)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PageContainer>
+  )
+}

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
-import { Gamepad2, LayoutDashboard, Library, LogOut, Menu, X } from "lucide-react"
+import { Gamepad2, LayoutDashboard, Library, LogOut, Menu, Sparkles, X } from "lucide-react"
 import type { SteamUser } from "@/lib/auth"
 import { useRouter, usePathname } from "next/navigation"
 import Link from "next/link"
@@ -92,6 +92,9 @@ export function DashboardHeader({ user }: DashboardHeaderProps) {
                 <NavLink href="/games" icon={Library}>
                   Library
                 </NavLink>
+                <NavLink href="/extras" icon={Sparkles}>
+                  Extras
+                </NavLink>
               </nav>
             </div>
 
@@ -129,6 +132,9 @@ export function DashboardHeader({ user }: DashboardHeaderProps) {
             </NavLink>
             <NavLink href="/games" icon={Library} onClick={() => setMobileMenuOpen(false)}>
               Library
+            </NavLink>
+            <NavLink href="/extras" icon={Sparkles} onClick={() => setMobileMenuOpen(false)}>
+              Extras
             </NavLink>
           </div>
         </nav>

--- a/hooks/use-steam-data.ts
+++ b/hooks/use-steam-data.ts
@@ -265,6 +265,51 @@ export function useSteamStats() {
   return { stats, loading, isRefreshing, lastUpdated, error, refetch }
 }
 
+export type SteamExtraGame = {
+  appid: number
+  name: string | null
+  playtime_forever: number
+  rtime_first_played: number | null
+  rtime_last_played: number | null
+  synced_at: string
+}
+
+export function useSteamExtras() {
+  const [games, setGames] = useState<SteamExtraGame[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch("/api/steam/extras")
+      if (!response.ok) throw new Error("Failed to fetch extras")
+      const data = (await response.json()) as { games: SteamExtraGame[] }
+      setGames(data.games)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error")
+      setGames([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  useEffect(() => {
+    function handleInvalidate() {
+      void load()
+    }
+    window.addEventListener(STEAM_DATA_INVALIDATED_EVENT, handleInvalidate)
+    return () => window.removeEventListener(STEAM_DATA_INVALIDATED_EVENT, handleInvalidate)
+  }, [load])
+
+  return { games, loading, error, refetch: load }
+}
+
 export function useSteamAchievements(appId: number | null) {
   const [achievements, setAchievements] = useState<SteamAchievementView[]>([])
   const [loading, setLoading] = useState(false)

--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -1,0 +1,181 @@
+import "server-only"
+
+import type { LastPlayedGame } from "@/lib/steam-api"
+import { getSqliteDatabase } from "@/lib/server/sqlite"
+import { nowIso } from "@/lib/server/steam-store-utils"
+import { logger } from "@/lib/server/logger"
+
+export type ExtraGame = {
+  appid: number
+  name: string | null
+  playtime_forever: number
+  rtime_first_played: number | null
+  rtime_last_played: number | null
+  synced_at: string
+}
+
+// Store API: max 200 appids per request, rate-limited ~200 req / 5min per IP.
+// We only batch during the owned-games refresh (~every 24h per user), so one
+// fan-out of 3 calls on first sync is fine.
+const STORE_BATCH_SIZE = 200
+
+type StoreAppDetails = {
+  success?: boolean
+  data?: {
+    name?: string
+    type?: string
+  }
+}
+
+/**
+ * Fetches `name` from the public store `appdetails` API for the given ids and
+ * upserts them into the shared `games` name cache. Subsequent queries that
+ * join against `games` will surface the names without re-fetching.
+ *
+ * Swallows per-batch errors so a transient store outage doesn't break the
+ * whole sync. Appids whose store entry 404s or returns `success=false`
+ * (delisted with no remaining metadata) are simply left nameless.
+ */
+async function hydrateMissingGameNames(appIds: number[]) {
+  if (appIds.length === 0) return
+
+  const db = getSqliteDatabase()
+  const now = nowIso()
+  const upsertGame = db.prepare(`
+    INSERT INTO games (appid, name, created_at, updated_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(appid) DO UPDATE SET
+      name = COALESCE(excluded.name, games.name),
+      updated_at = excluded.updated_at
+  `)
+
+  for (let i = 0; i < appIds.length; i += STORE_BATCH_SIZE) {
+    const batch = appIds.slice(i, i + STORE_BATCH_SIZE)
+    try {
+      const url = new URL("https://store.steampowered.com/api/appdetails")
+      url.searchParams.set("appids", batch.join(","))
+      url.searchParams.set("filters", "basic")
+      const response = await fetch(url.toString(), { cache: "no-store" })
+      if (!response.ok) continue
+
+      const payload = (await response.json()) as Record<string, StoreAppDetails>
+      for (const appid of batch) {
+        const entry = payload[String(appid)]
+        const name = entry?.success && entry.data?.name ? entry.data.name : null
+        upsertGame.run(appid, name, now, now)
+      }
+    } catch (error) {
+      logger.warn({ err: error, batchSize: batch.length }, "Store appdetails batch failed")
+    }
+  }
+}
+
+/**
+ * Upserts every played-game row that is NOT in the user's owned library and
+ * NOT a pinned game. These surfaces refunded, family-shared, delisted and
+ * otherwise-unowned games whose playtime Steam still remembers via
+ * ClientGetLastPlayedTimes.
+ *
+ * Fully isolated from `user_games` so nothing in `extra_games` can leak into
+ * library stats / KPIs / insights.
+ */
+export async function persistExtraGames(steamId: string, lastPlayed: LastPlayedGame[]) {
+  if (lastPlayed.length === 0) return
+
+  const db = getSqliteDatabase()
+
+  // Build the skip set: owned library entries + pinned appids. Both sources
+  // already live in user_games (pinned games get upserted there during
+  // ensurePinnedGamesSynced), so a single query covers both.
+  const ownedRows = db.prepare(`SELECT appid FROM user_games WHERE steam_id = ? AND owned = 1`).all(steamId) as Array<{
+    appid: number
+  }>
+  const skip = new Set(ownedRows.map((row) => row.appid))
+
+  const candidates = lastPlayed.filter((game) => {
+    if (skip.has(game.appid)) return false
+    // Skip entries that never actually accumulated playtime. Steam seems to
+    // emit some zero-playtime rows for games the user touched only in a
+    // launcher sense (hover / preload); they'd pollute the list.
+    if (!game.playtime_forever || game.playtime_forever <= 0) return false
+    return true
+  })
+
+  if (candidates.length === 0) return
+
+  const now = nowIso()
+  const upsert = db.prepare(`
+    INSERT INTO extra_games (
+      steam_id, appid, playtime_forever, rtime_first_played, rtime_last_played,
+      synced_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(steam_id, appid) DO UPDATE SET
+      playtime_forever = excluded.playtime_forever,
+      rtime_first_played = COALESCE(excluded.rtime_first_played, extra_games.rtime_first_played),
+      rtime_last_played = COALESCE(excluded.rtime_last_played, extra_games.rtime_last_played),
+      synced_at = excluded.synced_at,
+      updated_at = excluded.updated_at
+  `)
+
+  db.exec("BEGIN")
+  try {
+    for (const game of candidates) {
+      upsert.run(
+        steamId,
+        game.appid,
+        game.playtime_forever ?? 0,
+        game.first_playtime ?? null,
+        game.last_playtime ?? null,
+        now,
+        now,
+        now,
+      )
+    }
+    db.exec("COMMIT")
+  } catch (error) {
+    db.exec("ROLLBACK")
+    throw error
+  }
+
+  // Hydrate names for any candidate appids that don't already have a name
+  // cached in the shared `games` table. Fires one extra fan-out of store API
+  // calls on first sync (cheap, batches of 200), then becomes a no-op once
+  // the cache is warm.
+  const nameless = db
+    .prepare(
+      `
+      SELECT e.appid
+      FROM extra_games e
+      LEFT JOIN games g ON g.appid = e.appid
+      WHERE e.steam_id = ? AND (g.name IS NULL OR g.name = '')
+    `,
+    )
+    .all(steamId) as Array<{ appid: number }>
+
+  if (nameless.length > 0) {
+    await hydrateMissingGameNames(nameless.map((r) => r.appid))
+  }
+}
+
+/** Returns every extra-games row for a user, joined with the shared games name cache. */
+export function getExtraGamesForUser(steamId: string): ExtraGame[] {
+  const db = getSqliteDatabase()
+  const rows = db
+    .prepare(
+      `
+      SELECT
+        e.appid,
+        g.name,
+        e.playtime_forever,
+        e.rtime_first_played,
+        e.rtime_last_played,
+        e.synced_at
+      FROM extra_games e
+      LEFT JOIN games g ON g.appid = e.appid
+      WHERE e.steam_id = ?
+      ORDER BY e.playtime_forever DESC, e.rtime_last_played DESC
+    `,
+    )
+    .all(steamId) as ExtraGame[]
+  return rows
+}

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -153,9 +153,28 @@ function createBaseSchema(db: DatabaseSync) {
       added_at TEXT NOT NULL
     );
 
+    -- Games the user has played at some point but no longer owns in the
+    -- traditional sense: refunded, family-shared, delisted, removed from
+    -- library, etc. Sourced from ClientGetLastPlayedTimes minus the ids we
+    -- already treat as owned (user_games.owned = 1). Fully isolated from
+    -- user_games so nothing in here can contaminate library stats.
+    CREATE TABLE IF NOT EXISTS extra_games (
+      steam_id TEXT NOT NULL,
+      appid INTEGER NOT NULL,
+      playtime_forever INTEGER NOT NULL DEFAULT 0,
+      rtime_first_played INTEGER,
+      rtime_last_played INTEGER,
+      synced_at TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (steam_id, appid),
+      FOREIGN KEY (steam_id) REFERENCES steam_profile(steam_id)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id ON user_games(steam_id);
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id_owned ON user_games(steam_id, owned);
     CREATE INDEX IF NOT EXISTS idx_stats_snapshot_steam_id ON stats_snapshot(steam_id);
+    CREATE INDEX IF NOT EXISTS idx_extra_games_steam_id ON extra_games(steam_id);
   `)
 }
 

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -4,6 +4,7 @@ import { getLastPlayedTimes, getOwnedGames, type LastPlayedGame, type SteamGame 
 import { ensureGameImages } from "@/lib/server/steam-images"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { ensurePinnedGamesSynced } from "@/lib/server/pinned-games"
+import { persistExtraGames } from "@/lib/server/extra-games"
 import {
   nowIso,
   nullIfUndefined,
@@ -277,6 +278,10 @@ export async function ensureOwnedGamesSynced(steamId: string, options?: { forceR
   // first_playtime value that GetOwnedGames never exposes.
   const lastPlayed = await getLastPlayedTimes(steamId)
   persistLastPlayedTimes(steamId, lastPlayed)
+  // Everything in lastPlayed that ISN'T already in user_games (owned + pinned)
+  // lands in extra_games — refunded, family-shared, delisted-but-not-pinned,
+  // etc. Fully isolated from library stats.
+  await persistExtraGames(steamId, lastPlayed)
   const finalGames = getStoredOwnedGames(steamId)
   await ensureGameImages(finalGames.map((game) => game.appid))
   return finalGames

--- a/test/api-extras-route.test.ts
+++ b/test/api-extras-route.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("@/app/lib/server-auth", () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+vi.mock("@/lib/server/extra-games", () => ({
+  getExtraGamesForUser: vi.fn(),
+}))
+
+import { GET } from "@/app/api/steam/extras/route"
+import { getCurrentUser } from "@/app/lib/server-auth"
+import { getExtraGamesForUser } from "@/lib/server/extra-games"
+
+const mockUser = {
+  steamId: "76561198023709299",
+  displayName: "Jay",
+  avatar: "",
+  profileUrl: "",
+}
+
+beforeEach(() => {
+  vi.mocked(getCurrentUser).mockReset()
+  vi.mocked(getExtraGamesForUser).mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("GET /api/steam/extras", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it("returns the extras list for the authenticated user", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getExtraGamesForUser).mockReturnValue([
+      {
+        appid: 111,
+        name: "Refunded Game",
+        playtime_forever: 120,
+        rtime_first_played: 1_000_000_000,
+        rtime_last_played: 1_100_000_000,
+        synced_at: "2026-04-11T10:00:00.000Z",
+      },
+    ])
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { games: Array<{ appid: number }> }
+    expect(body.games).toHaveLength(1)
+    expect(body.games[0].appid).toBe(111)
+    expect(getExtraGamesForUser).toHaveBeenCalledWith("76561198023709299")
+  })
+
+  it("returns 500 when the store lookup throws", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getExtraGamesForUser).mockImplementation(() => {
+      throw new Error("db closed")
+    })
+    const res = await GET()
+    expect(res.status).toBe(500)
+  })
+})

--- a/test/dashboard-header.test.tsx
+++ b/test/dashboard-header.test.tsx
@@ -62,6 +62,7 @@ describe("DashboardHeader", () => {
     render(<DashboardHeader user={mockUser} />)
     expect(screen.getAllByText("Dashboard")[0]).toBeInTheDocument()
     expect(screen.getAllByText("Library")[0]).toBeInTheDocument()
+    expect(screen.getAllByText("Extras")[0]).toBeInTheDocument()
   })
 
   it("marks the current pathname's link as active", () => {

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const ORIGINAL_FETCH = globalThis.fetch
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-extras-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  vi.resetModules()
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  delete process.env.SQLITE_PATH
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const STEAM_ID = "76561198023709299"
+
+async function seedProfile() {
+  const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+  const db = getSqliteDatabase()
+  const now = new Date().toISOString()
+  db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
+  return db
+}
+
+function mockStoreAppDetails(handler: (appids: string) => Record<string, unknown>) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = new URL(String(input))
+    const appids = url.searchParams.get("appids") ?? ""
+    return {
+      ok: true,
+      status: 200,
+      json: async () => handler(appids),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+}
+
+describe("persistExtraGames", () => {
+  it("is a no-op when given an empty list", async () => {
+    await seedProfile()
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [])
+    expect(getExtraGamesForUser(STEAM_ID)).toEqual([])
+  })
+
+  it("upserts unowned + non-pinned games with playtime > 0", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    // An owned game (should be skipped)
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (620, 'Portal 2', ?, ?)`).run(now, now)
+    db.prepare(
+      `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+       VALUES (?, 620, 1000, 1, ?, ?)`,
+    ).run(STEAM_ID, now, now)
+    mockStoreAppDetails((appids) => {
+      const ids = appids.split(",").map(Number)
+      const out: Record<string, unknown> = {}
+      for (const id of ids) {
+        out[String(id)] = { success: true, data: { name: `Game ${id}`, type: "game" } }
+      }
+      return out
+    })
+
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [
+      // Already owned — must be skipped
+      { appid: 620, playtime_forever: 1000, first_playtime: 1, last_playtime: 2 },
+      // Extras
+      { appid: 111, playtime_forever: 500, first_playtime: 100, last_playtime: 200 },
+      { appid: 222, playtime_forever: 50, first_playtime: 300, last_playtime: 400 },
+      // Zero-playtime → skipped (launcher hover)
+      { appid: 333, playtime_forever: 0 },
+    ])
+
+    const extras = getExtraGamesForUser(STEAM_ID)
+    expect(extras.map((e) => e.appid)).toEqual([111, 222])
+    expect(extras[0]).toMatchObject({
+      appid: 111,
+      playtime_forever: 500,
+      rtime_first_played: 100,
+      rtime_last_played: 200,
+      name: "Game 111",
+    })
+  })
+
+  it("sorts by playtime_forever DESC, then by rtime_last_played DESC", async () => {
+    await seedProfile()
+    mockStoreAppDetails(() => ({}))
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [
+      { appid: 1, playtime_forever: 100 },
+      { appid: 2, playtime_forever: 500 },
+      { appid: 3, playtime_forever: 200 },
+    ])
+    const extras = getExtraGamesForUser(STEAM_ID)
+    expect(extras.map((e) => e.appid)).toEqual([2, 3, 1])
+  })
+
+  it("re-running updates playtime and preserves first_played via COALESCE", async () => {
+    await seedProfile()
+    mockStoreAppDetails(() => ({}))
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [
+      { appid: 111, playtime_forever: 100, first_playtime: 1000, last_playtime: 2000 },
+    ])
+    // Second run: new playtime, no first_playtime in response
+    await persistExtraGames(STEAM_ID, [{ appid: 111, playtime_forever: 150, last_playtime: 3000 }])
+    const extras = getExtraGamesForUser(STEAM_ID)
+    expect(extras[0].playtime_forever).toBe(150)
+    expect(extras[0].rtime_first_played).toBe(1000) // preserved
+    expect(extras[0].rtime_last_played).toBe(3000) // updated
+  })
+
+  it("caches fetched names into the shared games table so subsequent queries don't hit the store API", async () => {
+    const db = await seedProfile()
+    let calls = 0
+    mockStoreAppDetails((appids) => {
+      calls++
+      const ids = appids.split(",").map(Number)
+      const out: Record<string, unknown> = {}
+      for (const id of ids) out[String(id)] = { success: true, data: { name: `Game ${id}`, type: "game" } }
+      return out
+    })
+    const { persistExtraGames } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [{ appid: 111, playtime_forever: 500 }])
+    expect(calls).toBe(1)
+
+    // Second run with the same appid: name already cached → no new fetch
+    await persistExtraGames(STEAM_ID, [{ appid: 111, playtime_forever: 600 }])
+    expect(calls).toBe(1)
+
+    const game = db.prepare("SELECT name FROM games WHERE appid = 111").get() as { name: string }
+    expect(game.name).toBe("Game 111")
+  })
+
+  it("handles store API failures gracefully, leaving the row present without a name", async () => {
+    const db = await seedProfile()
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })) as unknown as typeof fetch
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [{ appid: 111, playtime_forever: 500 }])
+    const extras = getExtraGamesForUser(STEAM_ID)
+    expect(extras).toHaveLength(1)
+    expect(extras[0].appid).toBe(111)
+    // Nameless because the store API was down
+    expect(extras[0].name).toBeNull()
+    void db
+  })
+
+  it("handles store API rejected promises without breaking the sync", async () => {
+    await seedProfile()
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network")
+    }) as unknown as typeof fetch
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await expect(persistExtraGames(STEAM_ID, [{ appid: 111, playtime_forever: 500 }])).resolves.toBeUndefined()
+    expect(getExtraGamesForUser(STEAM_ID)).toHaveLength(1)
+  })
+
+  it("treats store API entries with success=false as nameless", async () => {
+    await seedProfile()
+    mockStoreAppDetails((appids) => {
+      const out: Record<string, unknown> = {}
+      for (const id of appids.split(",")) out[id] = { success: false }
+      return out
+    })
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [{ appid: 111, playtime_forever: 500 }])
+    const extras = getExtraGamesForUser(STEAM_ID)
+    expect(extras[0].name).toBeNull()
+  })
+
+  it("also skips pinned-resolved games (which land in user_games with owned=1)", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    // Simulate a pinned-resolved row: FaceRig upserted by ensurePinnedGamesSynced
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (274920, 'FaceRig', ?, ?)`).run(now, now)
+    db.prepare(
+      `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+       VALUES (?, 274920, 569, 1, ?, ?)`,
+    ).run(STEAM_ID, now, now)
+    mockStoreAppDetails(() => ({}))
+
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    await persistExtraGames(STEAM_ID, [{ appid: 274920, playtime_forever: 569 }])
+    expect(getExtraGamesForUser(STEAM_ID)).toEqual([])
+  })
+})
+
+describe("getExtraGamesForUser", () => {
+  it("returns [] for a user with no extras", async () => {
+    await seedProfile()
+    const { getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    expect(getExtraGamesForUser(STEAM_ID)).toEqual([])
+  })
+})

--- a/test/use-steam-data.test.tsx
+++ b/test/use-steam-data.test.tsx
@@ -197,6 +197,55 @@ describe("useSteamStats", () => {
   })
 })
 
+describe("useSteamExtras", () => {
+  it("loads extras on mount", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        games: [
+          {
+            appid: 111,
+            name: "Refunded Game",
+            playtime_forever: 100,
+            rtime_first_played: 1_000_000_000,
+            rtime_last_played: 1_100_000_000,
+            synced_at: "2026-04-11T10:00:00.000Z",
+          },
+        ],
+      }),
+    )
+    const { useSteamExtras } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamExtras())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.games).toHaveLength(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("sets error on non-ok response", async () => {
+    mockFetchSequence(async () => err(500))
+    const { useSteamExtras } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamExtras())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Failed to fetch extras")
+    expect(result.current.games).toEqual([])
+  })
+
+  it("re-fetches on invalidateSteamData event", async () => {
+    let calls = 0
+    mockFetchSequence(async () => {
+      calls++
+      return ok({ games: [] })
+    })
+    const { useSteamExtras } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamExtras())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const initial = calls
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steam-data-invalidated"))
+    })
+    await waitFor(() => expect(calls).toBeGreaterThan(initial))
+  })
+})
+
 describe("useSteamAchievements", () => {
   it("returns empty + loading=false when appId is null", async () => {
     const fetchSpy = vi.fn()


### PR DESCRIPTION
## Summary
Adds a fully isolated **Extras** section for games Steam remembers you played at some point but that aren't in your main library — refunded, family-shared, delisted-but-not-pinned, formerly-owned, etc. Sourced from \`ClientGetLastPlayedTimes\` minus the ids already in \`user_games\` (owned or pinned-resolved). Physically separated from \`user_games\` via a dedicated \`extra_games\` table so there's **no way** these can contaminate library stats / KPIs / insights.

## Schema
New \`extra_games\` table:
\`\`\`sql
extra_games (
  steam_id, appid, playtime_forever,
  rtime_first_played, rtime_last_played,
  synced_at, created_at, updated_at
)  -- PK (steam_id, appid)
\`\`\`

## Backend — \`lib/server/extra-games.ts\`
- **\`persistExtraGames\`**: upserts played rows that are NOT in user_games (owned=1). Filters out zero-playtime launcher noise. On first sync, hydrates missing names via the public \`store.steampowered.com/api/appdetails\` endpoint in batches of 200 and caches them in the shared \`games\` table. Swallows store failures gracefully (row stays; name is NULL).
- **\`getExtraGamesForUser\`**: \`SELECT … LEFT JOIN games\` for names, ordered by \`playtime_forever DESC\` then \`rtime_last_played DESC\`.
- Wired into \`ensureOwnedGamesSynced\` right after \`persistLastPlayedTimes\`, so one sync populates everything.

## Frontend
- New **\`useSteamExtras()\`** hook in \`hooks/use-steam-data.ts\` (mount fetch + \`invalidateSteamData\` event listener + refetch).
- New **\`/extras\`** page: searchable table with \`Game · Playtime · First played · Last played\`. Each row links out to \`store.steampowered.com/app/{appid}\`. Explicit banner at the top telling the user these don't count toward library stats.
- New **"Extras"** nav link in \`DashboardHeader\` (Sparkles icon), both desktop and mobile drawer.

## Tests (+18)
- **\`extra-games.test.ts\`** (10): no-op on empty, upsert + skip owned, skip zero-playtime, sort order, COALESCE on re-runs, name cache (no re-fetch), store 500 graceful, store network reject graceful, \`success=false\` → nameless, pinned game skip.
- **\`api-extras-route.test.ts\`** (3): 401, 200 happy path, 500 bubble.
- **\`use-steam-data.test.tsx\`** (3 new): \`useSteamExtras\` mount, error, invalidate.
- **\`dashboard-header.test.tsx\`** (updated): Extras nav link expected.

## Coverage
\`91.09\` → **\`91.45 / 83.98 / 83.11 / 92.99\`** (thresholds still met).

## Out of scope — coming in the next PR
- **Achievement sync for extras** (new \`extra_game_achievements\` table, separate from \`user_achievements\`). Same pipeline as library achievements but isolated.
- Rich UI (cover images, per-year grouping, \"played in 2014\" timeline).

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (361 passed)
- [x] \`pnpm test:coverage\`
- [ ] Restart dev server + sync → \`/extras\` shows refunded / family-shared / delisted games with real playtime and (mostly) real names. Library KPIs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)