### PR TITLE
fix(sync): dedupe concurrent heavy owned-games syncs per user

### DIFF
--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -260,19 +260,14 @@ export function persistLastPlayedTimes(steamId: string, games: LastPlayedGame[])
   }
 }
 
-export async function ensureOwnedGamesSynced(steamId: string, options?: { forceRefresh?: boolean }) {
-  const forceRefresh = options?.forceRefresh ?? false
-  upsertProfile(steamId)
+// Per-user in-flight promise for the heavy owned-games pipeline. Any
+// concurrent caller (POST /api/steam/sync + a GET /api/steam/games fired
+// by the UI on the same click) joins the same Promise instead of kicking
+// off a second extras/hydrate/images pass. Cleared in a finally so a
+// failed sync doesn't poison subsequent attempts.
+const heavyOwnedGamesSyncInflight = new Map<string, Promise<SteamGame[]>>()
 
-  const syncInfo = getProfileSync(steamId)
-  const shouldRefresh = forceRefresh || isStale(syncInfo?.last_owned_games_sync_at, OWNED_GAMES_STALE_MS)
-  const existingGames = getStoredOwnedGames(steamId)
-
-  if (!shouldRefresh && existingGames.length > 0) {
-    await ensureGameImages(existingGames.map((game) => game.appid))
-    return existingGames
-  }
-
+async function runHeavyOwnedGamesSync(steamId: string, existingGames: SteamGame[]): Promise<SteamGame[]> {
   const games = await getOwnedGames(steamId)
 
   // Guard against transient Steam API failures: if GetOwnedGames returned
@@ -323,6 +318,34 @@ export async function ensureOwnedGamesSynced(steamId: string, options?: { forceR
   const imageAppIds = Array.from(new Set([...finalGames.map((g) => g.appid), ...extraAppIds]))
   await ensureGameImages(imageAppIds)
   return finalGames
+}
+
+export async function ensureOwnedGamesSynced(steamId: string, options?: { forceRefresh?: boolean }) {
+  const forceRefresh = options?.forceRefresh ?? false
+  upsertProfile(steamId)
+
+  const syncInfo = getProfileSync(steamId)
+  const shouldRefresh = forceRefresh || isStale(syncInfo?.last_owned_games_sync_at, OWNED_GAMES_STALE_MS)
+  const existingGames = getStoredOwnedGames(steamId)
+
+  if (!shouldRefresh && existingGames.length > 0) {
+    await ensureGameImages(existingGames.map((game) => game.appid))
+    return existingGames
+  }
+
+  // Dedupe concurrent heavy syncs for the same user. Without this, a POST
+  // /api/steam/sync and a GET /api/steam/games fired from the same UI click
+  // both see the DB as unsynced and each runs the full pipeline in parallel.
+  const existing = heavyOwnedGamesSyncInflight.get(steamId)
+  if (existing) return existing
+
+  const promise = runHeavyOwnedGamesSync(steamId, existingGames)
+  heavyOwnedGamesSyncInflight.set(steamId, promise)
+  try {
+    return await promise
+  } finally {
+    heavyOwnedGamesSyncInflight.delete(steamId)
+  }
 }
 
 /** Returns all owned games for a user, syncing from Steam if needed. */


### PR DESCRIPTION
## Summary
- Keeps a per-\`steamId\` in-flight Promise for the heavy owned-games pipeline inside \`ensureOwnedGamesSynced\`. A single \"Sync\" click in the UI fires both \`POST /api/steam/sync\` and a \`GET /api/steam/games\` revalidation; on a fresh database both saw \`last_owned_games_sync_at\` as unset and ran the full pipeline in parallel, competing for the store API rate limit.
- Production logs confirmed two concurrent passes (\`hydrateMissingExtraNames\` backoffs with \`remaining: 621\` vs \`622\`, ~600ms apart) even after the #139 intra-sync dedupe.
- Concurrent callers now join the same Promise. Cleared in a \`finally\` so a failed sync doesn't poison subsequent attempts.

Closes #141

## Test plan
- [x] \`pnpm lint\` passes
- [x] \`pnpm exec vitest run test/stats-compute-gaps.test.ts test/api-sync-route.test.ts test/extra-games.test.ts\` — 42 tests pass
- [ ] Manual: delete the production SQLite file, restart, log in, press Sync. Confirm only one \`hydrateMissingExtraNames\` backoff (if any) and the three \`Sync:\` milestones all appear in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)