### PR TITLE
feat(extras): detail page /extras/[id] with achievements

### DIFF
--- a/app/api/steam/extras/[id]/route.ts
+++ b/app/api/steam/extras/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server"
+import { getCurrentUser } from "@/app/lib/server-auth"
+import { getStoredExtraGame, getExtraAchievementsList } from "@/lib/server/extra-games"
+import { logger } from "@/lib/server/logger"
+
+/** GET /api/steam/extras/:id — returns an extra game's detail + enriched achievements. */
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = await getCurrentUser()
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { id } = await params
+    const appId = Number(id)
+    if (!id || !Number.isFinite(appId) || appId <= 0) {
+      return NextResponse.json({ error: "Valid App ID required" }, { status: 400 })
+    }
+
+    const game = getStoredExtraGame(user.steamId, appId)
+    if (!game) {
+      return NextResponse.json({ error: "Extra game not found" }, { status: 404 })
+    }
+
+    const achievements = await getExtraAchievementsList(user.steamId, appId)
+
+    return NextResponse.json({
+      game,
+      achievements: achievements ?? [],
+    })
+  } catch (error) {
+    logger.error({ err: error, endpoint: "steam/extras/[id]" }, "Extra game detail error")
+    return NextResponse.json({ error: "Failed to fetch extra game detail" }, { status: 500 })
+  }
+}

--- a/app/extras/[id]/page.tsx
+++ b/app/extras/[id]/page.tsx
@@ -1,0 +1,288 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { Database, ExternalLink, LifeBuoy, Lock, Trophy } from "lucide-react"
+
+import { useCurrentUser } from "@/hooks/use-current-user"
+import { usePageTitle } from "@/components/ui/page-title-context"
+import { LoadingMessage } from "@/components/ui/loading-message"
+import { EmptyState } from "@/components/ui/empty-state"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import { getSteamHeaderImageUrl } from "@/lib/steam-api"
+import { formatPlaytime } from "@/lib/utils"
+import type { SteamAchievementView } from "@/lib/types/steam"
+
+type ExtraGameDetail = {
+  appid: number
+  name: string | null
+  image_landscape_url: string | null
+  image_portrait_url: string | null
+  image_icon_url: string | null
+  playtime_forever: number
+  rtime_first_played: number | null
+  rtime_last_played: number | null
+  unlocked_count: number | null
+  total_count: number | null
+  perfect_game: number
+}
+
+type ExtraDetailResponse = {
+  game: ExtraGameDetail
+  achievements: SteamAchievementView[]
+}
+
+type AchievementTab = "pending" | "unlocked"
+
+function sortByUnlockDateDesc(a: SteamAchievementView, b: SteamAchievementView) {
+  if (!a.unlocktime && !b.unlocktime) return 0
+  if (!a.unlocktime) return 1
+  if (!b.unlocktime) return -1
+  return b.unlocktime - a.unlocktime
+}
+
+export default function ExtraGameDetailPage() {
+  const params = useParams<{ id: string }>()
+  const appId = Number(params.id)
+  const { user, loading: loadingUser } = useCurrentUser()
+  const router = useRouter()
+  const { setTitle } = usePageTitle()
+  const [game, setGame] = useState<ExtraGameDetail | null>(null)
+  const [achievements, setAchievements] = useState<SteamAchievementView[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<AchievementTab>("pending")
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/steam/extras/${appId}`)
+      if (!res.ok) {
+        if (res.status === 404) {
+          setError("Extra game not found")
+        } else {
+          setError("Failed to load game details")
+        }
+        return
+      }
+      const data = (await res.json()) as ExtraDetailResponse
+      setGame(data.game)
+      setAchievements(data.achievements)
+    } catch {
+      setError("Network error")
+    } finally {
+      setLoading(false)
+    }
+  }, [appId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
+  useEffect(() => {
+    if (!loadingUser && !user) {
+      router.push("/")
+    }
+  }, [loadingUser, router, user])
+
+  useEffect(() => {
+    if (game?.name) {
+      setTitle(`${game.name} - Steam Backlog Hunter`)
+    }
+    return () => setTitle("")
+  }, [game?.name, setTitle])
+
+  const pending = useMemo(() => achievements.filter((a) => !a.achieved).sort(sortByUnlockDateDesc), [achievements])
+  const unlocked = useMemo(
+    () => achievements.filter((a) => a.achieved === 1).sort(sortByUnlockDateDesc),
+    [achievements],
+  )
+  const total = achievements.length
+  const unlockedCount = unlocked.length
+  const percent = total > 0 ? Math.round((unlockedCount / total) * 100) : 0
+
+  if (loadingUser) return <LoadingMessage />
+  if (!user) return null
+
+  const displayList = activeTab === "pending" ? pending : unlocked
+
+  let progressColor = "bg-danger"
+  if (percent >= 80) progressColor = "bg-success"
+  else if (percent >= 40) progressColor = "bg-warning"
+
+  const gameName = game?.name || `App #${appId}`
+
+  return (
+    <div className="from-background to-muted min-h-screen bg-gradient-to-br">
+      <div className="container mx-auto px-4 py-8">
+        {loading ? (
+          <div className="mb-8 flex items-center gap-6">
+            <Skeleton className="h-64 w-44 rounded-lg" />
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          </div>
+        ) : error ? (
+          <EmptyState message={error} />
+        ) : game ? (
+          <>
+            <div className="mb-8 flex items-start gap-6">
+              <img
+                src={game.image_portrait_url || game.image_landscape_url || getSteamHeaderImageUrl(game.appid)}
+                alt={`Cover art for ${gameName}`}
+                className="w-44 rounded-lg border"
+              />
+              <div className="flex-1 space-y-4 pt-1">
+                <div>
+                  <div className="mb-2 flex items-center gap-2">
+                    <h1 className="text-2xl font-bold">{gameName}</h1>
+                    <span className="bg-surface-3 text-muted-foreground rounded-full px-2 py-0.5 text-xs">Extra</span>
+                  </div>
+                  <div className="text-muted-foreground text-sm">
+                    {formatPlaytime(game.playtime_forever / 60)} played
+                  </div>
+                </div>
+
+                {total > 0 && (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground font-medium">Achievement progress</span>
+                      <span className="font-medium">
+                        {unlockedCount}/{total} ({percent}%)
+                      </span>
+                    </div>
+                    <Progress value={percent} indicatorClassName={progressColor} />
+                  </div>
+                )}
+
+                <div className="flex flex-wrap items-center gap-3 pt-1">
+                  <a
+                    href={`https://store.steampowered.com/app/${game.appid}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Button variant="outline" size="sm" className="gap-2">
+                      <ExternalLink className="h-4 w-4" />
+                      Steam Store
+                    </Button>
+                  </a>
+                  <a href={`https://steamdb.info/app/${game.appid}/`} target="_blank" rel="noopener noreferrer">
+                    <Button variant="outline" size="sm" className="gap-2">
+                      <Database className="h-4 w-4" />
+                      SteamDB
+                    </Button>
+                  </a>
+                  <a
+                    href={`https://help.steampowered.com/en/wizard/HelpWithGameIssue/?appid=${game.appid}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Button variant="outline" size="sm" className="gap-2">
+                      <LifeBuoy className="h-4 w-4" />
+                      Support
+                    </Button>
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            {total > 0 && (
+              <>
+                <div className="mb-4">
+                  <div className="bg-card/80 border-surface-4 inline-flex gap-2 rounded-lg border p-2">
+                    <Button
+                      variant={activeTab === "pending" ? "default" : "ghost"}
+                      size="sm"
+                      onClick={() => setActiveTab("pending")}
+                      className={
+                        activeTab === "pending"
+                          ? "bg-accent hover:bg-accent/90 text-foreground"
+                          : "text-muted-foreground hover:text-foreground hover:bg-surface-3"
+                      }
+                    >
+                      <Lock className="h-4 w-4" />
+                      Pending ({pending.length})
+                    </Button>
+                    <Button
+                      variant={activeTab === "unlocked" ? "default" : "ghost"}
+                      size="sm"
+                      onClick={() => setActiveTab("unlocked")}
+                      className={
+                        activeTab === "unlocked"
+                          ? "bg-accent hover:bg-accent/90 text-foreground"
+                          : "text-muted-foreground hover:text-foreground hover:bg-surface-3"
+                      }
+                    >
+                      <Trophy className="h-4 w-4" />
+                      Unlocked ({unlocked.length})
+                    </Button>
+                  </div>
+                </div>
+
+                {displayList.length === 0 ? (
+                  <EmptyState
+                    message={
+                      activeTab === "pending"
+                        ? "No pending achievements for this game!"
+                        : "No unlocked achievements yet."
+                    }
+                  />
+                ) : (
+                  <ul className="grid gap-3">
+                    {displayList.map((ach) => (
+                      <li
+                        key={ach.apiname}
+                        className={`border-surface-4 flex items-center gap-4 rounded-lg border p-4 transition-colors ${
+                          ach.achieved ? "bg-surface-1" : "bg-white/2 opacity-70"
+                        }`}
+                      >
+                        <img
+                          src={(ach.achieved ? ach.icon : ach.icongray) || ach.icon || "/placeholder-icon.svg"}
+                          alt={`Icon for ${ach.displayName} achievement`}
+                          className="h-12 w-12 rounded-lg"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate font-semibold">{ach.displayName}</div>
+                          {ach.description && <div className="text-muted-foreground text-sm">{ach.description}</div>}
+                        </div>
+                        {ach.achieved && ach.unlocktime ? (
+                          <div className="text-muted-foreground text-right text-xs">
+                            <div>
+                              {new Date(ach.unlocktime * 1000).toLocaleDateString(undefined, {
+                                year: "numeric",
+                                month: "short",
+                                day: "numeric",
+                              })}
+                            </div>
+                            <div>
+                              {new Date(ach.unlocktime * 1000).toLocaleTimeString(undefined, {
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              })}
+                            </div>
+                          </div>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            )}
+
+            {total === 0 && !loading && (
+              <EmptyState message="This game has no achievements or they haven't been synced yet." />
+            )}
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -230,7 +230,7 @@ export default function ExtrasPage() {
                   name={game.name || `App #${game.appid}`}
                   image={game.image_landscape_url ?? getSteamHeaderImageUrl(game.appid)}
                   playtime={Number(((game.playtime_forever ?? 0) / 60).toFixed(1))}
-                  href={`https://store.steampowered.com/app/${game.appid}`}
+                  href={`/extras/${game.appid}`}
                   achievements={[]}
                   achievementsLoading={false}
                   serverTotal={game.total_count ?? 0}

--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -1,6 +1,8 @@
 import "server-only"
 
 import { getGameSchema, getPlayerAchievements, type LastPlayedGame } from "@/lib/steam-api"
+import { ensureSchema } from "@/lib/server/steam-achievements-sync"
+import type { SteamAchievementView } from "@/lib/types/steam"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { isStale, nowIso } from "@/lib/server/steam-store-utils"
 import { ACHIEVEMENTS_STALE_MS } from "@/lib/server/steam-achievements-sync"
@@ -450,4 +452,105 @@ export function getHiddenGamesForUser(steamId: string): HiddenGame[] {
     )
     .all(steamId) as HiddenGame[]
   return rows
+}
+
+/** Returns a single extra game for a user, or null if not found. */
+export function getStoredExtraGame(steamId: string, appId: number): ExtraGame | null {
+  const db = getSqliteDatabase()
+  const row = db
+    .prepare(
+      `
+      SELECT
+        e.appid,
+        g.name,
+        g.image_landscape_url,
+        g.image_portrait_url,
+        g.image_icon_url,
+        e.playtime_forever,
+        e.rtime_first_played,
+        e.rtime_last_played,
+        e.unlocked_count,
+        e.total_count,
+        e.perfect_game,
+        e.achievements_synced_at,
+        e.synced_at
+      FROM extra_games e
+      LEFT JOIN games g ON g.appid = e.appid
+      WHERE e.steam_id = ? AND e.appid = ?
+    `,
+    )
+    .get(steamId, appId) as ExtraGame | undefined
+  return row ?? null
+}
+
+/**
+ * Reads enriched achievements for an extra game. Calls ensureSchema
+ * on-demand to populate game_achievements (names, icons) if missing,
+ * then joins with extra_game_achievements for unlock status.
+ */
+export async function getExtraAchievementsList(steamId: string, appId: number): Promise<SteamAchievementView[] | null> {
+  const db = getSqliteDatabase()
+
+  const meta = db
+    .prepare(`SELECT achievements_synced_at FROM extra_games WHERE steam_id = ? AND appid = ?`)
+    .get(steamId, appId) as { achievements_synced_at: string | null } | undefined
+  if (!meta?.achievements_synced_at) return null
+
+  // Ensure games row exists so ensureSchema's FK on game_achievements won't fail
+  const gamesRow = db.prepare(`SELECT 1 FROM games WHERE appid = ?`).get(appId)
+  if (!gamesRow) {
+    const now = nowIso()
+    db.prepare(`INSERT OR IGNORE INTO games (appid, name, created_at, updated_at) VALUES (?, '', ?, ?)`).run(
+      appId,
+      now,
+      now,
+    )
+  }
+
+  await ensureSchema(appId)
+
+  const rows = db
+    .prepare(
+      `
+      SELECT
+        ga.appid,
+        ga.apiname,
+        ga.display_name,
+        ga.description,
+        ga.icon,
+        ga.icon_gray,
+        COALESCE(ea.achieved, 0) AS achieved,
+        COALESCE(ea.unlock_time, 0) AS unlock_time
+      FROM game_achievements ga
+      LEFT JOIN extra_game_achievements ea
+        ON ea.appid = ga.appid
+        AND ea.apiname = ga.apiname
+        AND ea.steam_id = ?
+      WHERE ga.appid = ?
+      ORDER BY ga.apiname
+    `,
+    )
+    .all(steamId, appId) as Array<{
+    appid: number
+    apiname: string
+    display_name: string | null
+    description: string | null
+    icon: string | null
+    icon_gray: string | null
+    achieved: number
+    unlock_time: number | null
+  }>
+
+  if (rows.length === 0) return null
+
+  return rows.map((row) => ({
+    apiname: row.apiname,
+    achieved: row.achieved,
+    unlocktime: row.unlock_time ?? 0,
+    name: row.display_name ?? row.apiname,
+    description: row.description ?? "",
+    displayName: row.display_name ?? row.apiname,
+    icon: row.icon ?? "",
+    icongray: row.icon_gray ?? "",
+  }))
 }

--- a/test/api-extras-detail-route.test.ts
+++ b/test/api-extras-detail-route.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock("@/app/lib/server-auth", () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+vi.mock("@/lib/server/extra-games", () => ({
+  getStoredExtraGame: vi.fn(),
+  getExtraAchievementsList: vi.fn(),
+}))
+
+import { GET } from "@/app/api/steam/extras/[id]/route"
+import { getCurrentUser } from "@/app/lib/server-auth"
+import { getStoredExtraGame, getExtraAchievementsList } from "@/lib/server/extra-games"
+
+const mockUser = { steamId: "76561198023709299", displayName: "Jay", avatar: "", profileUrl: "" }
+
+beforeEach(() => {
+  vi.mocked(getCurrentUser).mockReset()
+  vi.mocked(getStoredExtraGame).mockReset()
+  vi.mocked(getExtraAchievementsList).mockReset()
+})
+
+afterEach(() => vi.clearAllMocks())
+
+function makeRequest(id: string) {
+  return [new Request(`http://localhost/api/steam/extras/${id}`), { params: Promise.resolve({ id }) }] as const
+}
+
+describe("GET /api/steam/extras/:id", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(null)
+    const res = await GET(...makeRequest("111"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 400 for invalid appId", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    const res = await GET(...makeRequest("abc"))
+    expect(res.status).toBe(400)
+  })
+
+  it("returns 404 when extra not found", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getStoredExtraGame).mockReturnValue(null)
+    const res = await GET(...makeRequest("111"))
+    expect(res.status).toBe(404)
+  })
+
+  it("returns game + achievements on success", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getStoredExtraGame).mockReturnValue({
+      appid: 111,
+      name: "Test Game",
+      image_landscape_url: null,
+      image_portrait_url: null,
+      image_icon_url: null,
+      playtime_forever: 60,
+      rtime_first_played: null,
+      rtime_last_played: null,
+      unlocked_count: 1,
+      total_count: 2,
+      perfect_game: 0,
+      achievements_synced_at: "2026-01-01",
+      synced_at: "2026-01-01",
+    })
+    vi.mocked(getExtraAchievementsList).mockResolvedValue([])
+    const res = await GET(...makeRequest("111"))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { game: { appid: number }; achievements: unknown[] }
+    expect(body.game.appid).toBe(111)
+    expect(body.achievements).toEqual([])
+  })
+
+  it("returns 500 on unexpected error", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue(mockUser)
+    vi.mocked(getStoredExtraGame).mockImplementation(() => {
+      throw new Error("db error")
+    })
+    const res = await GET(...makeRequest("111"))
+    expect(res.status).toBe(500)
+  })
+})

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -699,3 +699,81 @@ describe("getExtraGamesForUser filters hidden", () => {
     expect(extras[0].appid).toBe(222)
   })
 })
+
+describe("getStoredExtraGame", () => {
+  it("returns null when extra does not exist", async () => {
+    await seedProfile()
+    const { getStoredExtraGame } = await import("@/lib/server/extra-games")
+    expect(getStoredExtraGame(STEAM_ID, 999)).toBeNull()
+  })
+
+  it("returns the extra game with joined game metadata", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare("INSERT INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)").run(111, "Test", now, now)
+    db.prepare(
+      "INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(STEAM_ID, 111, 60, now, now, now)
+
+    const { getStoredExtraGame } = await import("@/lib/server/extra-games")
+    const game = getStoredExtraGame(STEAM_ID, 111)
+    expect(game).not.toBeNull()
+    expect(game!.appid).toBe(111)
+    expect(game!.name).toBe("Test")
+    expect(game!.playtime_forever).toBe(60)
+  })
+})
+
+describe("getExtraAchievementsList", () => {
+  it("returns null when extra has no achievements_synced_at", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare(
+      "INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(STEAM_ID, 111, 60, now, now, now)
+
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    const { getExtraAchievementsList } = await import("@/lib/server/extra-games")
+    expect(await getExtraAchievementsList(STEAM_ID, 111)).toBeNull()
+    void db
+  })
+
+  it("returns enriched achievements when schema and extras data exist", async () => {
+    const db = await seedProfile()
+    const now = new Date().toISOString()
+    db.prepare("INSERT INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)").run(111, "Test", now, now)
+    db.prepare(
+      "INSERT INTO extra_games (steam_id, appid, playtime_forever, achievements_synced_at, total_count, unlocked_count, synced_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(STEAM_ID, 111, 60, now, 2, 1, now, now, now)
+    db.prepare(
+      "INSERT INTO game_achievements (appid, apiname, display_name, description, icon, icon_gray, hidden, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)",
+    ).run(111, "ACH_1", "First Blood", "Get first kill", "icon1.jpg", "gray1.jpg", now, now)
+    db.prepare(
+      "INSERT INTO game_achievements (appid, apiname, display_name, description, icon, icon_gray, hidden, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)",
+    ).run(111, "ACH_2", "Winner", "Win a match", "icon2.jpg", "gray2.jpg", now, now)
+    db.prepare(
+      "INSERT INTO extra_game_achievements (steam_id, appid, apiname, achieved, unlock_time, created_at, updated_at) VALUES (?, ?, ?, 1, 1700000000, ?, ?)",
+    ).run(STEAM_ID, 111, "ACH_1", now, now)
+
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    const { getExtraAchievementsList } = await import("@/lib/server/extra-games")
+    const achs = await getExtraAchievementsList(STEAM_ID, 111)
+    expect(achs).not.toBeNull()
+    expect(achs).toHaveLength(2)
+    const ach1 = achs!.find((a) => a.apiname === "ACH_1")!
+    expect(ach1.achieved).toBe(1)
+    expect(ach1.displayName).toBe("First Blood")
+    const ach2 = achs!.find((a) => a.apiname === "ACH_2")!
+    expect(ach2.achieved).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- New **detail page** at \`/extras/[id]\` mirroring library's \`/game/[id]\`: game image, name with "Extra" badge, playtime, achievement progress bar, Pending/Unlocked tabs with icons + names + descriptions + dates
- **Steam Store / SteamDB / Support** buttons on the detail page
- Achievement metadata lazy-loaded via \`ensureSchema\` on first visit (avoids FK issues during bulk sync)
- Cards on \`/extras\` now link to \`/extras/{appid}\` instead of the Steam store
- New server functions: \`getStoredExtraGame\`, \`getExtraAchievementsList\`
- New API endpoint: \`GET /api/steam/extras/[id]\`

Closes #153

## Test plan
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` — 386 tests pass
- [ ] Manual: click an extra with achievements → detail page shows enriched achievement list with icons/names
- [ ] Manual: click an extra without achievements → shows "no achievements" message
- [ ] Manual: SteamDB/Support buttons open correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)