### PR TITLE
fix(steam-api): silence 500s from GetPlayerAchievements

### DIFF
--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -146,10 +146,13 @@ export async function getPlayerAchievements(steamId: string, appId: number): Pro
     // common for older titles, DLC-only entries, stats-only games, etc).
     // That's the signal the caller expects — a null return value — so don't
     // spam the console with "errors" for the normal case.
-    if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
+    if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403 || error.status === 500)) {
       return null
     }
-    console.error("Error fetching achievements for app:", appId, error)
+    console.warn(
+      `[steam-api] Unexpected error fetching achievements for app ${appId}:`,
+      error instanceof Error ? error.message : error,
+    )
     return null
   }
 }

--- a/test/steam-api.test.ts
+++ b/test/steam-api.test.ts
@@ -8,10 +8,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const ORIGINAL_FETCH = globalThis.fetch
 const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 
 beforeEach(() => {
   process.env.STEAM_API_KEY = "fake-key"
   consoleErrorSpy.mockClear()
+  consoleWarnSpy.mockClear()
 })
 
 afterEach(() => {
@@ -201,18 +203,19 @@ describe("getPlayerAchievements", () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  it("logs an error and returns null on 500", async () => {
+  it("returns null *silently* on 500 (broken stats) — no console noise", async () => {
     mockFetchSequence([{ ok: false, status: 500, body: {} }])
     const { getPlayerAchievements } = await import("@/lib/steam-api")
     expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
-  it("returns null on network error", async () => {
+  it("returns null on network error and warns (not errors)", async () => {
     mockFetchRejecting(new Error("socket hangup"))
     const { getPlayerAchievements } = await import("@/lib/steam-api")
     expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalled()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
   it("defaults achievements to [] when the response omits the array", async () => {


### PR DESCRIPTION
## Summary

- Add HTTP 500 to the silent-return-null list in `getPlayerAchievements` alongside 400/403, since Steam returns 500 consistently for certain games (Contractors, Don't Starve, Pavlov) with the same "no achievements" semantics
- Downgrade the fallback `console.error` (full stack trace) to a single-line `console.warn` with formatted app ID for truly unexpected errors
- Update tests to verify 500 is now silent and the network-error path uses `warn` instead of `error`

Closes #143

## Test plan

- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (382/382 tests)
- [x] Verified test for 500 now asserts `consoleErrorSpy` is NOT called
- [x] Verified test for network error asserts `consoleWarnSpy` IS called and `consoleErrorSpy` is NOT called

🤖 Generated with [Claude Code](https://claude.com/claude-code)