### PR TITLE
chore: gitignore .claude/skills/ and skills-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ dist/
 
 # pnpm store
 .pnpm-store/
+
+# Claude Code skill bundles (installed locally via autoskills or similar)
+.claude/skills/
+skills-lock.json


### PR DESCRIPTION
Closes #165

## Summary

- Add \`.claude/skills/\` and \`skills-lock.json\` to \`.gitignore\`.
- Scope intentionally narrow: \`.claude/\` itself stays tracked so future \`.claude/settings.json\` or similar shared config can be committed.

## Why

Tools like \`npx autoskills\` install AI skill bundles into \`.claude/skills/\` and drop a \`skills-lock.json\` at the repo root. These are local developer tooling — each contributor may want a different set — and shouldn't live in the shared repo. Without this, anyone who runs autoskills sees \`.claude/\` as untracked in \`git status\` forever and risks accidentally committing ~2MB of skill markdown.

## Test plan

- [x] \`git check-ignore -v .claude/skills/shadcn\` → matches rule
- [x] \`git check-ignore -v skills-lock.json\` → matches rule
- [x] \`git status\` no longer shows \`.claude/\` as untracked with skills present