### PR TITLE
fix(extras): GetSchemaForGame fallback + remove permanent name sentinel

### DIFF
--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -1,6 +1,6 @@
 import "server-only"
 
-import { getPlayerAchievements, type LastPlayedGame } from "@/lib/steam-api"
+import { getGameSchema, getPlayerAchievements, type LastPlayedGame } from "@/lib/steam-api"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { isStale, nowIso } from "@/lib/server/steam-store-utils"
 import { ACHIEVEMENTS_STALE_MS } from "@/lib/server/steam-achievements-sync"
@@ -31,11 +31,6 @@ const EXTRAS_ACHIEVEMENTS_CONCURRENCY = 5
 // complete in ~90s.
 const STORE_DELAY_MS = 150
 
-// Sentinel written to games.name when the store appdetails endpoint
-// said "no", so the next hydrate pass skips the appid instead of
-// hammering it forever.
-const NAME_UNRESOLVED_SENTINEL = ""
-
 type StoreAppDetails = {
   success?: boolean
   data?: {
@@ -56,8 +51,15 @@ type StoreAppDetails = {
  * appid. The UI falls back to `App #{appid}` for any game whose name is
  * null OR empty via `game.name || fallback`.
  *
- * Swallows per-call errors. On 5 consecutive failures we back off entirely
- * (Akamai/rate-limit guard).
+ * Swallows per-call errors. On 10 consecutive store failures we back off
+ * (Akamai/rate-limit guard). When the store API returns success=false
+ * (delisted/removed apps), falls back to GetSchemaForGame which returns
+ * gameName even for delisted titles.
+ *
+ * Does NOT write a sentinel for unresolvable apps: leaving the games row
+ * absent keeps the LEFT JOIN NULL so the next sync can retry. This avoids
+ * the old permanent-stick problem where a single transient store failure
+ * would brand an app as "App #12345" forever.
  */
 export async function hydrateMissingExtraNames(steamId: string) {
   const db = getSqliteDatabase()
@@ -67,7 +69,7 @@ export async function hydrateMissingExtraNames(steamId: string) {
       SELECT e.appid
       FROM extra_games e
       LEFT JOIN games g ON g.appid = e.appid
-      WHERE e.steam_id = ? AND g.name IS NULL
+      WHERE e.steam_id = ? AND (g.appid IS NULL OR g.name IS NULL OR g.name = '')
       ORDER BY e.playtime_forever DESC
     `,
     )
@@ -83,17 +85,20 @@ export async function hydrateMissingExtraNames(steamId: string) {
       updated_at = excluded.updated_at
   `)
 
-  let consecutiveFailures = 0
+  let consecutiveStoreFailures = 0
 
   for (const { appid } of rows) {
-    if (consecutiveFailures >= 5) {
+    if (consecutiveStoreFailures >= 10) {
       logger.warn(
         { steamId, remaining: rows.length, lastAppid: appid },
-        "Store appdetails returned 5 consecutive failures — backing off hydrateMissingExtraNames",
+        "Store appdetails returned 10 consecutive failures — backing off hydrateMissingExtraNames",
       )
       return
     }
 
+    let resolvedName: string | null = null
+
+    // Source 1: store appdetails (works for most active apps)
     try {
       const url = new URL("https://store.steampowered.com/api/appdetails")
       url.searchParams.set("appids", String(appid))
@@ -101,28 +106,35 @@ export async function hydrateMissingExtraNames(steamId: string) {
       const response = await fetch(url.toString(), { cache: "no-store" })
 
       if (!response.ok) {
-        consecutiveFailures++
-        continue
-      }
-      consecutiveFailures = 0
-
-      const payload = (await response.json()) as Record<string, StoreAppDetails>
-      const entry = payload[String(appid)]
-      const resolvedName = entry?.success && entry.data?.name ? entry.data.name : null
-      const now = nowIso()
-
-      if (resolvedName) {
-        upsertGame.run(appid, resolvedName, now, now)
+        consecutiveStoreFailures++
       } else {
-        // Negative cache: mark this appid as "we asked, nothing to show"
-        upsertGame.run(appid, NAME_UNRESOLVED_SENTINEL, now, now)
+        consecutiveStoreFailures = 0
+        const payload = (await response.json()) as Record<string, StoreAppDetails>
+        const entry = payload[String(appid)]
+        resolvedName = entry?.success && entry.data?.name ? entry.data.name : null
       }
     } catch (error) {
-      consecutiveFailures++
+      consecutiveStoreFailures++
       logger.warn({ err: error, appid }, "Store appdetails call failed")
     }
 
-    // Rate-limit friendliness: stay well below the ~200 req / 5min ceiling.
+    // Source 2: GetSchemaForGame (works for delisted apps the store rejects)
+    if (!resolvedName) {
+      try {
+        const schema = (await getGameSchema(appid)) as { gameName?: string } | null
+        if (schema?.gameName) {
+          resolvedName = schema.gameName
+        }
+      } catch {
+        // non-critical
+      }
+    }
+
+    if (resolvedName) {
+      const now = nowIso()
+      upsertGame.run(appid, resolvedName, now, now)
+    }
+
     await new Promise((resolve) => setTimeout(resolve, STORE_DELAY_MS))
   }
 }

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -477,16 +477,15 @@ describe("hydrateMissingExtraNames", () => {
     void db
   })
 
-  it("skips rows whose games.name is the empty-string sentinel (negative cache)", async () => {
+  it("retries rows whose games.name is empty string (no permanent sentinel)", async () => {
     const db = await seedExtraWithoutName(111)
     const now = new Date().toISOString()
     db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (111, '', ?, ?)`).run(now, now)
-    const fetchSpy = vi.fn()
-    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    mockStoreSingle((appid) => ({ success: true, data: { name: `Resolved ${appid}` } }))
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
     await hydrateMissingExtraNames(STEAM_ID)
-    expect(fetchSpy).not.toHaveBeenCalled()
-    void db
+    const row = db.prepare("SELECT name FROM games WHERE appid=111").get() as { name: string }
+    expect(row.name).toBe("Resolved 111")
   })
 
   it("upserts the real name when the store API returns success=true", async () => {
@@ -498,13 +497,19 @@ describe("hydrateMissingExtraNames", () => {
     expect(row.name).toBe("Game 111")
   })
 
-  it("writes the empty-string sentinel when the store API says success=false", async () => {
+  it("falls back to GetSchemaForGame when store returns success=false", async () => {
     const db = await seedExtraWithoutName(274920)
     mockStoreSingle(() => ({ success: false }))
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue({ gameName: "FaceRig" }),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
     await hydrateMissingExtraNames(STEAM_ID)
     const row = db.prepare("SELECT name FROM games WHERE appid=274920").get() as { name: string }
-    expect(row.name).toBe("")
+    expect(row.name).toBe("FaceRig")
   })
 
   it("calls the store API once per appid (single-appid queries only)", async () => {
@@ -567,23 +572,29 @@ describe("hydrateMissingExtraNames", () => {
     void db
   })
 
-  it("backs off after 5 consecutive store API failures", async () => {
+  it("backs off after 10 consecutive store API failures", async () => {
     const db = await seedProfile()
     const now = new Date().toISOString()
-    for (let i = 1; i <= 10; i++) {
+    for (let i = 1; i <= 15; i++) {
       db.prepare(
         `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?)`,
       ).run(STEAM_ID, i, 100 - i, now, now, now)
     }
-    let calls = 0
+    let storeCalls = 0
     globalThis.fetch = vi.fn(async () => {
-      calls++
+      storeCalls++
       return { ok: false, status: 500, json: async () => ({}) } as unknown as Response
     }) as unknown as typeof fetch
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
     await hydrateMissingExtraNames(STEAM_ID)
-    expect(calls).toBe(5)
+    expect(storeCalls).toBe(10)
     void db
   })
 


### PR DESCRIPTION
## Summary
- When store appdetails returns \`success=false\` (delisted apps), falls back to \`ISteamUserStats/GetSchemaForGame/v2\` which returns \`gameName\` even for removed titles
- Removes the permanent \`name=""\` sentinel that locked unresolvable apps into "App #12345" forever — failed hydrations now leave no games row so the next sync retries
- Widens the hydrate query to \`WHERE g.appid IS NULL OR g.name IS NULL OR g.name = ''\` to also retry legacy sentinel rows
- Relaxes consecutive failure backoff from 5 to 10

Verified with production examples: 622590 (PUBG Test Server, delisted) resolves via GetSchemaForGame where the store returns \`success=false\`.

Closes #151

## Test plan
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` — 386 tests pass (3 updated tests for new behavior)
- [ ] Manual: delete SQLite, sync. Extras that previously showed "App #N" should now show real names (e.g. 622590 → "PLAYERUNKNOWN'S BATTLEGROUNDS (Test Server)")

🤖 Generated with [Claude Code](https://claude.com/claude-code)