### PR TITLE
chore: gitignore next-env.d.ts to stop dev/build drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ node_modules/
 # Next.js build output
 .next/
 
+# Next.js generates next-env.d.ts with different content depending on whether
+# it ran in dev or build mode (.next/dev/types/... vs .next/types/...), so
+# tracking it causes permanent git status drift. Ignoring is safe because
+# pnpm dev/build/typecheck all regenerate it automatically.
+next-env.d.ts
+
 # Local environment variables
 .env*
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #174

## Summary

- \`git rm next-env.d.ts\` (delete from tracking)
- Add \`next-env.d.ts\` to \`.gitignore\`

## Why

Next 16 emits **different import paths** in \`next-env.d.ts\` depending on dev vs build mode:

\`\`\`
pnpm dev       → import "./.next/dev/types/routes.d.ts"
pnpm build     → import "./.next/types/routes.d.ts"
pnpm typecheck → import "./.next/types/routes.d.ts"
\`\`\`

Switching between \`pnpm dev\` and \`pnpm build\` permanently dirties \`git status\` until you run the opposite. PR #162 fixed the original Prettier-reformat loop; this finishes the job.

The file literally says \`// This file should not be edited\` — that's a strong hint it was never meant to be tracked. Treating it as fully generated (and ignored) matches Next's intent.

## Why it's safe

All paths that need the file regenerate it automatically:

| Command | Behavior |
|---|---|
| \`pnpm typecheck\` | runs \`next typegen && tsc --noEmit\` — regenerates first |
| \`pnpm dev\` | Next regenerates on start |
| \`pnpm build\` | Next regenerates at build time |
| \`pnpm test\` | vitest doesn't need it |

CI runs \`pnpm lint\` (which includes typecheck) before \`pnpm test\` and \`pnpm build\`, so the file is always present when required.

\`.oxfmtrc.json\` keeps \`next-env.d.ts\` in \`ignorePatterns\` as a belt-and-braces measure for the local file that still exists in the working tree, just untracked.

## Test plan

- [x] \`git rm\` the file, then \`rm -rf .next\` (clear stale dev-mode type cache from Phase C spike)
- [x] \`pnpm typecheck\` — \`next typegen\` regenerates the file, tsc passes
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 44 files / 395 tests passing
- [x] \`pnpm build\` — clean, file regenerated in build-mode form
- [x] \`git status\` after \`pnpm build\` — clean (no drift, file is gitignored)