### PR TITLE
feat(extras): SteamDB/Support links, hide extras, unified Hidden tab

### DIFF
--- a/app/api/steam/extras/route.ts
+++ b/app/api/steam/extras/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse } from "next/server"
+import { type NextRequest, NextResponse } from "next/server"
 import { getCurrentUser } from "@/app/lib/server-auth"
-import { getExtraGamesForUser } from "@/lib/server/extra-games"
+import { getExtraGamesForUser, getHiddenGamesForUser } from "@/lib/server/extra-games"
 import { logger } from "@/lib/server/logger"
 
 /**
@@ -11,18 +11,21 @@ import { logger } from "@/lib/server/logger"
  * Sourced from the dedicated `extra_games` table, never from user_games, so
  * the payload can never contaminate library stats.
  *
- * @returns {{ games: ExtraGame[] }} ordered by playtime_forever DESC
+ * @query hidden - If "1", returns all hidden games (library + extras) instead
+ * @returns {{ games: ExtraGame[] }} or {{ games: HiddenGame[] }} ordered by playtime_forever DESC
  * @throws 401 - Unauthorized
  * @throws 500 - Server error
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const user = await getCurrentUser()
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
-    const games = getExtraGamesForUser(user.steamId)
+    const hidden = request.nextUrl.searchParams.get("hidden") === "1"
+
+    const games = hidden ? getHiddenGamesForUser(user.steamId) : getExtraGamesForUser(user.steamId)
     return NextResponse.json({ games })
   } catch (error) {
     logger.error({ err: error, endpoint: "steam/extras" }, "Steam extras API error")

--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -1,22 +1,55 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
-import { AlertCircle, Search, Sparkles } from "lucide-react"
+import { AlertCircle, Database, EyeOff, LifeBuoy, RotateCcw, Search, Sparkles } from "lucide-react"
 
 import { useCurrentUser } from "@/hooks/use-current-user"
-import { useSteamExtras } from "@/hooks/use-steam-data"
+import { useSteamExtras, useSteamHiddenGames } from "@/hooks/use-steam-data"
 import { PageContainer } from "@/components/ui/page-container"
 import { LoadingMessage } from "@/components/ui/loading-message"
 import { GameCard } from "@/components/ui/game-card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { getSteamHeaderImageUrl } from "@/lib/steam-api"
 
+type Tab = "extras" | "hidden"
+
+function ExtraGameActions({ appid }: { appid: number }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <a
+        href={`https://steamdb.info/app/${appid}/`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors hover:bg-white/5"
+      >
+        <Database className="h-3 w-3" />
+        <span>SteamDB</span>
+      </a>
+      <a
+        href={`https://help.steampowered.com/en/wizard/HelpWithGameIssue/?appid=${appid}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors hover:bg-white/5"
+      >
+        <LifeBuoy className="h-3 w-3" />
+        <span>Support</span>
+      </a>
+    </div>
+  )
+}
+
 export default function ExtrasPage() {
   const { user, loading: loadingUser } = useCurrentUser()
   const router = useRouter()
-  const { games, loading: loadingGames, error } = useSteamExtras()
+  const { games: extras, loading: loadingExtras, error: extrasError, refetch: refetchExtras } = useSteamExtras()
+  const { games: hidden, loading: loadingHidden, error: hiddenError, refetch: refetchHidden } = useSteamHiddenGames()
+  const [tab, setTab] = useState<Tab>("extras")
   const [search, setSearch] = useState("")
+  const [locallyHidden, setLocallyHidden] = useState<Set<number>>(new Set())
+  const [locallyRestored, setLocallyRestored] = useState<Set<number>>(new Set())
 
   useEffect(() => {
     window.scrollTo(0, 0)
@@ -28,11 +61,66 @@ export default function ExtrasPage() {
     }
   }, [loadingUser, router, user])
 
-  const filtered = useMemo(() => {
+  const handleHide = useCallback(async (appId: number) => {
+    try {
+      const res = await fetch("/api/steam/games/hide", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appId }),
+      })
+      if (res.ok) {
+        setLocallyHidden((prev) => new Set([...prev, appId]))
+      }
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const handleRestore = useCallback(async (appId: number) => {
+    try {
+      const res = await fetch("/api/steam/games/hide", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appId }),
+      })
+      if (res.ok) {
+        setLocallyRestored((prev) => new Set([...prev, appId]))
+      }
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  useEffect(() => {
+    if (tab === "hidden" && (locallyHidden.size > 0 || locallyRestored.size > 0)) {
+      void refetchHidden()
+      setLocallyRestored(new Set())
+    }
+    if (tab === "extras" && locallyHidden.size > 0) {
+      void refetchExtras()
+      setLocallyHidden(new Set())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab])
+
+  const filteredExtras = useMemo(() => {
+    const visible = extras.filter((g) => !locallyHidden.has(g.appid))
     const q = search.trim().toLowerCase()
-    if (!q) return games
-    return games.filter((g) => (g.name || `app #${g.appid}`).toLowerCase().includes(q))
-  }, [games, search])
+    if (!q) return visible
+    return visible.filter((g) => (g.name || `app #${g.appid}`).toLowerCase().includes(q))
+  }, [extras, search, locallyHidden])
+
+  const filteredHidden = useMemo(() => {
+    const visible = hidden.filter((g) => !locallyRestored.has(g.appid))
+    const q = search.trim().toLowerCase()
+    if (!q) return visible
+    return visible.filter((g) => (g.name || `app #${g.appid}`).toLowerCase().includes(q))
+  }, [hidden, search, locallyRestored])
+
+  const loading = tab === "extras" ? loadingExtras : loadingHidden
+  const error = tab === "extras" ? extrasError : hiddenError
+  const totalCount = tab === "extras" ? extras.length - locallyHidden.size : hidden.length - locallyRestored.size
+  const filteredCount = tab === "extras" ? filteredExtras.length : filteredHidden.length
 
   if (loadingUser) return <LoadingMessage />
   if (!user) return null
@@ -55,6 +143,30 @@ export default function ExtrasPage() {
           </div>
         </div>
 
+        <div className="border-surface-4 flex gap-1 rounded-lg border p-1">
+          <button
+            type="button"
+            onClick={() => setTab("extras")}
+            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${tab === "extras" ? "bg-surface-3 text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-surface-2"}`}
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            Extras
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("hidden")}
+            className={`flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${tab === "hidden" ? "bg-surface-3 text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-surface-2"}`}
+          >
+            <EyeOff className="h-3.5 w-3.5" />
+            Hidden
+            {hidden.length > 0 && (
+              <span className="bg-surface-4 text-muted-foreground rounded-full px-1.5 py-0.5 text-xs">
+                {hidden.length}
+              </span>
+            )}
+          </button>
+        </div>
+
         <div className="flex items-center justify-between gap-4">
           <div className="border-surface-4 bg-surface-1 focus-within:border-accent flex h-9 min-w-0 flex-1 items-center gap-2 rounded-lg border px-3">
             <Search className="text-muted-foreground h-4 w-4 shrink-0" />
@@ -62,14 +174,14 @@ export default function ExtrasPage() {
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search extras…"
+              placeholder={tab === "extras" ? "Search extras\u2026" : "Search hidden games\u2026"}
               className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
             />
           </div>
           <p className="text-muted-foreground shrink-0 text-sm">
-            {loadingGames
-              ? "Loading…"
-              : `${filtered.length}${filtered.length !== games.length ? ` of ${games.length}` : ""} games`}
+            {loading
+              ? "Loading\u2026"
+              : `${filteredCount}${filteredCount !== totalCount ? ` of ${totalCount}` : ""} games`}
           </p>
         </div>
 
@@ -79,11 +191,13 @@ export default function ExtrasPage() {
           <div className="border-destructive/40 bg-destructive/5 flex items-start gap-3 rounded-lg border px-4 py-3">
             <AlertCircle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
             <div className="text-sm">
-              <p className="text-destructive font-medium">Could not load extras</p>
+              <p className="text-destructive font-medium">
+                Could not load {tab === "extras" ? "extras" : "hidden games"}
+              </p>
               <p className="text-muted-foreground">{error}</p>
             </div>
           </div>
-        ) : loadingGames ? (
+        ) : loading ? (
           <div className="space-y-4">
             {Array.from({ length: 4 }).map((_, i) => (
               <div
@@ -99,28 +213,73 @@ export default function ExtrasPage() {
               </div>
             ))}
           </div>
-        ) : filtered.length === 0 ? (
+        ) : tab === "extras" ? (
+          filteredExtras.length === 0 ? (
+            <div className="border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center">
+              <p className="text-muted-foreground">No extras yet.</p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                After syncing, games Steam remembers you played but no longer own will show up here.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {filteredExtras.map((game) => (
+                <GameCard
+                  key={game.appid}
+                  id={game.appid}
+                  name={game.name || `App #${game.appid}`}
+                  image={game.image_landscape_url ?? getSteamHeaderImageUrl(game.appid)}
+                  playtime={Number(((game.playtime_forever ?? 0) / 60).toFixed(1))}
+                  href={`https://store.steampowered.com/app/${game.appid}`}
+                  achievements={[]}
+                  achievementsLoading={false}
+                  serverTotal={game.total_count ?? 0}
+                  serverUnlocked={game.unlocked_count ?? 0}
+                  serverPerfect={game.perfect_game === 1}
+                  onHide={handleHide}
+                  actions={<ExtraGameActions appid={game.appid} />}
+                />
+              ))}
+            </div>
+          )
+        ) : filteredHidden.length === 0 ? (
           <div className="border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center">
-            <p className="text-muted-foreground">No extras yet.</p>
+            <p className="text-muted-foreground">No hidden games.</p>
             <p className="text-muted-foreground mt-1 text-sm">
-              After syncing, games Steam remembers you played but no longer own will show up here.
+              Games you hide from the library or extras will appear here so you can restore them.
             </p>
           </div>
         ) : (
           <div className="space-y-4">
-            {filtered.map((game) => (
+            {filteredHidden.map((game) => (
               <GameCard
                 key={game.appid}
                 id={game.appid}
                 name={game.name || `App #${game.appid}`}
                 image={game.image_landscape_url ?? getSteamHeaderImageUrl(game.appid)}
-                playtime={Number(((game.playtime_forever ?? 0) / 60).toFixed(1))}
+                playtime={game.playtime_forever != null ? Number((game.playtime_forever / 60).toFixed(1)) : undefined}
                 href={`https://store.steampowered.com/app/${game.appid}`}
                 achievements={[]}
                 achievementsLoading={false}
-                serverTotal={game.total_count ?? 0}
-                serverUnlocked={game.unlocked_count ?? 0}
-                serverPerfect={game.perfect_game === 1}
+                actions={
+                  <div className="flex items-center gap-2">
+                    <span className="bg-surface-3 text-muted-foreground rounded-full px-2 py-0.5 text-xs">
+                      {game.source === "library" ? "Library" : "Extras"}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        e.preventDefault()
+                        void handleRestore(game.appid)
+                      }}
+                      className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors hover:bg-white/5"
+                    >
+                      <RotateCcw className="h-3 w-3" />
+                      <span>Restore</span>
+                    </button>
+                  </div>
+                }
               />
             ))}
           </div>

--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -19,6 +19,7 @@ interface GameCardProps {
   serverUnlocked?: number
   serverPerfect?: boolean
   onHide?: (appId: number) => void
+  actions?: React.ReactNode
 }
 
 const FALLBACK_STAGES = ["primary", "header", "legacy", "capsule", "generic", "placeholder"] as const
@@ -53,6 +54,7 @@ export function GameCard({
   serverUnlocked = 0,
   serverPerfect = false,
   onHide,
+  actions,
 }: GameCardProps) {
   const [imageSrc, setImageSrc] = useState(image || "/placeholder-landscape.svg")
   const [fallbackIndex, setFallbackIndex] = useState(0)
@@ -135,6 +137,11 @@ export function GameCard({
             <div className="h-2" />
           )}
         </div>
+        {actions && (
+          <div className="mt-2 flex items-center gap-2" onClick={(e) => e.preventDefault()}>
+            {actions}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/hooks/use-steam-data.ts
+++ b/hooks/use-steam-data.ts
@@ -317,6 +317,45 @@ export function useSteamExtras() {
   return { games, loading, error, refetch: load }
 }
 
+export type SteamHiddenGame = {
+  appid: number
+  name: string | null
+  image_landscape_url: string | null
+  image_portrait_url: string | null
+  image_icon_url: string | null
+  playtime_forever: number | null
+  hidden_at: string
+  source: "library" | "extras"
+}
+
+export function useSteamHiddenGames() {
+  const [games, setGames] = useState<SteamHiddenGame[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch("/api/steam/extras?hidden=1")
+      if (!response.ok) throw new Error("Failed to fetch hidden games")
+      const data = (await response.json()) as { games: SteamHiddenGame[] }
+      setGames(data.games)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error")
+      setGames([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  return { games, loading, error, refetch: load }
+}
+
 export function useSteamAchievements(appId: number | null) {
   const [achievements, setAchievements] = useState<SteamAchievementView[]>([])
   const [loading, setLoading] = useState(false)

--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -384,6 +384,7 @@ export function getExtraGamesForUser(steamId: string): ExtraGame[] {
       FROM extra_games e
       LEFT JOIN games g ON g.appid = e.appid
       WHERE e.steam_id = ?
+        AND NOT EXISTS (SELECT 1 FROM hidden_games hg WHERE hg.steam_id = e.steam_id AND hg.appid = e.appid)
       ORDER BY e.playtime_forever DESC, e.rtime_last_played DESC
     `,
     )
@@ -396,4 +397,45 @@ export function getExtraAppIds(steamId: string): number[] {
   const db = getSqliteDatabase()
   const rows = db.prepare(`SELECT appid FROM extra_games WHERE steam_id = ?`).all(steamId) as Array<{ appid: number }>
   return rows.map((r) => r.appid)
+}
+
+export type HiddenGame = {
+  appid: number
+  name: string | null
+  image_landscape_url: string | null
+  image_portrait_url: string | null
+  image_icon_url: string | null
+  playtime_forever: number | null
+  hidden_at: string
+  source: "library" | "extras"
+}
+
+/** Returns all hidden games for a user, from both library and extras. */
+export function getHiddenGamesForUser(steamId: string): HiddenGame[] {
+  const db = getSqliteDatabase()
+  const rows = db
+    .prepare(
+      `
+      SELECT
+        hg.appid,
+        g.name,
+        g.image_landscape_url,
+        g.image_portrait_url,
+        g.image_icon_url,
+        COALESCE(ug.playtime_forever, eg.playtime_forever) AS playtime_forever,
+        hg.hidden_at,
+        CASE
+          WHEN ug.steam_id IS NOT NULL THEN 'library'
+          ELSE 'extras'
+        END AS source
+      FROM hidden_games hg
+      LEFT JOIN games g ON g.appid = hg.appid
+      LEFT JOIN user_games ug ON ug.steam_id = hg.steam_id AND ug.appid = hg.appid AND ug.owned = 1
+      LEFT JOIN extra_games eg ON eg.steam_id = hg.steam_id AND eg.appid = hg.appid
+      WHERE hg.steam_id = ?
+      ORDER BY hg.hidden_at DESC
+    `,
+    )
+    .all(steamId) as HiddenGame[]
+  return rows
 }

--- a/test/api-extras-route.test.ts
+++ b/test/api-extras-route.test.ts
@@ -22,11 +22,17 @@ vi.mock("@/app/lib/server-auth", () => ({
 
 vi.mock("@/lib/server/extra-games", () => ({
   getExtraGamesForUser: vi.fn(),
+  getHiddenGamesForUser: vi.fn(),
 }))
 
+import { NextRequest } from "next/server"
 import { GET } from "@/app/api/steam/extras/route"
 import { getCurrentUser } from "@/app/lib/server-auth"
 import { getExtraGamesForUser } from "@/lib/server/extra-games"
+
+function makeRequest(query = "") {
+  return new NextRequest(`http://localhost/api/steam/extras${query}`)
+}
 
 const mockUser = {
   steamId: "76561198023709299",
@@ -47,7 +53,7 @@ afterEach(() => {
 describe("GET /api/steam/extras", () => {
   it("returns 401 when unauthenticated", async () => {
     vi.mocked(getCurrentUser).mockResolvedValue(null)
-    const res = await GET()
+    const res = await GET(makeRequest())
     expect(res.status).toBe(401)
   })
 
@@ -70,7 +76,7 @@ describe("GET /api/steam/extras", () => {
         synced_at: "2026-04-11T10:00:00.000Z",
       },
     ])
-    const res = await GET()
+    const res = await GET(makeRequest())
     expect(res.status).toBe(200)
     const body = (await res.json()) as { games: Array<{ appid: number }> }
     expect(body.games).toHaveLength(1)
@@ -83,7 +89,7 @@ describe("GET /api/steam/extras", () => {
     vi.mocked(getExtraGamesForUser).mockImplementation(() => {
       throw new Error("db closed")
     })
-    const res = await GET()
+    const res = await GET(makeRequest())
     expect(res.status).toBe(500)
   })
 })

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -623,3 +623,68 @@ describe("getExtraAppIds", () => {
     expect(new Set(getExtraAppIds(STEAM_ID))).toEqual(new Set([111, 222]))
   })
 })
+
+describe("getHiddenGamesForUser", () => {
+  it("returns empty when nothing is hidden", async () => {
+    await seedProfile()
+    const { getHiddenGamesForUser } = await import("@/lib/server/extra-games")
+    expect(getHiddenGamesForUser(STEAM_ID)).toEqual([])
+  })
+
+  it("returns hidden extras with source='extras'", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare("INSERT INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)").run(111, "Test", now, now)
+    db.prepare(
+      "INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(STEAM_ID, 111, 60, now, now, now)
+    db.prepare("INSERT INTO hidden_games (steam_id, appid, hidden_at) VALUES (?, ?, ?)").run(STEAM_ID, 111, now)
+
+    const { getHiddenGamesForUser } = await import("@/lib/server/extra-games")
+    const hidden = getHiddenGamesForUser(STEAM_ID)
+    expect(hidden).toHaveLength(1)
+    expect(hidden[0].appid).toBe(111)
+    expect(hidden[0].name).toBe("Test")
+    expect(hidden[0].source).toBe("extras")
+  })
+
+  it("returns hidden library games with source='library'", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare("INSERT INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)").run(
+      222,
+      "Library Game",
+      now,
+      now,
+    )
+    db.prepare(
+      "INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)",
+    ).run(STEAM_ID, 222, 120, now, now)
+    db.prepare("INSERT INTO hidden_games (steam_id, appid, hidden_at) VALUES (?, ?, ?)").run(STEAM_ID, 222, now)
+
+    const { getHiddenGamesForUser } = await import("@/lib/server/extra-games")
+    const hidden = getHiddenGamesForUser(STEAM_ID)
+    expect(hidden).toHaveLength(1)
+    expect(hidden[0].appid).toBe(222)
+    expect(hidden[0].source).toBe("library")
+  })
+})
+
+describe("getExtraGamesForUser filters hidden", () => {
+  it("excludes hidden extras from the result", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare(
+      "INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(STEAM_ID, 111, 60, now, now, now)
+    db.prepare(
+      "INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(STEAM_ID, 222, 120, now, now, now)
+    db.prepare("INSERT INTO hidden_games (steam_id, appid, hidden_at) VALUES (?, ?, ?)").run(STEAM_ID, 111, now)
+
+    const { getExtraGamesForUser } = await import("@/lib/server/extra-games")
+    const extras = getExtraGamesForUser(STEAM_ID)
+    expect(extras).toHaveLength(1)
+    expect(extras[0].appid).toBe(222)
+  })
+})


### PR DESCRIPTION
## Summary
- **SteamDB + Support links** on every extras card via new GameCard `actions` prop
- **Hide extras** reusing the existing `hidden_games` table + `/api/steam/games/hide` endpoint
- **Hidden tab** on `/extras` showing all hidden games (library + extras) with source badge and restore button
- Extras query now filters out hidden games with `NOT EXISTS`

Closes #147

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test` — 382 tests pass
- [ ] Manual: on /extras, verify SteamDB and Support links open correct URLs
- [ ] Manual: hide an extra → disappears from list → appears in Hidden tab with "Extras" badge
- [ ] Manual: hide a library game → appears in Hidden tab with "Library" badge
- [ ] Manual: restore from Hidden tab → game reappears in original list

🤖 Generated with [Claude Code](https://claude.com/claude-code)