### PR TITLE
fix(extras): store-API fallback for names on apps without achievements

### DIFF
--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -24,6 +24,80 @@ export type ExtraGame = {
 
 const EXTRAS_ACHIEVEMENTS_CONCURRENCY = 5
 
+// Store API: max 200 appids per request, rate-limited ~200 req / 5min per IP.
+// Only fires on extras whose name is still missing after the achievements
+// pass (so typically live games without achievements — dedicated servers,
+// demos, betas retired after launch, etc). Batches of 200 → ≤3 calls even
+// on a 500-extras account.
+const STORE_BATCH_SIZE = 200
+
+type StoreAppDetails = {
+  success?: boolean
+  data?: {
+    name?: string
+    type?: string
+  }
+}
+
+/**
+ * Fallback name hydrator: for any extras row whose `games.name` is still
+ * NULL after the achievement sync, try the public
+ * `store.steampowered.com/api/appdetails` endpoint. Covers live apps that
+ * have no Steam achievements (dedicated servers, old demos, …) for which
+ * GetPlayerAchievements can't give us a name.
+ *
+ * Delisted apps usually return `success=false` from this endpoint — those
+ * stay nameless and fall back to `App #{appid}` in the UI, same as before.
+ *
+ * Swallows per-batch errors so a transient store outage never breaks the
+ * parent sync pipeline.
+ */
+export async function hydrateMissingExtraNames(steamId: string) {
+  const db = getSqliteDatabase()
+  const rows = db
+    .prepare(
+      `
+      SELECT e.appid
+      FROM extra_games e
+      LEFT JOIN games g ON g.appid = e.appid
+      WHERE e.steam_id = ? AND (g.name IS NULL OR g.name = '')
+    `,
+    )
+    .all(steamId) as Array<{ appid: number }>
+
+  if (rows.length === 0) return
+
+  const now = nowIso()
+  const upsertGame = db.prepare(`
+    INSERT INTO games (appid, name, created_at, updated_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(appid) DO UPDATE SET
+      name = COALESCE(excluded.name, games.name),
+      updated_at = excluded.updated_at
+  `)
+
+  const appIds = rows.map((r) => r.appid)
+  for (let i = 0; i < appIds.length; i += STORE_BATCH_SIZE) {
+    const batch = appIds.slice(i, i + STORE_BATCH_SIZE)
+    try {
+      const url = new URL("https://store.steampowered.com/api/appdetails")
+      url.searchParams.set("appids", batch.join(","))
+      url.searchParams.set("filters", "basic")
+      const response = await fetch(url.toString(), { cache: "no-store" })
+      if (!response.ok) continue
+
+      const payload = (await response.json()) as Record<string, StoreAppDetails>
+      for (const appid of batch) {
+        const entry = payload[String(appid)]
+        const name = entry?.success && entry.data?.name ? entry.data.name : null
+        if (name) upsertGame.run(appid, name, now, now)
+      }
+    } catch (error) {
+      logger.warn({ err: error, batchSize: batch.length }, "Store appdetails batch failed")
+    }
+  }
+}
+
 /**
  * Upserts every played-game row that is NOT in the user's owned library and
  * NOT a pinned game. These surface refunded, family-shared, delisted and

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -4,7 +4,12 @@ import { getLastPlayedTimes, getOwnedGames, type LastPlayedGame, type SteamGame 
 import { ensureGameImages } from "@/lib/server/steam-images"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { ensurePinnedGamesSynced } from "@/lib/server/pinned-games"
-import { getExtraAppIds, persistExtraGames, syncExtraAchievements } from "@/lib/server/extra-games"
+import {
+  getExtraAppIds,
+  hydrateMissingExtraNames,
+  persistExtraGames,
+  syncExtraAchievements,
+} from "@/lib/server/extra-games"
 import { logger } from "@/lib/server/logger"
 import {
   nowIso,
@@ -301,9 +306,15 @@ export async function ensureOwnedGamesSynced(steamId: string, options?: { forceR
   persistExtraGames(steamId, lastPlayed)
   // Fetch achievements + names for extras so the Extras page has the same
   // level of detail as the Library. GetPlayerAchievements.gameName is the
-  // authoritative name source for delisted apps (the public store API
-  // returns success=false for them).
+  // authoritative name source for apps with achievements (delisted or not).
   await syncExtraAchievements(steamId)
+  // Fallback pass: hydrate names for extras that are still nameless after
+  // the achievement sync — typically live apps without any Steam
+  // achievements (dedicated servers, demos, retired betas) where
+  // GetPlayerAchievements has nothing to return. Uses the public store
+  // appdetails endpoint. Truly delisted no-achievement apps stay nameless
+  // and render as "App #{appid}".
+  await hydrateMissingExtraNames(steamId)
   const finalGames = getStoredOwnedGames(steamId)
   // Image probes: both owned and extras share the `games` cache, so running
   // ensureGameImages across the union fills in headers/portraits for every

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -435,6 +435,108 @@ describe("syncExtraAchievements", () => {
   })
 })
 
+describe("hydrateMissingExtraNames", () => {
+  function mockStore(handler: (appids: string) => Record<string, unknown>) {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      const appids = url.searchParams.get("appids") ?? ""
+      return {
+        ok: true,
+        status: 200,
+        json: async () => handler(appids),
+      } as unknown as Response
+    }) as unknown as typeof fetch
+  }
+
+  async function seedExtraWithoutName(appId: number) {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+       VALUES (?, ?, 100, ?, ?, ?)`,
+    ).run(STEAM_ID, appId, now, now, now)
+    return db
+  }
+
+  const ORIGINAL_FETCH = globalThis.fetch
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH
+  })
+
+  it("is a no-op when every extras row already has a name cached", async () => {
+    const db = await seedExtraWithoutName(111)
+    const now = new Date().toISOString()
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (111, 'Already Cached', ?, ?)`).run(
+      now,
+      now,
+    )
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("upserts names fetched from the store API for nameless extras", async () => {
+    const db = await seedExtraWithoutName(111)
+    mockStore((appids) => {
+      const out: Record<string, unknown> = {}
+      for (const id of appids.split(",")) {
+        out[id] = { success: true, data: { name: `Game ${id}`, type: "game" } }
+      }
+      return out
+    })
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=111").get() as { name: string }
+    expect(row.name).toBe("Game 111")
+  })
+
+  it("leaves the row nameless when the store API says success=false (delisted)", async () => {
+    const db = await seedExtraWithoutName(274920)
+    mockStore((appids) => {
+      const out: Record<string, unknown> = {}
+      for (const id of appids.split(",")) out[id] = { success: false }
+      return out
+    })
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=274920").get() as { name: string | null } | undefined
+    // Either no row at all, or row with null name — either way it's nameless
+    expect(row?.name ?? null).toBeNull()
+  })
+
+  it("swallows store API failures without throwing", async () => {
+    await seedExtraWithoutName(111)
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })) as unknown as typeof fetch
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await expect(hydrateMissingExtraNames(STEAM_ID)).resolves.toBeUndefined()
+  })
+
+  it("swallows store API rejected promises without throwing", async () => {
+    await seedExtraWithoutName(111)
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network")
+    }) as unknown as typeof fetch
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await expect(hydrateMissingExtraNames(STEAM_ID)).resolves.toBeUndefined()
+  })
+
+  it("is a no-op when the user has no extras at all", async () => {
+    await seedProfile()
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
 describe("getExtraAppIds", () => {
   it("returns an empty array for a user with no extras", async () => {
     await seedProfile()


### PR DESCRIPTION
## Summary
Follow-up to #131 / #132. Extras rows were only getting a name when \`GetPlayerAchievements\` returned a successful response, so any extras game without Steam achievements (dedicated servers, demos, retired betas, stats-only betas) stayed nameless forever. On the affected account this was **~290 of ~625 extras**.

## Root cause
\`syncExtraAchievements\` only calls \`persistExtraAchievements\` with a real \`gameName\` when \`getPlayerAchievements\` returned a successful payload. For the \"no stats\" branch we pass \`""\` as the name and the upsert guard skips it. So games without achievements never got a name from anywhere.

## Fix
New \`hydrateMissingExtraNames(steamId)\` function, called from \`ensureOwnedGamesSynced\` right after \`syncExtraAchievements\`. It queries extras rows whose \`games.name\` is still \`NULL\` after the achievements pass and batches them into the public \`store.steampowered.com/api/appdetails\` endpoint (200 per request).

Delisted apps still return \`success=false\` from that endpoint — those stay nameless and fall back to \`App #{appid}\` in the UI — but **live no-achievement apps now get their real name**, which covers the vast majority of the gap.

## Full name-resolution pipeline for extras
1. \`GetPlayerAchievements.gameName\` during \`syncExtraAchievements\` → covers delisted WITH achievements (FaceRig class) + every live app with achievements
2. Store appdetails via \`hydrateMissingExtraNames\` → covers live apps without achievements
3. \`App #{appid}\` placeholder → delisted without achievements (rare)

## Tests (+6)
- No-op when every extras row already has a cached name
- Upserts names from the store API response
- Leaves the row nameless when store returns \`success=false\` (delisted case still handled gracefully)
- Swallows store HTTP failures
- Swallows store network errors
- No-op when the user has no extras

## Coverage
\`91.46\` → **\`91.63 / 84.09 / 83.49 / 93.14\`**.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (379 passed)
- [x] \`pnpm test:coverage\`
- [ ] On the real account: restart dev server, sync, confirm /extras shows real names for most entries. Only genuinely obscure delisted no-achievement apps should still show as \`App #{appid}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)