### PR TITLE
refactor: migrate game/[id] and extras/[id] toggles to shadcn Tabs

### DIFF
--- a/app/extras/[id]/page.tsx
+++ b/app/extras/[id]/page.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from "@/components/ui/empty-state"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { getSteamHeaderImageUrl } from "@/lib/steam-api"
 import { formatPlaytime } from "@/lib/utils"
 import type { SteamAchievementView } from "@/lib/types/steam"
@@ -111,13 +112,58 @@ export default function ExtraGameDetailPage() {
   if (loadingUser) return <LoadingMessage />
   if (!user) return null
 
-  const displayList = activeTab === "pending" ? pending : unlocked
-
   let progressColor = "bg-danger"
   if (percent >= 80) progressColor = "bg-success"
   else if (percent >= 40) progressColor = "bg-warning"
 
   const gameName = game?.name || `App #${appId}`
+
+  // Shared renderer for both tab panels. Extras doesn't need a loading/error
+  // branch here because total > 0 gates the whole Tabs block.
+  const renderAchievementPanel = (list: SteamAchievementView[], emptyMessage: string) => {
+    if (list.length === 0) {
+      return <EmptyState message={emptyMessage} />
+    }
+    return (
+      <ul className="grid gap-3">
+        {list.map((ach) => (
+          <li
+            key={ach.apiname}
+            className={`border-surface-4 flex items-center gap-4 rounded-lg border p-4 transition-colors ${
+              ach.achieved ? "bg-surface-1" : "bg-white/2 opacity-70"
+            }`}
+          >
+            <img
+              src={(ach.achieved ? ach.icon : ach.icongray) || ach.icon || "/placeholder-icon.svg"}
+              alt={`Icon for ${ach.displayName} achievement`}
+              className="h-12 w-12 rounded-lg"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-semibold">{ach.displayName}</div>
+              {ach.description && <div className="text-muted-foreground text-sm">{ach.description}</div>}
+            </div>
+            {ach.achieved && ach.unlocktime ? (
+              <div className="text-muted-foreground text-right text-xs">
+                <div>
+                  {new Date(ach.unlocktime * 1000).toLocaleDateString(undefined, {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </div>
+                <div>
+                  {new Date(ach.unlocktime * 1000).toLocaleTimeString(undefined, {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    )
+  }
 
   return (
     <div className="from-background to-muted min-h-screen bg-gradient-to-br">
@@ -195,86 +241,24 @@ export default function ExtraGameDetailPage() {
             </div>
 
             {total > 0 && (
-              <>
-                <div className="mb-4">
-                  <div className="bg-card/80 border-surface-4 inline-flex gap-2 rounded-lg border p-2">
-                    <Button
-                      variant={activeTab === "pending" ? "default" : "ghost"}
-                      size="sm"
-                      onClick={() => setActiveTab("pending")}
-                      className={
-                        activeTab === "pending"
-                          ? "bg-accent hover:bg-accent/90 text-foreground"
-                          : "text-muted-foreground hover:text-foreground hover:bg-surface-3"
-                      }
-                    >
-                      <Lock className="h-4 w-4" />
-                      Pending ({pending.length})
-                    </Button>
-                    <Button
-                      variant={activeTab === "unlocked" ? "default" : "ghost"}
-                      size="sm"
-                      onClick={() => setActiveTab("unlocked")}
-                      className={
-                        activeTab === "unlocked"
-                          ? "bg-accent hover:bg-accent/90 text-foreground"
-                          : "text-muted-foreground hover:text-foreground hover:bg-surface-3"
-                      }
-                    >
-                      <Trophy className="h-4 w-4" />
-                      Unlocked ({unlocked.length})
-                    </Button>
-                  </div>
-                </div>
-
-                {displayList.length === 0 ? (
-                  <EmptyState
-                    message={
-                      activeTab === "pending"
-                        ? "No pending achievements for this game!"
-                        : "No unlocked achievements yet."
-                    }
-                  />
-                ) : (
-                  <ul className="grid gap-3">
-                    {displayList.map((ach) => (
-                      <li
-                        key={ach.apiname}
-                        className={`border-surface-4 flex items-center gap-4 rounded-lg border p-4 transition-colors ${
-                          ach.achieved ? "bg-surface-1" : "bg-white/2 opacity-70"
-                        }`}
-                      >
-                        <img
-                          src={(ach.achieved ? ach.icon : ach.icongray) || ach.icon || "/placeholder-icon.svg"}
-                          alt={`Icon for ${ach.displayName} achievement`}
-                          className="h-12 w-12 rounded-lg"
-                        />
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate font-semibold">{ach.displayName}</div>
-                          {ach.description && <div className="text-muted-foreground text-sm">{ach.description}</div>}
-                        </div>
-                        {ach.achieved && ach.unlocktime ? (
-                          <div className="text-muted-foreground text-right text-xs">
-                            <div>
-                              {new Date(ach.unlocktime * 1000).toLocaleDateString(undefined, {
-                                year: "numeric",
-                                month: "short",
-                                day: "numeric",
-                              })}
-                            </div>
-                            <div>
-                              {new Date(ach.unlocktime * 1000).toLocaleTimeString(undefined, {
-                                hour: "2-digit",
-                                minute: "2-digit",
-                              })}
-                            </div>
-                          </div>
-                        ) : null}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </>
+              <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as AchievementTab)}>
+                <TabsList>
+                  <TabsTrigger value="pending">
+                    <Lock className="h-4 w-4" />
+                    Pending ({pending.length})
+                  </TabsTrigger>
+                  <TabsTrigger value="unlocked">
+                    <Trophy className="h-4 w-4" />
+                    Unlocked ({unlocked.length})
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent value="pending">
+                  {renderAchievementPanel(pending, "No pending achievements for this game!")}
+                </TabsContent>
+                <TabsContent value="unlocked">
+                  {renderAchievementPanel(unlocked, "No unlocked achievements yet.")}
+                </TabsContent>
+              </Tabs>
             )}
 
             {total === 0 && !loading && (

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -12,6 +12,7 @@ import { usePageTitle } from "@/components/ui/page-title-context"
 import type { SteamAchievementView } from "@/lib/types/steam"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ExternalLink, Lock, RefreshCw, Trophy } from "lucide-react"
 import { formatPlaytime } from "@/lib/utils"
 
@@ -99,11 +100,75 @@ export default function GameDetailPage() {
     return null
   }
 
-  const displayList = activeTab === "pending" ? pending : unlocked
-
   let progressColor = "bg-danger"
   if (percent >= 80) progressColor = "bg-success"
   else if (percent >= 40) progressColor = "bg-warning"
+
+  // Shared panel renderer so the loading/error/empty/list logic lives in one
+  // place across both tabs. Radix only mounts the active panel, but the
+  // helper keeps the TabsContent blocks compact and DRY.
+  const renderAchievementPanel = (list: SteamAchievementView[], emptyMessage: string) => {
+    if (loadingAchievements) {
+      return (
+        <div className="grid gap-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="bg-card flex items-center gap-4 rounded p-4 shadow">
+              <Skeleton className="h-12 w-12 rounded" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )
+    }
+    if (errorAchievements && !syncedAchievements) {
+      return <EmptyState message="Could not load achievements." />
+    }
+    if (list.length === 0) {
+      return <EmptyState message={emptyMessage} />
+    }
+    return (
+      <ul className="grid gap-3">
+        {list.map((ach) => (
+          <li
+            key={ach.apiname}
+            className={`border-surface-4 flex items-center gap-4 rounded-lg border p-4 transition-colors ${
+              ach.achieved ? "bg-surface-1" : "bg-white/2 opacity-70"
+            }`}
+          >
+            <img
+              src={(ach.achieved ? ach.icon : ach.icongray) || ach.icon || "/placeholder-icon.svg"}
+              alt={`Icon for ${ach.displayName} achievement`}
+              className="h-12 w-12 rounded-lg"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-semibold">{ach.displayName}</div>
+              {ach.description && <div className="text-muted-foreground text-sm">{ach.description}</div>}
+            </div>
+            {ach.achieved && ach.unlocktime ? (
+              <div className="text-muted-foreground text-right text-xs">
+                <div>
+                  {new Date(ach.unlocktime * 1000).toLocaleDateString(undefined, {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </div>
+                <div>
+                  {new Date(ach.unlocktime * 1000).toLocaleTimeString(undefined, {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </div>
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    )
+  }
 
   return (
     <div className="from-background to-muted min-h-screen bg-gradient-to-br">
@@ -161,100 +226,24 @@ export default function GameDetailPage() {
         )}
 
         {game && (
-          <>
-            <div className="mb-4">
-              <div className="bg-card/80 border-surface-4 inline-flex gap-2 rounded-lg border p-2">
-                <Button
-                  variant={activeTab === "pending" ? "default" : "ghost"}
-                  size="sm"
-                  onClick={() => setActiveTab("pending")}
-                  className={
-                    activeTab === "pending"
-                      ? "bg-accent hover:bg-accent/90 text-foreground"
-                      : "text-muted-foreground hover:text-foreground hover:bg-surface-3"
-                  }
-                >
-                  <Lock className="h-4 w-4" />
-                  Pending{!loadingAchievements && ` (${pending.length})`}
-                </Button>
-                <Button
-                  variant={activeTab === "unlocked" ? "default" : "ghost"}
-                  size="sm"
-                  onClick={() => setActiveTab("unlocked")}
-                  className={
-                    activeTab === "unlocked"
-                      ? "bg-accent hover:bg-accent/90 text-foreground"
-                      : "text-muted-foreground hover:text-foreground hover:bg-surface-3"
-                  }
-                >
-                  <Trophy className="h-4 w-4" />
-                  Unlocked{!loadingAchievements && ` (${unlocked.length})`}
-                </Button>
-              </div>
-            </div>
-
-            {loadingAchievements ? (
-              <div className="grid gap-4">
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <div key={i} className="bg-card flex items-center gap-4 rounded p-4 shadow">
-                    <Skeleton className="h-12 w-12 rounded" />
-                    <div className="min-w-0 flex-1 space-y-2">
-                      <Skeleton className="h-4 w-32" />
-                      <Skeleton className="h-3 w-24" />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : errorAchievements && !syncedAchievements ? (
-              <EmptyState message="Could not load achievements." />
-            ) : displayList.length === 0 ? (
-              <EmptyState
-                message={
-                  activeTab === "pending"
-                    ? "You have no pending achievements for this game!"
-                    : "No unlocked achievements yet."
-                }
-              />
-            ) : (
-              <ul className="grid gap-3">
-                {displayList.map((ach) => (
-                  <li
-                    key={ach.apiname}
-                    className={`border-surface-4 flex items-center gap-4 rounded-lg border p-4 transition-colors ${
-                      ach.achieved ? "bg-surface-1" : "bg-white/2 opacity-70"
-                    }`}
-                  >
-                    <img
-                      src={(ach.achieved ? ach.icon : ach.icongray) || ach.icon || "/placeholder-icon.svg"}
-                      alt={`Icon for ${ach.displayName} achievement`}
-                      className="h-12 w-12 rounded-lg"
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-semibold">{ach.displayName}</div>
-                      {ach.description && <div className="text-muted-foreground text-sm">{ach.description}</div>}
-                    </div>
-                    {ach.achieved && ach.unlocktime ? (
-                      <div className="text-muted-foreground text-right text-xs">
-                        <div>
-                          {new Date(ach.unlocktime * 1000).toLocaleDateString(undefined, {
-                            year: "numeric",
-                            month: "short",
-                            day: "numeric",
-                          })}
-                        </div>
-                        <div>
-                          {new Date(ach.unlocktime * 1000).toLocaleTimeString(undefined, {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })}
-                        </div>
-                      </div>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </>
+          <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as AchievementTab)}>
+            <TabsList>
+              <TabsTrigger value="pending">
+                <Lock className="h-4 w-4" />
+                Pending{!loadingAchievements && ` (${pending.length})`}
+              </TabsTrigger>
+              <TabsTrigger value="unlocked">
+                <Trophy className="h-4 w-4" />
+                Unlocked{!loadingAchievements && ` (${unlocked.length})`}
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="pending">
+              {renderAchievementPanel(pending, "You have no pending achievements for this game!")}
+            </TabsContent>
+            <TabsContent value="unlocked">
+              {renderAchievementPanel(unlocked, "No unlocked achievements yet.")}
+            </TabsContent>
+          </Tabs>
         )}
       </div>
     </div>

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({ className, orientation = "horizontal", ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content data-slot="tabs-content" className={cn("flex-1 outline-none", className)} {...props} />
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }


### PR DESCRIPTION
Closes #178

Both pages had the same ternary-button toggle pattern for switching between "Pending" and "Unlocked" achievement lists — the same pattern #177 replaced in \`dashboard-insights.tsx\`. The dashboard case was a genuine segmented metric switch (\`ToggleGroup\` / radiogroup). **These two are semantically tabs** (switching between distinct lists of content), so shadcn \`Tabs\` is the correct primitive.

## Changes

### 1. Install the component

\`pnpm dlx shadcn@latest add tabs\` — creates \`components/ui/tabs.tsx\`. **Zero new deps** (Radix was already installed via \`ToggleGroup\` in #179).

### 2. \`app/game/[id]/page.tsx\`

- Extract a local \`renderAchievementPanel(list, emptyMessage)\` helper that owns the loading / error / empty / list decision tree, so both \`TabsContent\` blocks stay compact and DRY
- Replace the toggle \`<div>\` + content block with \`Tabs > TabsList > TabsTrigger\` + two \`TabsContent\`s
- Drop the \`displayList\` variable — each \`TabsContent\` receives its own list explicitly

### 3. \`app/extras/[id]/page.tsx\`

- Same pattern. The extras variant doesn't have a loading/error branch (\`total > 0\` already gates the whole Tabs block), so the helper is simpler — just empty-state + list.

## Accessibility win

Radix \`Tabs\` gives us \`role="tablist"\` + \`role="tab"\` + \`role="tabpanel"\` with proper \`aria-selected\`, keyboard navigation (arrow keys), and focus management — **for free**. The previous implementation had two unrelated \`<button>\`s with no semantic relationship in the a11y tree.

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 44 files / 395 tests passing (no test changes needed; neither page had tests that drove the toggles)
- [x] \`pnpm build\` — clean
- [ ] **Visual verification before merge** — load \`/game/730\` (or any game with achievements) and \`/extras/{id}\`, click between Pending/Unlocked tabs, confirm:
  - Active tab indicator visible
  - Keyboard nav works (arrow keys, Enter/Space)
  - Counts in tab labels still render
  - Content swaps correctly between pending and unlocked lists

## Out of scope

- Other pages with ternary toggles (none remaining)
- #168 (already in PR #196), #174 (merged as #195), #181 (surface drift unification)