### PR TITLE
fix(sync): force retry for games with stats but zero count

### DIFF
--- a/lib/server/steam-stats-compute.ts
+++ b/lib/server/steam-stats-compute.ts
@@ -194,13 +194,14 @@ async function doSyncAchievementsForStats(
 
     const stored = getStoredAchievements(steamId, game.appid)
 
-    // Known-broken: first sync reported 0 achievements (stats-only game,
-    // retired game, private profile, etc). Don't keep retrying — UNLESS
-    // Steam explicitly said the game has community stats, in which case a
-    // zero count likely came from a transient API failure (500/timeout)
-    // and we should retry on the next sync.
-    if (stored?.achievements_synced_at && (stored.total_count ?? 0) === 0 && game.has_community_visible_stats !== true)
-      return false
+    // Transient failure recovery: Steam says stats exist but we recorded 0
+    // (likely a 500/timeout during the first sync). Always retry these.
+    if (stored?.achievements_synced_at && (stored.total_count ?? 0) === 0 && game.has_community_visible_stats === true)
+      return true
+
+    // Known-broken: synced once and reported 0 achievements, AND Steam
+    // didn't flag the game as having community stats. Don't keep retrying.
+    if (stored?.achievements_synced_at && (stored.total_count ?? 0) === 0) return false
 
     // Never synced → always include (covers first sync and new purchases).
     if (!stored?.achievements_synced_at) return true


### PR DESCRIPTION
## Summary
- Previous fix (#156) prevented permanent exclusion but the staleness check still blocked retries ("synced recently, skip for 7 days")
- Now explicitly returns \`true\` (always retry) when \`total_count=0\` AND \`has_community_visible_stats=true\`, bypassing the staleness window
- Games like AoE2 (221380) and 140 (242820) that got 0 from a transient 500 will now be retried immediately on the next sync

## Test plan
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` — 395 tests pass
- [ ] Manual: deploy, press Sync → AoE2 and 140 should show real achievement counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)