### PR TITLE
feat: dashboard entrance orchestra + GameCard hover lift

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -42,9 +42,29 @@ export default function DashboardPage() {
     <PageContainer>
       <h1 className="sr-only">Dashboard</h1>
       <div className="grid gap-8">
-        <UserProfile user={user} stats={stats} statsLoading={statsLoading} syncLabel={syncLabel ?? "Not synced yet"} />
-        <DashboardInsights stats={stats} loading={statsLoading} />
-        <RecentGames />
+        <div
+          className="animate-in fade-in slide-in-from-bottom-4 fill-mode-both"
+          style={{ animationDuration: "500ms", animationDelay: "0ms" }}
+        >
+          <UserProfile
+            user={user}
+            stats={stats}
+            statsLoading={statsLoading}
+            syncLabel={syncLabel ?? "Not synced yet"}
+          />
+        </div>
+        <div
+          className="animate-in fade-in slide-in-from-bottom-4 fill-mode-both"
+          style={{ animationDuration: "500ms", animationDelay: "80ms" }}
+        >
+          <DashboardInsights stats={stats} loading={statsLoading} />
+        </div>
+        <div
+          className="animate-in fade-in slide-in-from-bottom-4 fill-mode-both"
+          style={{ animationDuration: "500ms", animationDelay: "160ms" }}
+        >
+          <RecentGames />
+        </div>
       </div>
     </PageContainer>
   )

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -356,22 +356,32 @@ export function LibraryOverview({
         </div>
       ) : (
         <div className="space-y-4">
-          {displayedGames.map((game: SteamGameCardModel) => (
-            <GameCard
-              key={game.id}
-              id={game.id}
-              name={game.name}
-              image={game.image}
-              playtime={game.playtime}
-              achievements={game.achievements}
-              achievementsLoading={achievementsLoading}
-              href={`/game/${game.id}`}
-              serverTotal={game.totalAchievements}
-              serverUnlocked={game.unlockedAchievements}
-              serverPerfect={game.completed}
-              onHide={handleHideGame}
-            />
-          ))}
+          {displayedGames.map((game: SteamGameCardModel, i: number) => {
+            // Cap the entrance stagger to the first 12 cards — beyond that
+            // the animation cost on big libraries outweighs the polish.
+            const animateEntrance = i < 12
+            return (
+              <div
+                key={game.id}
+                className={animateEntrance ? "animate-in fade-in slide-in-from-bottom-2 fill-mode-both" : undefined}
+                style={animateEntrance ? { animationDelay: `${i * 25}ms`, animationDuration: "350ms" } : undefined}
+              >
+                <GameCard
+                  id={game.id}
+                  name={game.name}
+                  image={game.image}
+                  playtime={game.playtime}
+                  achievements={game.achievements}
+                  achievementsLoading={achievementsLoading}
+                  href={`/game/${game.id}`}
+                  serverTotal={game.totalAchievements}
+                  serverUnlocked={game.unlockedAchievements}
+                  serverPerfect={game.completed}
+                  onHide={handleHideGame}
+                />
+              </div>
+            )
+          })}
           {hasMore ? (
             <div ref={sentinelRef} className="h-1" />
           ) : filteredCount > PAGE_SIZE ? (

--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -133,7 +133,7 @@ export function GameCard({
     <Card
       data-game-id={id}
       className={cn(
-        "group relative gap-0 overflow-hidden rounded-lg px-4 py-4 shadow-none backdrop-blur-none transition-all duration-300",
+        "group relative gap-0 overflow-hidden rounded-lg px-4 py-4 shadow-none backdrop-blur-none transition-all duration-300 hover:-translate-y-0.5",
         isCompleted
           ? "bg-success/10 hover:border-success/40"
           : "bg-surface-1 hover:border-accent/45 hover:bg-surface-2",


### PR DESCRIPTION
Closes #187

Second PR of **Frontend Refresh — Phase B (Visual Personality)**.

The frontend-design skill recommends focusing on **one well-orchestrated page load** rather than scattering micro-interactions. This PR adds exactly that, plus two minimal tactile touches.

## Changes

### 1. Dashboard page-load orchestra 🎬

The 3 top-level children of \`/dashboard\` now wrap in \`animate-in fade-in slide-in-from-bottom-4\` with a staggered delay:
- \`UserProfile\` — 0ms
- \`DashboardInsights\` — 80ms
- \`RecentGames\` — 160ms

The chart cards inside \`DashboardInsights\` already have their own internal stagger from B.1 (legend rows + chart animation), so the cascade nests naturally: dashboard sections → chart bars/legend rows.

### 2. GameCard hover lift

Add \`hover:-translate-y-0.5\` to the \`Card\` wrapper in \`components/ui/game-card.tsx\`. Same gesture vocabulary as \`card-grid.tsx\`, cohesive with the existing \`hover:border-accent/45\` and \`hover:bg-surface-2\` transitions.

### 3. Library grid entrance stagger (capped)

The first 12 cards in the \`/games\` library list wrap in a div with \`animate-in fade-in slide-in-from-bottom-2\` and a 25ms stagger. Beyond 12, no animation — to avoid penalizing libraries with hundreds of games (animation cost outweighs polish).

## What's NOT here (intentional restraint)

- Page transitions between routes
- Custom cursor
- Parallax / scroll-triggered animations
- Hover scale on every clickable element

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 44 files / 395 tests passing (no test changes; tests check text/ARIA only)
- [x] \`pnpm build\` clean
- [x] \`pnpm dev\` smoke test — \`/dashboard\` and \`/games\` return 200, dev output clean
- [ ] **Visual verification before merge**:
  - Cold-load \`/dashboard\` — watch the 3 sections cascade in (~500ms total, ending around when the chart legend rows finish)
  - Hover any \`GameCard\` in \`/games\` or \`/dashboard\` — should lift ~2px with the existing border/bg transitions
  - On \`/games\`, apply a filter (e.g., Played: Played) and watch the first 12 cards fade in with stagger