### PR TITLE
feat: hero progress-orbits illustration on landing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,70 @@
 
 import { useEffect } from "react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Gamepad2, AlertCircle, Trophy, BarChart3, Target } from "lucide-react"
+import { AlertCircle, Trophy, BarChart3, Target } from "lucide-react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { useCurrentUser } from "@/hooks/use-current-user"
+
+// Hero illustration: three offset progress rings (90% / 60% / 25%) using
+// the project's chart color tokens. Visualizes the app's purpose
+// (achievement completion tracking) with the same palette users see on
+// the dashboard donut/bar charts after sign-in.
+//
+// Stroke-dasharray math: dash = circumference * percent, gap = remainder.
+// Circumference = 2 * π * r — values rounded.
+function HeroOrbits() {
+  return (
+    <div className="relative mx-auto h-32 w-32">
+      <div className="bg-accent/15 absolute inset-2 rounded-full blur-2xl" />
+      <svg viewBox="0 0 200 200" className="relative h-32 w-32" aria-hidden="true">
+        {/* Outer ring — chart-1 (cyan), 90% complete */}
+        <circle cx="100" cy="100" r="78" fill="none" className="stroke-chart-1/20" strokeWidth="1.5" />
+        <circle
+          cx="100"
+          cy="100"
+          r="78"
+          fill="none"
+          className="stroke-chart-1"
+          strokeWidth="2.5"
+          strokeDasharray="441 49"
+          strokeLinecap="round"
+          transform="rotate(-90 100 100)"
+        />
+
+        {/* Mid ring — chart-2 (mint), 60%, slightly offset */}
+        <circle cx="92" cy="105" r="58" fill="none" className="stroke-chart-2/20" strokeWidth="1.5" />
+        <circle
+          cx="92"
+          cy="105"
+          r="58"
+          fill="none"
+          className="stroke-chart-2"
+          strokeWidth="2.5"
+          strokeDasharray="219 146"
+          strokeLinecap="round"
+          transform="rotate(-30 92 105)"
+        />
+
+        {/* Inner ring — chart-3 (gold), 25%, more offset */}
+        <circle cx="108" cy="92" r="38" fill="none" className="stroke-chart-3/20" strokeWidth="1.5" />
+        <circle
+          cx="108"
+          cy="92"
+          r="38"
+          fill="none"
+          className="stroke-chart-3"
+          strokeWidth="2.5"
+          strokeDasharray="60 179"
+          strokeLinecap="round"
+          transform="rotate(45 108 92)"
+        />
+
+        {/* Center pulsing dot */}
+        <circle cx="100" cy="100" r="5" className="fill-accent animate-pulse" />
+      </svg>
+    </div>
+  )
+}
 
 export default function HomePage() {
   const searchParams = useSearchParams()
@@ -25,10 +86,8 @@ export default function HomePage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4 py-16">
       <div className="w-full max-w-md space-y-10 text-center">
-        <div className="space-y-5">
-          <div className="bg-accent/15 text-accent border-surface-4 mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border shadow-[0_0_40px_-12px_rgba(88,198,255,0.5)]">
-            <Gamepad2 className="h-7 w-7" />
-          </div>
+        <div className="space-y-6">
+          <HeroOrbits />
           <div className="space-y-2">
             <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Steam Backlog Hunter</h1>
             <p className="text-muted-foreground mx-auto max-w-sm text-base">


### PR DESCRIPTION
Closes #189

Third PR of **Frontend Refresh — Phase B (Visual Personality)**.

## Summary

Replace the basic \`Gamepad2\` icon-in-a-box with a custom inline SVG: **three asymmetrically offset progress rings** that visualize the app's purpose (achievement completion).

## Concept

Each ring uses a different chart color token — \`chart-1\` cyan, \`chart-2\` mint, \`chart-3\` gold — the same palette users will see on the dashboard donut/bar charts after sign-in. Visual continuity from landing → dashboard.

The rings are partially filled via \`stroke-dasharray\` to suggest progress at three levels:
- Outer: 90% (cyan)
- Mid: 60% (mint)
- Inner: 25% (gold)

The rings are **asymmetrically offset** (centers at different coords, not concentric) per the frontend-design skill's recommendation: *"Asymmetry. Overlap. Diagonal flow."*

A central pulsing dot anchors the composition (\`animate-pulse\`). A blurred accent glow sits behind the SVG for atmosphere.

## Why this concept

- **Conceptually grounded** — completion rings = the app's purpose
- **Cohesive** — reuses \`chart-1/2/3\` tokens, no new colors
- **Refined, not maximalist** — matches the project's direction
- **Pure inline SVG** — ~50 lines, no new dependencies
- **Accessible** — SVG is \`aria-hidden\`, \`<h1>\` carries the page identity

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 44 files / 395 tests passing (no test changes; landing has no behavioral tests)
- [x] \`pnpm build\` clean
- [x] \`pnpm dev\` smoke — \`/\` returns 200
- [x] **HTML inspection**: confirmed \`stroke-chart-1\`, \`stroke-chart-2\`, \`stroke-chart-3\`, and \`fill-accent\` all appear in the rendered markup of \`/\`
- [ ] **Visual verification before merge** — open \`/\` and judge:
  - Do the asymmetric rings land or feel awkward?
  - Are the chart colors recognizable + cohesive?
  - Is the center pulse subtle or distracting?
  - Stroke widths / radii / opacities — anything you want me to dial in?

This is the most "design-decision" PR of the series — easiest to iterate before merge if anything feels off.

## Out of scope

- Background changes to globals.css body
- Dashboard personality moment (B.4 — separate PR)
- Hero typography refactor (mixed text-3xl/text-4xl scales)