### PR TITLE
feat: extract SurfaceCard + InputFrame primitives

### DIFF
--- a/components/ui/input-frame.tsx
+++ b/components/ui/input-frame.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+// InputFrame is the bordered h-9 wrapper used to host a search-style input
+// with an optional leading icon. Catalogued as "Shape 4" in issue #181 — the
+// focus-within-border-accent pattern that repeats across the library filter
+// search box and the extras search box.
+//
+// Usage:
+//   <InputFrame>
+//     <Search className="text-muted-foreground h-4 w-4 shrink-0" />
+//     <input type="text" ... className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none" />
+//   </InputFrame>
+//
+// Layout-level concerns (flex-1, min-w-0, full-width in a grid cell, etc.)
+// stay with the caller via className — the component only owns the visual
+// identity of the frame itself.
+function InputFrame({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-frame"
+      className={cn(
+        "border-surface-4 bg-surface-1 focus-within:border-accent flex h-9 items-center gap-2 rounded-lg border px-3 transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { InputFrame }

--- a/components/ui/surface-card.tsx
+++ b/components/ui/surface-card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+// SurfaceCard consolidates the five bordered-surface shapes that were
+// previously inlined in ~15 places across the repo. The CVA variants map
+// directly to the six clusters catalogued in issue #181:
+//
+//   default       — subcard (border, p-4)
+//   row           — list row (border, px-4 py-4)
+//   empty         — empty state (border, px-6 py-10, centered text)
+//   metric        — borderless metric row (px-3 py-2.5, flex layout)
+//   admin-item    — admin item (border, px-4 py-3, flex layout)
+//
+// Hover variants handle the "accent highlight on hover" case used by
+// interactive rows (user-profile stats, clickable cards).
+//
+// Callers can still pass className for layout-level concerns that aren't
+// part of the surface identity (flex-1, min-w-0, backdrop-blur-sm, etc.).
+const surfaceCardVariants = cva("bg-surface-1 rounded-lg transition-colors", {
+  variants: {
+    variant: {
+      default: "border-surface-4 border p-4",
+      row: "border-surface-4 border px-4 py-4",
+      empty: "border-surface-4 border px-6 py-10 text-center",
+      metric: "flex items-center justify-between px-3 py-2.5",
+      "admin-item": "border-surface-4 flex items-center gap-4 border px-4 py-3",
+    },
+    hover: {
+      none: "",
+      accent: "hover:border-accent/30 hover:bg-surface-2",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    hover: "none",
+  },
+})
+
+function SurfaceCard({
+  className,
+  variant,
+  hover,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof surfaceCardVariants>) {
+  return <div data-slot="surface-card" className={cn(surfaceCardVariants({ variant, hover }), className)} {...props} />
+}
+
+export { SurfaceCard, surfaceCardVariants }


### PR DESCRIPTION
Part of #181 (phase 1 of the surface drift cleanup).

Introduce two new primitives in \`components/ui/\` that consolidate the bordered-surface patterns currently inlined in ~17 places across the repo. **This PR only creates the primitives — migrations follow in separate cluster-by-cluster PRs** (empty states, list rows, subcards, input wrappers, admin items) so each migration can be reviewed for visual fidelity in isolation.

## \`components/ui/surface-card.tsx\`

CVA-based component with five variants covering the five shapes catalogued in #181:

| Variant | Shape |
|---|---|
| \`default\` | Subcard — \`border\`, \`p-4\` |
| \`row\` | List row — \`border\`, \`px-4 py-4\` |
| \`empty\` | Empty state — \`border\`, \`px-6 py-10\`, \`text-center\` |
| \`metric\` | Metric row — borderless, \`px-3 py-2.5\`, \`flex\` |
| \`admin-item\` | Admin item — \`border\`, \`px-4 py-3\`, \`flex\` |

Separate \`hover\` prop (\`none\` | \`accent\`) for interactive variants (e.g., the clickable user-profile stat cards that highlight on hover).

\`data-slot="surface-card"\` for styling hooks, matching shadcn conventions.

Callers can still pass \`className\` for layout-level concerns (\`flex-1\`, \`min-w-0\`, \`backdrop-blur-sm\`, etc.) that aren't part of the surface identity.

## \`components/ui/input-frame.tsx\`

The bordered \`h-9\` wrapper with \`focus-within:border-accent\`, used for search-style inputs (library filter search, extras search).

Minimal API — just a \`<div>\` wrapper that forwards children and className.

## Migration plan (future PRs)

- PR 2 — empty states (4 sites)
- PR 3 — list rows (5 sites)
- PR 4 — subcards (4 sites)
- PR 5 — input wrappers + admin item + metric row (4 sites)

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 44 files / 395 tests passing (no consumers yet; primitives are just type definitions at this point)
- [x] \`pnpm build\` — clean
- No visual change — nothing calls the new primitives yet

## Out of scope

- Any migrations (deliberately)
- Replacing \`InsightChartFrame\` and \`METRIC_LEGEND_BASE\` in \`dashboard-insights.tsx\` — those are local helpers with semantic names that are worth keeping; they can optionally be updated to internally use SurfaceCard in a later PR