### PR TITLE
fix(sync): dedupe concurrent stats computation

### DIFF
--- a/lib/server/steam-stats-compute.ts
+++ b/lib/server/steam-stats-compute.ts
@@ -148,7 +148,30 @@ export function getStoredStatsSnapshot(steamId: string) {
     .get(steamId) as StatsSnapshotRow | undefined
 }
 
+// Dedupe concurrent achievement syncs for the same user. Without this,
+// POST /api/steam/sync and GET /api/steam/stats fired from the same UI
+// click both enter syncAchievementsForStats in parallel, doubling Steam
+// API calls and error logs.
+const achievementsSyncInflight = new Map<string, Promise<void>>()
+
 async function syncAchievementsForStats(
+  steamId: string,
+  forceRefresh: boolean,
+  options?: { skipOwnedGamesSync?: boolean },
+) {
+  const existing = achievementsSyncInflight.get(steamId)
+  if (existing) return existing
+
+  const promise = doSyncAchievementsForStats(steamId, forceRefresh, options)
+  achievementsSyncInflight.set(steamId, promise)
+  try {
+    return await promise
+  } finally {
+    achievementsSyncInflight.delete(steamId)
+  }
+}
+
+async function doSyncAchievementsForStats(
   steamId: string,
   forceRefresh: boolean,
   options?: { skipOwnedGamesSync?: boolean },


### PR DESCRIPTION
## Summary

- Add an in-flight Promise cache (`achievementsSyncInflight`) to `syncAchievementsForStats` in `lib/server/steam-stats-compute.ts`
- When concurrent calls arrive for the same `steamId`, the second caller joins the existing Promise instead of starting a parallel sync
- Follows the same pattern as `heavyOwnedGamesSyncInflight` in `steam-games-sync.ts`

Closes #145

## Test plan

- [x] `pnpm lint` passes (no new errors)
- [x] `test/stats-compute-gaps.test.ts` — 5 tests pass
- [x] `test/api-sync-route.test.ts` — 7 tests pass
- [ ] Manual: click Sync on dashboard, verify Steam API logs show a single achievement sync pass (not two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)