### PR TITLE
fix(sync): retry achievements for games Steam confirms have stats

### DIFF
--- a/lib/server/steam-stats-compute.ts
+++ b/lib/server/steam-stats-compute.ts
@@ -195,8 +195,12 @@ async function doSyncAchievementsForStats(
     const stored = getStoredAchievements(steamId, game.appid)
 
     // Known-broken: first sync reported 0 achievements (stats-only game,
-    // retired game, private profile, etc). Don't keep retrying.
-    if (stored?.achievements_synced_at && (stored.total_count ?? 0) === 0) return false
+    // retired game, private profile, etc). Don't keep retrying — UNLESS
+    // Steam explicitly said the game has community stats, in which case a
+    // zero count likely came from a transient API failure (500/timeout)
+    // and we should retry on the next sync.
+    if (stored?.achievements_synced_at && (stored.total_count ?? 0) === 0 && game.has_community_visible_stats !== true)
+      return false
 
     // Never synced → always include (covers first sync and new purchases).
     if (!stored?.achievements_synced_at) return true


### PR DESCRIPTION
## Summary
- Games with \`has_community_visible_stats=true\` that got \`total_count=0\` from a transient API failure (500/timeout) during the first sync were permanently excluded by the "known-broken" filter
- Now only skips games where Steam did NOT confirm they have stats, so transient failures get retried on the next sync
- Verified: AoE2 (221380) and 140 (242820) both have achievements that Steam returns correctly but were stuck at \`total_count=0\`

Closes #155

## Test plan
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` — 395 tests pass
- [ ] Manual: press Sync → games like AoE2 that were stuck at "-" should now show their real achievement counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)