### PR TITLE
refactor: migrate subcard surfaces to SurfaceCard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { SurfaceCard } from "@/components/ui/surface-card"
 import { AlertCircle, Trophy, BarChart3, Target } from "lucide-react"
 import { useSearchParams, useRouter } from "next/navigation"
 import { useCurrentUser } from "@/hooks/use-current-user"
@@ -121,21 +122,21 @@ export default function HomePage() {
         </div>
 
         <div className="grid grid-cols-3 gap-4">
-          <div className="border-surface-4 bg-surface-1 space-y-2 rounded-lg border p-4">
+          <SurfaceCard className="space-y-2">
             <Trophy className="text-accent mx-auto h-5 w-5" />
             <p className="text-foreground text-xs font-medium">Achievements</p>
             <p className="text-muted-foreground text-2xs leading-snug">Pending, unlocked, and completion per game.</p>
-          </div>
-          <div className="border-surface-4 bg-surface-1 space-y-2 rounded-lg border p-4">
+          </SurfaceCard>
+          <SurfaceCard className="space-y-2">
             <BarChart3 className="text-accent mx-auto h-5 w-5" />
             <p className="text-foreground text-xs font-medium">Analytics</p>
             <p className="text-muted-foreground text-2xs leading-snug">Playtime, perfect games, and library stats.</p>
-          </div>
-          <div className="border-surface-4 bg-surface-1 space-y-2 rounded-lg border p-4">
+          </SurfaceCard>
+          <SurfaceCard className="space-y-2">
             <Target className="text-accent mx-auto h-5 w-5" />
             <p className="text-foreground text-xs font-medium">Completion</p>
             <p className="text-muted-foreground text-2xs leading-snug">Games closest to 100% from recent play.</p>
-          </div>
+          </SurfaceCard>
         </div>
 
         <p className="text-muted-foreground text-xs">Not affiliated with Valve Corporation.</p>

--- a/components/skeletons/dashboard-skeleton.tsx
+++ b/components/skeletons/dashboard-skeleton.tsx
@@ -52,11 +52,11 @@ function InsightCardSkeleton() {
       </CardHeader>
       <CardContent>
         <div className="grid gap-5">
-          <div className="border-surface-3 bg-surface-1 rounded-lg border p-4">
+          <SurfaceCard>
             <Skeleton className="mb-2 h-4 w-32" />
             <Skeleton className="mb-3 h-3 w-48" />
             <Skeleton className="mx-auto h-44 w-44 rounded-full" />
-          </div>
+          </SurfaceCard>
           <div className="space-y-3">
             {Array.from({ length: 3 }).map((_, i) => (
               <div key={i} className="bg-surface-1 flex items-center justify-between rounded-lg px-3 py-2.5">


### PR DESCRIPTION
Part of #181 (phase 4 — subcards cluster).

Replace 4 inline subcard surfaces with `<SurfaceCard>` (default variant) from the primitive introduced in #198.

## Migrated sites

| File | Usage |
|---|---|
| `app/page.tsx` | 3 landing feature cards (Achievements, Analytics, Completion) |
| `components/skeletons/dashboard-skeleton.tsx` | `InsightCardSkeleton` chart frame |

## Consolidation note

`dashboard-skeleton` previously used `border-surface-3` while `app/page.tsx` used `border-surface-4` (8% vs 10% opacity — barely perceptible). SurfaceCard standardizes on `border-surface-4` across all variants. The skeleton frame ends up a hair more visible, but well within the intended surface hierarchy.

**`dashboard-insights.tsx:135` is not touched here** — that `border-surface-3` lives inside the local `InsightChartFrame` helper, not inline drift. It's a semantic component with a semantic purpose (the chart frame inside an outer Card). Optionally we could update it later to internally use SurfaceCard, but it's not drift.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 44 files / 395 tests passing
- [x] `pnpm build` — clean
- [ ] Visual spot-check before merge:
  - `/` (landing) — 3 feature cards
  - `/dashboard` on cold load — insight chart skeleton frame

## Remaining clusters

- Input wrappers (2 sites) + admin item (1 site) + metric row (1 site) — PR 5 (final)