### PR TITLE
refactor: migrate list-row surfaces to SurfaceCard

### DIFF
--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -201,17 +201,14 @@ export default function ExtrasPage() {
         ) : loading ? (
           <div className="space-y-4">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="border-surface-4 bg-surface-1 flex items-stretch gap-4 rounded-lg border px-4 py-4"
-              >
+              <SurfaceCard key={i} variant="row" className="flex items-stretch gap-4">
                 <Skeleton className="h-[5.9rem] w-48 rounded-2xl" />
                 <div className="min-w-0 flex-1 space-y-2">
                   <Skeleton className="h-5 w-44" />
                   <Skeleton className="h-4 w-24" />
                   <Skeleton className="h-2 w-full rounded-full" />
                 </div>
-              </div>
+              </SurfaceCard>
             ))}
           </div>
         ) : tab === "extras" ? (

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -333,7 +333,7 @@ export function LibraryOverview({
       {listLoading ? (
         <div className="space-y-4">
           {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="border-surface-4 bg-surface-1 flex items-stretch gap-4 rounded-lg border px-4 py-4">
+            <SurfaceCard key={i} variant="row" className="flex items-stretch gap-4">
               <Skeleton className="h-[5.9rem] w-48 rounded-2xl" />
               <div className="min-w-0 flex-1 space-y-2">
                 <Skeleton className="h-5 w-44" />
@@ -343,7 +343,7 @@ export function LibraryOverview({
                 </div>
                 <Skeleton className="h-2 w-full rounded-full" />
               </div>
-            </div>
+            </SurfaceCard>
           ))}
         </div>
       ) : error ? (

--- a/components/dashboard/user-profile.tsx
+++ b/components/dashboard/user-profile.tsx
@@ -3,7 +3,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { AnimatedNumber } from "@/components/ui/animated-number"
 import { CompletionRing } from "@/components/dashboard/completion-ring"
+import { surfaceCardVariants } from "@/components/ui/surface-card"
 import { AlertTriangle, ExternalLink } from "lucide-react"
+import { cn } from "@/lib/utils"
 import type { SteamUser } from "@/lib/auth"
 import type { SteamStatsResponse } from "@/lib/types/steam"
 
@@ -302,7 +304,7 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
               <Link
                 key={item.label}
                 href={item.href}
-                className="border-surface-4 bg-surface-1 hover:border-accent/30 hover:bg-surface-2 rounded-lg border px-4 py-4 backdrop-blur-sm transition-colors"
+                className={cn(surfaceCardVariants({ variant: "row", hover: "accent" }), "backdrop-blur-sm")}
               >
                 <p className="text-muted-foreground text-2xs tracking-eyebrow font-semibold uppercase">{item.label}</p>
                 <p className="mt-2 text-2xl font-semibold tracking-tight">

--- a/components/skeletons/dashboard-skeleton.tsx
+++ b/components/skeletons/dashboard-skeleton.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { PageContainer } from "@/components/ui/page-container"
+import { SurfaceCard } from "@/components/ui/surface-card"
 
 function UserProfileSkeleton() {
   return (
@@ -28,10 +29,10 @@ function UserProfileSkeleton() {
           <Skeleton className="h-9 w-32" />
           <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
             {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="border-surface-4 bg-surface-1 rounded-lg border px-4 py-4">
+              <SurfaceCard key={i} variant="row">
                 <Skeleton className="h-3 w-20" />
                 <Skeleton className="mt-3 h-7 w-12" />
-              </div>
+              </SurfaceCard>
             ))}
           </div>
         </div>

--- a/components/skeletons/library-skeleton.tsx
+++ b/components/skeletons/library-skeleton.tsx
@@ -1,9 +1,10 @@
 import { Skeleton } from "@/components/ui/skeleton"
 import { PageContainer } from "@/components/ui/page-container"
+import { SurfaceCard } from "@/components/ui/surface-card"
 
 function GameCardSkeleton() {
   return (
-    <div className="border-surface-4 bg-surface-1 flex items-stretch gap-4 rounded-lg border px-4 py-4">
+    <SurfaceCard variant="row" className="flex items-stretch gap-4">
       <Skeleton className="h-[5.9rem] w-48 rounded-2xl" />
       <div className="min-w-0 flex-1 space-y-2">
         <Skeleton className="h-5 w-44" />
@@ -13,7 +14,7 @@ function GameCardSkeleton() {
         </div>
         <Skeleton className="h-2 w-full rounded-full" />
       </div>
-    </div>
+    </SurfaceCard>
   )
 }
 


### PR DESCRIPTION
Part of #181 (phase 3 — list rows cluster).

Replace 5 inline list-row surfaces with `<SurfaceCard variant="row">` from the primitive introduced in #198.

## Migrated sites

| File | Usage |
|---|---|
| `app/extras/page.tsx` | Loading skeleton row |
| `components/dashboard/library-overview.tsx` | Loading skeleton row |
| `components/skeletons/library-skeleton.tsx` | `GameCardSkeleton` |
| `components/skeletons/dashboard-skeleton.tsx` | KPI summary card |
| `components/dashboard/user-profile.tsx` | Summary item `<Link>` |

## Special case — user-profile Link

The className was applied directly on `<Link>` elements (not on a wrapping div), so wrapping each Link in `<SurfaceCard>` would add a redundant DOM node. Instead, apply `surfaceCardVariants()` directly to Link's `className`:

```tsx
<Link className={cn(surfaceCardVariants({ variant: "row", hover: "accent" }), "backdrop-blur-sm")}>
```

Same CSS, same DOM. This is the intended use of the `surfaceCardVariants` export — giving callers access to the variant string when a wrapping component can't replace the element.

## Zero visual change

Base classes (`border-surface-4 bg-surface-1 rounded-lg border px-4 py-4`) come from the primitive. Site-specific layout classes (`flex items-stretch gap-4`, `backdrop-blur-sm`) stay with the caller via className.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 44 files / 395 tests passing
- [x] `pnpm build` — clean
- [ ] Visual spot-check before merge — easiest way to verify:
  - `/games` or `/dashboard` while loading → skeleton rows
  - `/dashboard` user profile → 4 summary stat cards with hover-accent effect
  - `/extras` while loading → skeleton rows

## Remaining clusters

- Subcards (4 sites) — PR 4
- Input wrappers + admin item + metric row (4 sites) — PR 5