### PR TITLE
refactor: typography scale + remove arbitrary text sizes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -119,6 +119,10 @@
   --color-warning-foreground: var(--warning-foreground);
   --color-danger: var(--danger);
   --color-danger-foreground: var(--danger-foreground);
+  /* Below text-xs (0.75rem) — for sub-xs captions and eyebrow labels. */
+  --text-2xs: 0.68rem;
+  /* Letter-spacing used by uppercase eyebrow labels. */
+  --tracking-eyebrow: 0.18em;
 }
 
 @layer base {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,7 +56,7 @@ export default function HomePage() {
               className="mx-auto transition-opacity group-hover:opacity-80"
             />
           </button>
-          <p className="text-muted-foreground text-[0.7rem]">
+          <p className="text-muted-foreground text-2xs">
             Authenticates via Steam OpenID. Only your public profile and game data are accessed.
           </p>
         </div>
@@ -65,21 +65,17 @@ export default function HomePage() {
           <div className="border-surface-4 bg-surface-1 space-y-2 rounded-lg border p-4">
             <Trophy className="text-accent mx-auto h-5 w-5" />
             <p className="text-foreground text-xs font-medium">Achievements</p>
-            <p className="text-muted-foreground text-[0.68rem] leading-snug">
-              Pending, unlocked, and completion per game.
-            </p>
+            <p className="text-muted-foreground text-2xs leading-snug">Pending, unlocked, and completion per game.</p>
           </div>
           <div className="border-surface-4 bg-surface-1 space-y-2 rounded-lg border p-4">
             <BarChart3 className="text-accent mx-auto h-5 w-5" />
             <p className="text-foreground text-xs font-medium">Analytics</p>
-            <p className="text-muted-foreground text-[0.68rem] leading-snug">
-              Playtime, perfect games, and library stats.
-            </p>
+            <p className="text-muted-foreground text-2xs leading-snug">Playtime, perfect games, and library stats.</p>
           </div>
           <div className="border-surface-4 bg-surface-1 space-y-2 rounded-lg border p-4">
             <Target className="text-accent mx-auto h-5 w-5" />
             <p className="text-foreground text-xs font-medium">Completion</p>
-            <p className="text-muted-foreground text-[0.68rem] leading-snug">Games closest to 100% from recent play.</p>
+            <p className="text-muted-foreground text-2xs leading-snug">Games closest to 100% from recent play.</p>
           </div>
         </div>
 

--- a/components/dashboard/user-profile.tsx
+++ b/components/dashboard/user-profile.tsx
@@ -179,6 +179,8 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
                 {user.steamLevel != null &&
                   (() => {
                     const badge = getSteamLevelBadge(user.steamLevel)
+                    // text-[13px] below is locked to the Steam badge sprite's pixel grid
+                    // (DISPLAY_SIZE/SPRITE_FRAME) — intentional pixel sizing, not drift.
                     if (badge.type === "circle") {
                       return (
                         <span
@@ -252,9 +254,7 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
           </CardTitle>
           {!statsLoading && stats && (
             <div className="text-right">
-              <p className="text-muted-foreground text-[0.68rem] font-semibold tracking-[0.18em] uppercase">
-                Avg. completion
-              </p>
+              <p className="text-muted-foreground text-2xs tracking-eyebrow font-semibold uppercase">Avg. completion</p>
               <p className="mt-1 flex items-baseline justify-end text-3xl font-semibold tracking-tight">
                 <AnimatedNumber value={stats.averageCompletion} />
                 <span className="text-muted-foreground ml-1.5 self-center text-lg">%</span>
@@ -311,9 +311,7 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
                 href={item.href}
                 className="border-surface-4 bg-surface-1 hover:border-accent/30 hover:bg-surface-2 rounded-lg border px-4 py-4 backdrop-blur-sm transition-colors"
               >
-                <p className="text-muted-foreground text-[0.68rem] font-semibold tracking-[0.18em] uppercase">
-                  {item.label}
-                </p>
+                <p className="text-muted-foreground text-2xs tracking-eyebrow font-semibold uppercase">{item.label}</p>
                 <p className="mt-2 text-2xl font-semibold tracking-tight">
                   {statsLoading ? "..." : <AnimatedNumber value={item.value} />}
                 </p>


### PR DESCRIPTION
Closes #183

Final PR of **Frontend Refresh — Phase A (Polish & Consistency)**.

## Summary

- Add two tokens to \`globals.css\` \`@theme inline\`: \`--text-2xs: 0.68rem\` and \`--tracking-eyebrow: 0.18em\`. Tailwind v4 auto-generates \`text-2xs\` and \`tracking-eyebrow\` utilities from these.
- Replace the 5 sites using \`text-[0.68rem]\` / \`text-[0.7rem]\` with \`text-2xs\`.
- Replace the 2 sites using \`tracking-[0.18em]\` with \`tracking-eyebrow\`.
- Add a one-line comment next to the two \`text-[13px]\` sites in \`user-profile.tsx\` explaining they're locked to the Steam badge sprite's pixel grid (intentional, not drift).

The 0.68rem vs 0.7rem difference (0.32px at 16px base) is invisible and intentionally collapsed into one token.

## Why

The audit flagged scattered arbitrary text sizes — they bypass the design token system and create silent drift. A single new token plus one tracking value covers all the legit non-drift cases.

## Verification

- [x] \`pnpm lint\` clean (oxlint + typecheck)
- [x] \`pnpm test\` — 44 files / 395 tests passing
- [x] \`pnpm build\` clean
- [x] \`pnpm dev\` smoke test — \`/\` and \`/dashboard\` return 200
- [x] **CSS bundle inspection**: confirmed both \`text-2xs\` and \`tracking-eyebrow\` resolve to compiled utility classes in \`/_next/static/chunks/_0tbo_3h._.css\`
- [x] **Markup verification**: confirmed \`text-2xs\` appears in the rendered HTML of \`/\`
- [ ] **Visual verification recommended before merge** — render \`/\` (3 feature card captions + sign-in disclaimer) and \`/dashboard\` (Avg. completion eyebrow, library card eyebrows). Should be pixel-identical to before.

## Out of scope

- Headline hierarchy refactor (\`text-2xl\` / \`text-3xl\` / \`text-4xl\` mixed in hero sections — separate concern, would need a typography role naming decision)
- Semantic role tokens (\`text-headline-1\`, \`text-eyebrow\`, \`text-body\`) — bigger philosophical move, can be a future PR if desired

## Phase A complete after this merge

This is the last PR of the Polish & Consistency phase. After merging:

| PR | Phase | Title |
|---|---|---|
| #173 | A.1 | refactor: GameCard with proper Card composition |
| #176 | A.2 | refactor: replace react-select with shadcn Select |
| #179 | A.3 | refactor: dashboard insight toggle uses ToggleGroup |
| #182 | A.4 | refactor: unify dashboard insight subcards |
| #184 | A.5 | refactor: typography scale + remove arbitrary text sizes |

Phase B (Visual Personality) starts after this lands.