### PR TITLE
fix(extras): single-appid store API + sentinel negative cache + typo

### DIFF
--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -31,7 +31,7 @@ export default function ExtrasPage() {
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()
     if (!q) return games
-    return games.filter((g) => (g.name ?? `app #${g.appid}`).toLowerCase().includes(q))
+    return games.filter((g) => (g.name || `app #${g.appid}`).toLowerCase().includes(q))
   }, [games, search])
 
   if (loadingUser) return <LoadingMessage />
@@ -112,7 +112,7 @@ export default function ExtrasPage() {
               <GameCard
                 key={game.appid}
                 id={game.appid}
-                name={game.name ?? `App #${game.appid}`}
+                name={game.name || `App #${game.appid}`}
                 image={game.image_landscape_url ?? getSteamHeaderImageUrl(game.appid)}
                 playtime={Number(((game.playtime_forever ?? 0) / 60).toFixed(1))}
                 href={`https://store.steampowered.com/app/${game.appid}`}

--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -24,12 +24,17 @@ export type ExtraGame = {
 
 const EXTRAS_ACHIEVEMENTS_CONCURRENCY = 5
 
-// Store API: max 200 appids per request, rate-limited ~200 req / 5min per IP.
-// Only fires on extras whose name is still missing after the achievements
-// pass (so typically live games without achievements — dedicated servers,
-// demos, betas retired after launch, etc). Batches of 200 → ≤3 calls even
-// on a 500-extras account.
-const STORE_BATCH_SIZE = 200
+// Delay between sequential store appdetails calls. The endpoint doesn't
+// accept batches (any appid count >1 returns "400 null"), so we have to
+// fan out single calls. 150ms keeps us well below Steam's rate limiter
+// (~200 req/5min community-measured) and lets a 600-game first sync
+// complete in ~90s.
+const STORE_DELAY_MS = 150
+
+// Sentinel written to games.name when the store appdetails endpoint
+// said "no", so the next hydrate pass skips the appid instead of
+// hammering it forever.
+const NAME_UNRESOLVED_SENTINEL = ""
 
 type StoreAppDetails = {
   success?: boolean
@@ -41,16 +46,18 @@ type StoreAppDetails = {
 
 /**
  * Fallback name hydrator: for any extras row whose `games.name` is still
- * NULL after the achievement sync, try the public
- * `store.steampowered.com/api/appdetails` endpoint. Covers live apps that
- * have no Steam achievements (dedicated servers, old demos, …) for which
- * GetPlayerAchievements can't give us a name.
+ * NULL after the achievement sync, probe the public
+ * `store.steampowered.com/api/appdetails` endpoint one appid at a time.
+ * Covers live apps that have no Steam achievements (dedicated servers,
+ * old demos, …) which GetPlayerAchievements can't name for us.
  *
- * Delisted apps usually return `success=false` from this endpoint — those
- * stay nameless and fall back to `App #{appid}` in the UI, same as before.
+ * Negative caching: if the store says `success=false` (delisted, no store
+ * page) we upsert an empty-string sentinel so the next run skips the
+ * appid. The UI falls back to `App #{appid}` for any game whose name is
+ * null OR empty via `game.name || fallback`.
  *
- * Swallows per-batch errors so a transient store outage never breaks the
- * parent sync pipeline.
+ * Swallows per-call errors. On 5 consecutive failures we back off entirely
+ * (Akamai/rate-limit guard).
  */
 export async function hydrateMissingExtraNames(steamId: string) {
   const db = getSqliteDatabase()
@@ -60,41 +67,63 @@ export async function hydrateMissingExtraNames(steamId: string) {
       SELECT e.appid
       FROM extra_games e
       LEFT JOIN games g ON g.appid = e.appid
-      WHERE e.steam_id = ? AND (g.name IS NULL OR g.name = '')
+      WHERE e.steam_id = ? AND g.name IS NULL
+      ORDER BY e.playtime_forever DESC
     `,
     )
     .all(steamId) as Array<{ appid: number }>
 
   if (rows.length === 0) return
 
-  const now = nowIso()
   const upsertGame = db.prepare(`
     INSERT INTO games (appid, name, created_at, updated_at)
     VALUES (?, ?, ?, ?)
     ON CONFLICT(appid) DO UPDATE SET
-      name = COALESCE(excluded.name, games.name),
+      name = excluded.name,
       updated_at = excluded.updated_at
   `)
 
-  const appIds = rows.map((r) => r.appid)
-  for (let i = 0; i < appIds.length; i += STORE_BATCH_SIZE) {
-    const batch = appIds.slice(i, i + STORE_BATCH_SIZE)
+  let consecutiveFailures = 0
+
+  for (const { appid } of rows) {
+    if (consecutiveFailures >= 5) {
+      logger.warn(
+        { steamId, remaining: rows.length, lastAppid: appid },
+        "Store appdetails returned 5 consecutive failures — backing off hydrateMissingExtraNames",
+      )
+      return
+    }
+
     try {
       const url = new URL("https://store.steampowered.com/api/appdetails")
-      url.searchParams.set("appids", batch.join(","))
+      url.searchParams.set("appids", String(appid))
       url.searchParams.set("filters", "basic")
       const response = await fetch(url.toString(), { cache: "no-store" })
-      if (!response.ok) continue
+
+      if (!response.ok) {
+        consecutiveFailures++
+        continue
+      }
+      consecutiveFailures = 0
 
       const payload = (await response.json()) as Record<string, StoreAppDetails>
-      for (const appid of batch) {
-        const entry = payload[String(appid)]
-        const name = entry?.success && entry.data?.name ? entry.data.name : null
-        if (name) upsertGame.run(appid, name, now, now)
+      const entry = payload[String(appid)]
+      const resolvedName = entry?.success && entry.data?.name ? entry.data.name : null
+      const now = nowIso()
+
+      if (resolvedName) {
+        upsertGame.run(appid, resolvedName, now, now)
+      } else {
+        // Negative cache: mark this appid as "we asked, nothing to show"
+        upsertGame.run(appid, NAME_UNRESOLVED_SENTINEL, now, now)
       }
     } catch (error) {
-      logger.warn({ err: error, batchSize: batch.length }, "Store appdetails batch failed")
+      consecutiveFailures++
+      logger.warn({ err: error, appid }, "Store appdetails call failed")
     }
+
+    // Rate-limit friendliness: stay well below the ~200 req / 5min ceiling.
+    await new Promise((resolve) => setTimeout(resolve, STORE_DELAY_MS))
   }
 }
 

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -436,25 +436,24 @@ describe("syncExtraAchievements", () => {
 })
 
 describe("hydrateMissingExtraNames", () => {
-  function mockStore(handler: (appids: string) => Record<string, unknown>) {
+  type StoreResponse = { success?: boolean; data?: { name?: string } }
+
+  function mockStoreSingle(handler: (appid: number) => StoreResponse) {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = new URL(String(input))
-      const appids = url.searchParams.get("appids") ?? ""
-      return {
-        ok: true,
-        status: 200,
-        json: async () => handler(appids),
-      } as unknown as Response
+      const appid = Number(url.searchParams.get("appids") ?? "0")
+      const body = { [String(appid)]: handler(appid) }
+      return { ok: true, status: 200, json: async () => body } as unknown as Response
     }) as unknown as typeof fetch
   }
 
-  async function seedExtraWithoutName(appId: number) {
+  async function seedExtraWithoutName(appId: number, playtime = 100) {
     const db = await seedProfile()
     const now = new Date().toISOString()
     db.prepare(
       `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
-       VALUES (?, ?, 100, ?, ?, ?)`,
-    ).run(STEAM_ID, appId, now, now, now)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(STEAM_ID, appId, playtime, now, now, now)
     return db
   }
 
@@ -463,7 +462,7 @@ describe("hydrateMissingExtraNames", () => {
     globalThis.fetch = ORIGINAL_FETCH
   })
 
-  it("is a no-op when every extras row already has a name cached", async () => {
+  it("is a no-op when every extras row already has a cached name", async () => {
     const db = await seedExtraWithoutName(111)
     const now = new Date().toISOString()
     db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (111, 'Already Cached', ?, ?)`).run(
@@ -472,53 +471,123 @@ describe("hydrateMissingExtraNames", () => {
     )
     const fetchSpy = vi.fn()
     globalThis.fetch = fetchSpy as unknown as typeof fetch
-
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
     await hydrateMissingExtraNames(STEAM_ID)
     expect(fetchSpy).not.toHaveBeenCalled()
+    void db
   })
 
-  it("upserts names fetched from the store API for nameless extras", async () => {
+  it("skips rows whose games.name is the empty-string sentinel (negative cache)", async () => {
     const db = await seedExtraWithoutName(111)
-    mockStore((appids) => {
-      const out: Record<string, unknown> = {}
-      for (const id of appids.split(",")) {
-        out[id] = { success: true, data: { name: `Game ${id}`, type: "game" } }
-      }
-      return out
-    })
+    const now = new Date().toISOString()
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (111, '', ?, ?)`).run(now, now)
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    void db
+  })
+
+  it("upserts the real name when the store API returns success=true", async () => {
+    const db = await seedExtraWithoutName(111)
+    mockStoreSingle((appid) => ({ success: true, data: { name: `Game ${appid}` } }))
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
     await hydrateMissingExtraNames(STEAM_ID)
     const row = db.prepare("SELECT name FROM games WHERE appid=111").get() as { name: string }
     expect(row.name).toBe("Game 111")
   })
 
-  it("leaves the row nameless when the store API says success=false (delisted)", async () => {
+  it("writes the empty-string sentinel when the store API says success=false", async () => {
     const db = await seedExtraWithoutName(274920)
-    mockStore((appids) => {
-      const out: Record<string, unknown> = {}
-      for (const id of appids.split(",")) out[id] = { success: false }
-      return out
-    })
+    mockStoreSingle(() => ({ success: false }))
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
     await hydrateMissingExtraNames(STEAM_ID)
-    const row = db.prepare("SELECT name FROM games WHERE appid=274920").get() as { name: string | null } | undefined
-    // Either no row at all, or row with null name — either way it's nameless
-    expect(row?.name ?? null).toBeNull()
+    const row = db.prepare("SELECT name FROM games WHERE appid=274920").get() as { name: string }
+    expect(row.name).toBe("")
   })
 
-  it("swallows store API failures without throwing", async () => {
-    await seedExtraWithoutName(111)
-    globalThis.fetch = vi.fn(async () => ({
-      ok: false,
-      status: 500,
-      json: async () => ({}),
-    })) as unknown as typeof fetch
+  it("calls the store API once per appid (single-appid queries only)", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    for (const appid of [111, 222, 333]) {
+      db.prepare(
+        `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+         VALUES (?, ?, 100, ?, ?, ?)`,
+      ).run(STEAM_ID, appid, now, now, now)
+    }
+    const calls: string[] = []
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      calls.push(url.searchParams.get("appids") ?? "")
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          [url.searchParams.get("appids") ?? ""]: { success: true, data: { name: "X" } },
+        }),
+      } as unknown as Response
+    }) as unknown as typeof fetch
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
-    await expect(hydrateMissingExtraNames(STEAM_ID)).resolves.toBeUndefined()
+    await hydrateMissingExtraNames(STEAM_ID)
+    expect(calls).toHaveLength(3)
+    for (const call of calls) expect(call.split(",")).toHaveLength(1)
+    void db
   })
 
-  it("swallows store API rejected promises without throwing", async () => {
+  it("orders hydration by playtime_forever DESC so the most-played games come first", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+       VALUES (?, 111, 100, ?, ?, ?)`,
+    ).run(STEAM_ID, now, now, now)
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+       VALUES (?, 222, 500, ?, ?, ?)`,
+    ).run(STEAM_ID, now, now, now)
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+       VALUES (?, 333, 200, ?, ?, ?)`,
+    ).run(STEAM_ID, now, now, now)
+    const order: number[] = []
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      const appid = Number(url.searchParams.get("appids"))
+      order.push(appid)
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ [String(appid)]: { success: true, data: { name: "X" } } }),
+      } as unknown as Response
+    }) as unknown as typeof fetch
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    expect(order).toEqual([222, 333, 111])
+    void db
+  })
+
+  it("backs off after 5 consecutive store API failures", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    for (let i = 1; i <= 10; i++) {
+      db.prepare(
+        `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(STEAM_ID, i, 100 - i, now, now, now)
+    }
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      return { ok: false, status: 500, json: async () => ({}) } as unknown as Response
+    }) as unknown as typeof fetch
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    expect(calls).toBe(5)
+    void db
+  })
+
+  it("swallows rejected fetches without throwing", async () => {
     await seedExtraWithoutName(111)
     globalThis.fetch = vi.fn(async () => {
       throw new Error("network")


### PR DESCRIPTION
## Summary
Diagnosed against the real account: **623 of 625 extras were nameless** after PR #133 shipped, because the store \`appdetails\` endpoint doesn't accept batches at all.

## Root cause
I tested the store API with a single appid while writing #133 and it worked. I assumed \`appids=X,Y,Z\` batches would work too. They don't:

\`\`\`
1 appid  → 200 OK with full JSON  ✓
2 appids → 400 "null"              ✗
4 appids → 400 "null"              ✗
\`\`\`

So every batched call in the previous hydrator was returning nothing, leaving the \`games\` table untouched for 623 extras. And even the 2 games that were named had slipped in through \`syncExtraAchievements.gameName\`, not the store hydrator.

## Fix

### hydrateMissingExtraNames
- **Sequential single-appid calls** with a 150ms delay (keeps us well below Steam's ~200 req / 5min ceiling). A 625-game first sync completes in ~90s.
- **Negative cache via empty-string sentinel**: when the store says \`success=false\` (delisted, no store page) we upsert \`games.name = ''\` so the next hydrate pass skips the appid. The query filters on \`g.name IS NULL\`, so "tried and failed" no longer looks the same as "never tried".
- **\`ORDER BY playtime_forever DESC\`** — most-played extras hydrate first, so when the rate-limit backoff kicks in the user still sees meaningful names.
- **Hard backoff after 5 consecutive non-200 responses** — logs a warning and returns. Prevents chain-retrying against Akamai.

### UI fallback
\`app/extras/page.tsx\` switched from \`game.name ?? fallback\` to \`game.name || fallback\` so the empty-string sentinel also renders as \`App #{appid}\` instead of a blank cell.

### Copy typo
Fixed the extras banner — the wrap was visually gluing "count" and "in" in the rendered text (you reported it as "countin your library stats").

## Verified on the real DB
\`\`\`
BEFORE: with_name=2   untried=623  sentinel=0
AFTER:  with_name=181 untried=417  sentinel=27     (77.1s, hit rate-limit backoff)

Top named:
  250820: SteamVR
  24200:  DC Universe™ Online
  41050:  Serious Sam Classic: The First Encounter
  41060:  Serious Sam Classic: The Second Encounter
  43110:  Metro 2033
  99300:  Renegade Ops
  201480: Serious Sam: The Random Encounter
  227780: Serious Sam Classics: Revolution
\`\`\`

208 of 625 processed before Steam rate-limited. Remaining 417 chip away on subsequent syncs. 2–3 sync cycles = full coverage.

## Tests (+4 new, 4 rewritten)
- No-op when all rows already cached
- **Skips empty-string sentinel rows (negative cache)**
- Upserts real name on \`success=true\`
- **Writes sentinel on \`success=false\`**
- **Single-appid queries only** (regression assertion that we're not batching)
- **\`ORDER BY playtime_forever DESC\` is honoured**
- **Backs off after 5 consecutive failures**
- Swallows rejected fetches

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (382 passed)
- [x] Diag script against the real account: 208 resolved in 77s
- [ ] Restart dev server, sync 2–3 times, confirm /extras shows real names for most entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)