### PR TITLE
fix(auth): handle non-JSON responses from GetPlayerSummaries

### DIFF
--- a/app/api/auth/steam/callback/route.ts
+++ b/app/api/auth/steam/callback/route.ts
@@ -120,8 +120,29 @@ export async function GET(request: NextRequest) {
       fetch(levelUrl),
       fetch(badgesUrl),
     ])
-    const userInfo = await userInfoResponse.json()
-    const player = userInfo.response.players[0]
+
+    const userInfoText = await userInfoResponse.text()
+    let userInfo: { response?: { players?: Array<Record<string, unknown>> } }
+    try {
+      userInfo = JSON.parse(userInfoText)
+    } catch {
+      logger.error(
+        { status: userInfoResponse.status, bodySnippet: userInfoText.slice(0, 200) },
+        "GetPlayerSummaries returned non-JSON response",
+      )
+      return NextResponse.redirect(getAppUrl("/?error=auth_error", request))
+    }
+    const player = userInfo.response?.players?.[0] as
+      | {
+          steamid: string
+          personaname: string
+          avatarfull: string
+          profileurl: string
+          timecreated?: number
+          personastate?: number
+          communityvisibilitystate?: number
+        }
+      | undefined
 
     if (!player) {
       return NextResponse.redirect(getAppUrl("/?error=auth_failed", request))

--- a/test/auth-callback-route.test.ts
+++ b/test/auth-callback-route.test.ts
@@ -191,20 +191,22 @@ describe("GET /api/auth/steam/callback", () => {
         const urlStr = url instanceof URL ? url.toString() : url
         if (urlStr.includes("GetPlayerSummaries")) {
           return Promise.resolve({
-            json: async () => ({
-              response: {
-                players: [
-                  {
-                    steamid: steamId,
-                    personaname: "TestPlayer",
-                    avatarfull: "https://avatar.url/full.jpg",
-                    profileurl: "https://steamcommunity.com/id/testplayer/",
-                    timecreated: 1234567890,
-                    personastate: 1,
-                  },
-                ],
-              },
-            }),
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                response: {
+                  players: [
+                    {
+                      steamid: steamId,
+                      personaname: "TestPlayer",
+                      avatarfull: "https://avatar.url/full.jpg",
+                      profileurl: "https://steamcommunity.com/id/testplayer/",
+                      timecreated: 1234567890,
+                      personastate: 1,
+                    },
+                  ],
+                },
+              }),
           })
         }
         // OpenID verification
@@ -243,20 +245,22 @@ describe("GET /api/auth/steam/callback", () => {
         const urlStr = url instanceof URL ? url.toString() : url
         if (urlStr.includes("GetPlayerSummaries")) {
           return Promise.resolve({
-            json: async () => ({
-              response: {
-                players: [
-                  {
-                    steamid: steamId,
-                    personaname: "TestPlayer",
-                    avatarfull: "https://avatar.url/full.jpg",
-                    profileurl: "https://steamcommunity.com/id/testplayer/",
-                    timecreated: 1234567890,
-                    personastate: 1,
-                  },
-                ],
-              },
-            }),
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                response: {
+                  players: [
+                    {
+                      steamid: steamId,
+                      personaname: "TestPlayer",
+                      avatarfull: "https://avatar.url/full.jpg",
+                      profileurl: "https://steamcommunity.com/id/testplayer/",
+                      timecreated: 1234567890,
+                      personastate: 1,
+                    },
+                  ],
+                },
+              }),
           })
         }
         if (urlStr.includes("GetSteamLevel")) {


### PR DESCRIPTION
## Summary
- `app/api/auth/steam/callback/route.ts` now reads `GetPlayerSummaries` as text and parses defensively, logging status + body snippet on failure instead of throwing an opaque `SyntaxError`.
- Unblocks diagnosing transient Steam API HTML error pages without leaking user data (snippet comes from `steamcommunity.com`).

Closes #135

## Test plan
- [x] `pnpm lint` (eslint + typecheck) passes
- [ ] Manual: trigger a Steam login in production and confirm normal flow still works
- [ ] Manual: on next transient Steam outage, confirm logs include status + body snippet and user is redirected to `/?error=auth_error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)