### PR TITLE
chore: remove unused tailwindcss-animate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "recharts": "3.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.1",
-    "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",
     "zod": "4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       tailwind-merge:
         specifier: ^3.4.1
         version: 3.4.1
-      tailwindcss-animate:
-        specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@4.1.18)
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3611,11 +3608,6 @@ packages:
 
   tailwind-merge@3.4.1:
     resolution: {integrity: sha512-2OA0rFqWOkITEAOFWSBSApYkDeH9t2B3XSJuI4YztKBzK3mX0737A2qtxDZ7xkw9Zfh0bWl+r34sF3HXV+Ig7Q==}
-
-  tailwindcss-animate@1.0.7:
-    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
@@ -7436,10 +7428,6 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.4.1: {}
-
-  tailwindcss-animate@1.0.7(tailwindcss@4.1.18):
-    dependencies:
-      tailwindcss: 4.1.18
 
   tailwindcss@4.1.18: {}
 


### PR DESCRIPTION
Closes #163

## Summary

- Remove \`tailwindcss-animate\` from \`package.json\` — it's not imported anywhere.
- The active animation library is \`tw-animate-css\` (imported in \`app/globals.css:2\`), which is the Tailwind v4 rewrite providing the same \`animate-in\`/\`animate-out\` utilities shadcn overlays rely on.

## Why

With Tailwind v4 + \`@tailwindcss/postcss\` and no \`tailwind.config\`, \`tailwindcss-animate\` would need explicit wiring (plugin config or a \`@plugin\` directive in CSS) to contribute at build time — neither exists. It's a dead dep left over from the v3-era setup.

## Test plan

- [x] \`pnpm lint\` (ESLint + typecheck) — clean
- [x] \`pnpm test\` — 44 files, 395 tests passing
- [x] \`pnpm build\` — clean
- [ ] After merge: smoke-test shadcn overlay animations (Dialog, DropdownMenu, Sheet) on dashboard/games pages