### PR TITLE
fix(sync): guard against empty GetOwnedGames + self-heal extras

### DIFF
--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -34,9 +34,22 @@ const EXTRAS_ACHIEVEMENTS_CONCURRENCY = 5
  * library stats / KPIs / insights.
  */
 export function persistExtraGames(steamId: string, lastPlayed: LastPlayedGame[]) {
-  if (lastPlayed.length === 0) return
-
   const db = getSqliteDatabase()
+
+  // Self-healing: drop any extras row whose appid is currently owned (in
+  // user_games with owned=1). Protects against the case where a previous
+  // sync wrongly added library games to extras because GetOwnedGames
+  // returned empty — a subsequent successful sync puts them back in
+  // user_games, and this cleanup removes the stale extras rows.
+  db.prepare(
+    `
+    DELETE FROM extra_games
+    WHERE steam_id = ?
+      AND appid IN (SELECT appid FROM user_games WHERE steam_id = ? AND owned = 1)
+  `,
+  ).run(steamId, steamId)
+
+  if (lastPlayed.length === 0) return
 
   // Build the skip set: owned library entries + pinned appids. Both sources
   // already live in user_games (pinned games get upserted there during

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -5,6 +5,7 @@ import { ensureGameImages } from "@/lib/server/steam-images"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { ensurePinnedGamesSynced } from "@/lib/server/pinned-games"
 import { getExtraAppIds, persistExtraGames, syncExtraAchievements } from "@/lib/server/extra-games"
+import { logger } from "@/lib/server/logger"
 import {
   nowIso,
   nullIfUndefined,
@@ -268,6 +269,22 @@ export async function ensureOwnedGamesSynced(steamId: string, options?: { forceR
   }
 
   const games = await getOwnedGames(steamId)
+
+  // Guard against transient Steam API failures: if GetOwnedGames returned
+  // empty but we already had a populated library last time, it's almost
+  // certainly a blip (rate limit, 5xx, network flap) and NOT the user
+  // refunding every game in their catalog. persistOwnedGames' markMissing
+  // sweep would otherwise flip every owned row to owned=0, which later
+  // dumps them all into extras. Preserve the existing state and bail.
+  if (games.length === 0 && existingGames.length > 0) {
+    logger.warn(
+      { steamId, existingCount: existingGames.length },
+      "GetOwnedGames returned empty but user already had a populated library — preserving existing rows",
+    )
+    await ensureGameImages(existingGames.map((game) => game.appid))
+    return existingGames
+  }
+
   persistOwnedGames(steamId, games)
   // Resolve pinned (delisted) games after the main upsert so persistOwnedGames'
   // markMissingAsUnowned sweep can't flip them back to owned=0.

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -120,6 +120,30 @@ describe("persistExtraGames", () => {
     persistExtraGames(STEAM_ID, [{ appid: 274920, playtime_forever: 569 }])
     expect(getExtraGamesForUser(STEAM_ID)).toEqual([])
   })
+
+  it("self-heals by deleting extras whose appid is now back in the owned library", async () => {
+    // Regression for the post-#131 incident: a transient GetOwnedGames
+    // failure wiped user_games.owned and persistExtraGames dumped the
+    // whole library into extras. On the next successful sync, Portal 2
+    // (etc.) is back in user_games, so the stale extras row must go.
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+       VALUES (?, 620, 600, ?, ?, ?)`,
+    ).run(STEAM_ID, now, now, now)
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (620, 'Portal 2', ?, ?)`).run(now, now)
+    db.prepare(
+      `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+       VALUES (?, 620, 600, 1, ?, ?)`,
+    ).run(STEAM_ID, now, now)
+
+    const { persistExtraGames, getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    // The cleanup runs even when lastPlayed is empty — otherwise a user
+    // who'd been wiped couldn't self-heal without new data coming in.
+    persistExtraGames(STEAM_ID, [])
+    expect(getExtraGamesForUser(STEAM_ID)).toEqual([])
+  })
 })
 
 describe("getExtraGamesForUser", () => {

--- a/test/steam-games-sync.test.ts
+++ b/test/steam-games-sync.test.ts
@@ -114,6 +114,43 @@ describe("ensureOwnedGamesSynced", () => {
     expect(games).toHaveLength(1)
   })
 
+  it("preserves the existing library when GetOwnedGames returns empty (transient failure guard)", async () => {
+    // Regression: a transient Steam API failure made getOwnedGames return []
+    // and persistOwnedGames' markMissingAsUnowned flipped the whole library
+    // to owned=0, which then fed the entire library into extras. Guard:
+    // if the fetch comes back empty but we already had a populated library,
+    // treat it as a blip and bail without touching user_games.
+    mockSteamApi([]) // Steam returns nothing
+    const db = await seedBase()
+    const oldIso = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    db.prepare(
+      `INSERT INTO steam_profile (steam_id, last_owned_games_sync_at, created_at, updated_at)
+                VALUES (?, ?, ?, ?)`,
+    ).run(STEAM_ID, oldIso, oldIso, oldIso)
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (620, 'Portal 2', ?, ?)`).run(
+      oldIso,
+      oldIso,
+    )
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (440, 'TF2', ?, ?)`).run(oldIso, oldIso)
+    db.prepare(
+      `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+                VALUES (?, 620, 100, 1, ?, ?)`,
+    ).run(STEAM_ID, oldIso, oldIso)
+    db.prepare(
+      `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+                VALUES (?, 440, 500, 1, ?, ?)`,
+    ).run(STEAM_ID, oldIso, oldIso)
+
+    const { ensureOwnedGamesSynced } = await import("@/lib/server/steam-games-sync")
+    const games = await ensureOwnedGamesSynced(STEAM_ID)
+    expect(games).toHaveLength(2)
+
+    const owned = db
+      .prepare("SELECT appid FROM user_games WHERE steam_id = ? AND owned = 1 ORDER BY appid")
+      .all(STEAM_ID) as Array<{ appid: number }>
+    expect(owned.map((r) => r.appid)).toEqual([440, 620])
+  })
+
   it("marks games no longer owned as owned=0 on refresh", async () => {
     mockSteamApi([{ appid: 620, name: "Portal 2" }]) // 440 missing from the new fetch
     const db = await seedBase()


### PR DESCRIPTION
## Summary
Two linked safety nets against a failure mode found in production after merging #131.

## The incident
A transient \`GetOwnedGames\` failure (rate limit, 5xx, network flap) made the wrapper fall through to its \`catch → return []\` branch. Then:

1. \`persistOwnedGames\` ran \`markMissingAsUnowned\` on the empty list → **every** \`user_games\` row flipped to \`owned=0\`
2. \`ensurePinnedGamesSynced\` put the 6 pinned apps back to \`owned=1\`
3. \`persistExtraGames\` saw only 6 owned → dumped the whole library into \`extra_games\`

End state on the affected account: **6 games in the library (just pinned), 1161 in extras**. The user's stats and filters collapsed accordingly.

## Fix 1 — \`ensureOwnedGamesSynced\` guard
If \`getOwnedGames\` comes back empty **and** there are existing games in the library, treat it as a transient blip and bail without touching \`user_games\`. Preserve the existing rows, log a warning, keep \`ensureGameImages\` running across the known set, return. The legitimate "new account with zero games" case is still handled because \`existingGames.length\` is 0 on first sync.

## Fix 2 — \`persistExtraGames\` self-heal
Every run now starts with:
\`\`\`sql
DELETE FROM extra_games
WHERE steam_id = ?
  AND appid IN (SELECT appid FROM user_games WHERE steam_id = ? AND owned = 1)
\`\`\`
This is the **automatic recovery path** for accounts already affected: the next successful sync restores the library through \`persistOwnedGames\`, then \`persistExtraGames\` prunes the stale extras in the same pass. The cleanup runs even when \`lastPlayed\` is empty so a recovery isn't blocked waiting for new data.

## Tests (+2)
- **\`steam-games-sync.test.ts\`**: empty \`GetOwnedGames\` preserves existing library, does NOT flip \`owned\` flags, returns the existing list.
- **\`extra-games.test.ts\`**: stale extras row for an owned appid is deleted on the next \`persistExtraGames\` call, even with an empty \`lastPlayed\` payload.

## Recovery for anyone already affected
1. Pull this branch
2. Restart dev server
3. Click **Sync** in the header once

The first good sync after the fix restores every \`user_games\` row and prunes the stale extras in the same pass. No manual DB surgery needed.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (373 passed)
- [ ] Pull on the affected account, sync once, confirm library count is back and extras drops to its real size

🤖 Generated with [Claude Code](https://claude.com/claude-code)