### PR TITLE
fix: stop Prettier reformatting next-env.d.ts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 node_modules
 coverage
 pnpm-lock.yaml
+next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts"
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #161

## Summary

- Add `next-env.d.ts` to `.prettierignore` so `lint-staged` stops stripping the trailing semicolon Next.js writes.
- Commit the file in its canonical Next-generated form (with `;`) one last time.

## Why

Root cause of the drift loop:

1. Next regenerates the file with `import "./.next/types/routes.d.ts";`
2. `.prettierrc` has `"semi": false`
3. `lint-staged` runs Prettier on commit → strips the semicolon
4. Next rewrites it on next \`dev\`/\`typecheck\`/\`build\`
5. \`git status\` is permanently dirty

Historical cost: the file has already been re-committed 4 times just to sync (\`a19b6b3\`, \`9221576\`, \`ff807d8\`, \`c209071\`). The file itself says \`// This file should not be edited\`.

## Test plan

- [x] \`pnpm exec prettier --check next-env.d.ts\` — reports ignored / no issues
- [x] Pre-commit hook ran Prettier + ESLint and did NOT strip the semicolon (verified in commit)
- [ ] After merge: run \`pnpm dev\` or \`pnpm typecheck\` and confirm \`git status\` stays clean