### PR TITLE
feat: dashboard CompletionRing — animated focal point

### DIFF
--- a/components/dashboard/completion-ring.tsx
+++ b/components/dashboard/completion-ring.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useEffect, useId, useState } from "react"
+
+import { AnimatedNumber } from "@/components/ui/animated-number"
+
+interface CompletionRingProps {
+  percent: number
+  size?: number
+}
+
+// Animated circular progress ring for the dashboard hero stat. The dasharray
+// transitions from 0 to the target percent on mount, creating a "filling up"
+// effect that anchors the dashboard's first visual moment.
+export function CompletionRing({ percent, size = 96 }: CompletionRingProps) {
+  // Tick after mount so the CSS transition runs from 0 → target.
+  const [animatedPercent, setAnimatedPercent] = useState(0)
+  useEffect(() => {
+    const t = setTimeout(() => setAnimatedPercent(percent), 50)
+    return () => clearTimeout(t)
+  }, [percent])
+
+  const r = 42
+  const c = 2 * Math.PI * r
+  const filled = (animatedPercent / 100) * c
+  const gap = c - filled
+
+  // Unique gradient id per instance to avoid collisions if the component is
+  // rendered more than once on the same page.
+  const uid = useId()
+  const gradId = `completion-ring-grad-${uid}`
+
+  return (
+    <div className="relative inline-flex" style={{ width: size, height: size }}>
+      <svg viewBox="0 0 100 100" className="absolute inset-0 -rotate-90" aria-hidden="true">
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--color-accent)" stopOpacity="0.95" />
+            <stop offset="100%" stopColor="var(--color-accent)" stopOpacity="0.55" />
+          </linearGradient>
+        </defs>
+        {/* Track */}
+        <circle cx="50" cy="50" r={r} fill="none" className="stroke-surface-4" strokeWidth="6" />
+        {/* Progress */}
+        <circle
+          cx="50"
+          cy="50"
+          r={r}
+          fill="none"
+          stroke={`url(#${gradId})`}
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeDasharray={`${filled} ${gap}`}
+          style={{ transition: "stroke-dasharray 1.2s cubic-bezier(0.22, 1, 0.36, 1)" }}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-foreground inline-flex items-baseline text-2xl font-semibold tracking-tight">
+          <AnimatedNumber value={Math.round(percent)} />
+          <span className="text-muted-foreground ml-0.5 text-sm">%</span>
+        </span>
+        <span className="text-muted-foreground text-2xs tracking-eyebrow mt-0.5 font-semibold uppercase">Avg</span>
+      </div>
+    </div>
+  )
+}

--- a/components/dashboard/user-profile.tsx
+++ b/components/dashboard/user-profile.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { AnimatedNumber } from "@/components/ui/animated-number"
+import { CompletionRing } from "@/components/dashboard/completion-ring"
 import { AlertTriangle, ExternalLink } from "lucide-react"
 import type { SteamUser } from "@/lib/auth"
 import type { SteamStatsResponse } from "@/lib/types/steam"
@@ -252,15 +253,7 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
               </div>
             </div>
           </CardTitle>
-          {!statsLoading && stats && (
-            <div className="text-right">
-              <p className="text-muted-foreground text-2xs tracking-eyebrow font-semibold uppercase">Avg. completion</p>
-              <p className="mt-1 flex items-baseline justify-end text-3xl font-semibold tracking-tight">
-                <AnimatedNumber value={stats.averageCompletion} />
-                <span className="text-muted-foreground ml-1.5 self-center text-lg">%</span>
-              </p>
-            </div>
-          )}
+          {!statsLoading && stats && <CompletionRing percent={stats.averageCompletion} />}
         </div>
       </CardHeader>
 

--- a/test/user-profile.test.tsx
+++ b/test/user-profile.test.tsx
@@ -65,7 +65,9 @@ describe("UserProfile", () => {
 
   it("shows average completion when stats are available", () => {
     render(<UserProfile user={baseUser} stats={baseStats} />)
-    expect(screen.getByText("Avg. completion")).toBeInTheDocument()
+    // The avg-completion ring renders "Avg" as a compact eyebrow label
+    // alongside the percentage value inside the SVG ring.
+    expect(screen.getByText("Avg")).toBeInTheDocument()
     expect(screen.getByText("77")).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Closes #191

**Final PR of Frontend Refresh — Phase B (Visual Personality).**

## Summary

Replace the plain "Avg. completion" right-aligned text block in \`UserProfile\` with a **\`CompletionRing\`** — an SVG circular progress ring that animates from 0 to the user's actual \`averageCompletion %\` on mount over 1.2s.

The percentage number is rendered inside the ring via the existing \`AnimatedNumber\` count-up component, so the **number counts up while the ring fills** — both animations run in sync, giving the dashboard its first delight moment.

## Why this is the right "moment"

The audit asked for a wow moment. The frontend-design skill asks "what's the one thing someone will remember?" My answer: the personal completion ring.

- **Real data the user cares about**: their personal completion %
- **Visual narrative continuity**: B.3's landing hero shows abstract progress orbits → this PR shows the **real** ring with the user's number. Same visual language, real meaning.
- **Anchored, not scattered**: one focal point at the top-right of the page, not tinkering with multiple secondary elements
- **Self-contained**: new \`components/dashboard/completion-ring.tsx\` client component + 5-line edit in \`user-profile.tsx\`
- \`user-profile.tsx\` stays a server component (the new client component is the leaf)

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 44 files / 395 tests passing (one assertion in \`user-profile.test.tsx\` flipped from \`"Avg. completion"\` → \`"Avg"\` because the ring label is shorter)
- [x] \`pnpm build\` clean
- [x] \`pnpm dev\` smoke — \`/dashboard\` returns 200
- [ ] **Visual verification before merge** — load \`/dashboard\` cold:
  - The ring should appear empty initially and fill from 0 to the user's percent over ~1.2s
  - The number inside should count up from 0 to the same value, syncing with the ring fill
  - The accent gradient (top brighter, bottom dimmer) should match the chart gradients from B.1
  - Hover/focus states are unchanged

## Phase B complete after this merge

| PR | Phase | Title |
|---|---|---|
| #186 | B.1 | branded chart styling for dashboard insights |
| #188 | B.2 | dashboard entrance orchestra + GameCard hover lift |
| #190 | B.3 | hero progress-orbits illustration on landing |
| #192 | B.4 | dashboard CompletionRing — animated focal point |

Phase C (bold redesign exploration) starts after this lands — local-only, no commits, you'll preview alternatives before deciding.

## Out of scope

- Touching the rest of \`user-profile.tsx\` layout
- Other dashboard cards
- Refactors tracked in #168, #178, #181