### PR TITLE
refactor: migrate empty-state surfaces to SurfaceCard

### DIFF
--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -10,6 +10,7 @@ import { PageContainer } from "@/components/ui/page-container"
 import { LoadingMessage } from "@/components/ui/loading-message"
 import { GameCard } from "@/components/ui/game-card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { SurfaceCard } from "@/components/ui/surface-card"
 import { getSteamHeaderImageUrl } from "@/lib/steam-api"
 
 type Tab = "extras" | "hidden"
@@ -215,12 +216,12 @@ export default function ExtrasPage() {
           </div>
         ) : tab === "extras" ? (
           filteredExtras.length === 0 ? (
-            <div className="border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center">
+            <SurfaceCard variant="empty">
               <p className="text-muted-foreground">No extras yet.</p>
               <p className="text-muted-foreground mt-1 text-sm">
                 After syncing, games Steam remembers you played but no longer own will show up here.
               </p>
-            </div>
+            </SurfaceCard>
           ) : (
             <div className="space-y-4">
               {filteredExtras.map((game) => (
@@ -243,12 +244,12 @@ export default function ExtrasPage() {
             </div>
           )
         ) : filteredHidden.length === 0 ? (
-          <div className="border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center">
+          <SurfaceCard variant="empty">
             <p className="text-muted-foreground">No hidden games.</p>
             <p className="text-muted-foreground mt-1 text-sm">
               Games you hide from the library or extras will appear here so you can restore them.
             </p>
-          </div>
+          </SurfaceCard>
         ) : (
           <div className="space-y-4">
             {filteredHidden.map((game) => (

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -6,6 +6,7 @@ import { Trophy, PieChart, ArrowUpDown, Play, Search } from "lucide-react"
 import { GameCard } from "@/components/ui/game-card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
+import { SurfaceCard } from "@/components/ui/surface-card"
 import { useSteamAchievementsBatch, useSteamGames } from "@/hooks/use-steam-data"
 import { getSteamHeaderImageUrl } from "@/lib/steam-api"
 import { buildGamesWithStats, mapOwnedGamesToGameCards, sortGames } from "@/lib/games-mapping"
@@ -348,12 +349,12 @@ export function LibraryOverview({
       ) : error ? (
         <p className="text-destructive py-8 text-center">{error}</p>
       ) : visibleGames.length === 0 ? (
-        <div className="border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center">
+        <SurfaceCard variant="empty">
           <p className="text-muted-foreground">No games match the current filters.</p>
           <p className="text-muted-foreground mt-1 text-sm">
             Hit the Sync button in the header to load your Steam data.
           </p>
-        </div>
+        </SurfaceCard>
       ) : (
         <div className="space-y-4">
           {displayedGames.map((game: SteamGameCardModel, i: number) => {

--- a/components/dashboard/recent-games.tsx
+++ b/components/dashboard/recent-games.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Play } from "lucide-react"
 import { GameCard } from "@/components/ui/game-card"
+import { SurfaceCard } from "@/components/ui/surface-card"
 import { useSteamGames, useSteamAchievementsBatch } from "@/hooks/use-steam-data"
 import { useMemo, useState, useCallback } from "react"
 import { getSteamHeaderImageUrl } from "@/lib/steam-api"
@@ -99,12 +100,12 @@ export function RecentGames() {
       <CardContent>
         <div className="space-y-4">
           {visibleGames.length === 0 ? (
-            <div className="border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center">
+            <SurfaceCard variant="empty">
               <p className="text-muted-foreground">No recently played games.</p>
               <p className="text-muted-foreground mt-1 text-sm">
                 Hit the Sync button in the header to load your Steam data.
               </p>
-            </div>
+            </SurfaceCard>
           ) : (
             visibleGames.map((game) => {
               const achievements = achievementsMap[game.appid] || []


### PR DESCRIPTION
Part of #181 (phase 2 — empty states cluster).

Replace 4 inline empty-state cards with \`<SurfaceCard variant="empty">\` from the new primitive introduced in #198. All 4 sites used the **exact same class string**:

\`\`\`
border-surface-4 bg-surface-1 rounded-lg border px-6 py-10 text-center
\`\`\`

## Migrated sites

| File | Message |
|---|---|
| \`app/extras/page.tsx\` | "No extras yet" |
| \`app/extras/page.tsx\` | "No hidden games" |
| \`components/dashboard/library-overview.tsx\` | "No games match the current filters" |
| \`components/dashboard/recent-games.tsx\` | "No recently played games" |

## Zero visual change

\`SurfaceCard\` with \`variant="empty"\` produces the exact same CSS classes as the inline version. Grep for \`px-6 py-10 text-center\` across the repo now returns **only** the primitive's own definition.

## Test plan

- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 44 files / 395 tests passing
- [x] \`pnpm build\` — clean
- [ ] Visual spot-check before merge — easiest way to verify:
  - \`/extras\` with a fresh account (nothing synced) → should show "No extras yet" in the same bordered card
  - \`/games\` with all filters set so nothing matches → should show "No games match" in the same bordered card
  - \`/dashboard\` with no recent games → "No recently played games"

## Remaining clusters (future PRs in this series)

- List rows (5 sites)
- Subcards (4 sites)
- Input wrappers (2 sites)
- Admin item (1 site)
- Metric row (1 site)