### PR TITLE
refactor: migrate final surface cluster — inputs/admin/metric

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { useCurrentUser } from "@/hooks/use-current-user"
 import { PageContainer } from "@/components/ui/page-container"
 import { LoadingMessage } from "@/components/ui/loading-message"
+import { SurfaceCard } from "@/components/ui/surface-card"
 import { Button } from "@/components/ui/button"
 import { ExternalLink, RefreshCw, Trash2, UserPlus } from "lucide-react"
 
@@ -144,10 +145,7 @@ export default function AdminPage() {
       ) : (
         <div className="space-y-2">
           {users.map((u) => (
-            <div
-              key={u.steam_id}
-              className="border-surface-4 bg-surface-1 flex items-center gap-4 rounded-lg border px-4 py-3"
-            >
+            <SurfaceCard key={u.steam_id} variant="admin-item">
               {u.avatar_url ? (
                 <img
                   src={u.avatar_url}
@@ -208,7 +206,7 @@ export default function AdminPage() {
                   </Button>
                 )}
               </div>
-            </div>
+            </SurfaceCard>
           ))}
         </div>
       )}

--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -9,6 +9,7 @@ import { useSteamExtras, useSteamHiddenGames } from "@/hooks/use-steam-data"
 import { PageContainer } from "@/components/ui/page-container"
 import { LoadingMessage } from "@/components/ui/loading-message"
 import { GameCard } from "@/components/ui/game-card"
+import { InputFrame } from "@/components/ui/input-frame"
 import { Skeleton } from "@/components/ui/skeleton"
 import { SurfaceCard } from "@/components/ui/surface-card"
 import { getSteamHeaderImageUrl } from "@/lib/steam-api"
@@ -169,7 +170,7 @@ export default function ExtrasPage() {
         </div>
 
         <div className="flex items-center justify-between gap-4">
-          <div className="border-surface-4 bg-surface-1 focus-within:border-accent flex h-9 min-w-0 flex-1 items-center gap-2 rounded-lg border px-3">
+          <InputFrame className="min-w-0 flex-1">
             <Search className="text-muted-foreground h-4 w-4 shrink-0" />
             <input
               type="text"
@@ -178,7 +179,7 @@ export default function ExtrasPage() {
               placeholder={tab === "extras" ? "Search extras\u2026" : "Search hidden games\u2026"}
               className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
             />
-          </div>
+          </InputFrame>
           <p className="text-muted-foreground shrink-0 text-sm">
             {loading
               ? "Loading\u2026"

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from "react"
 import { Trophy, PieChart, ArrowUpDown, Play, Search } from "lucide-react"
 
 import { GameCard } from "@/components/ui/game-card"
+import { InputFrame } from "@/components/ui/input-frame"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { SurfaceCard } from "@/components/ui/surface-card"
@@ -301,7 +302,7 @@ export function LibraryOverview({
       </div>
 
       <div className="flex items-center justify-between gap-4">
-        <div className="border-surface-4 bg-surface-1 focus-within:border-accent flex h-9 min-w-0 flex-1 items-center gap-2 rounded-lg border px-3">
+        <InputFrame className="min-w-0 flex-1">
           <Search className="text-muted-foreground h-4 w-4 shrink-0" />
           <input
             type="text"
@@ -318,7 +319,7 @@ export function LibraryOverview({
             placeholder="Search games..."
             className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
           />
-        </div>
+        </InputFrame>
         <p className="text-muted-foreground shrink-0 text-sm">
           {listLoading
             ? "Loading..."

--- a/components/skeletons/dashboard-skeleton.tsx
+++ b/components/skeletons/dashboard-skeleton.tsx
@@ -59,13 +59,13 @@ function InsightCardSkeleton() {
           </SurfaceCard>
           <div className="space-y-3">
             {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="bg-surface-1 flex items-center justify-between rounded-lg px-3 py-2.5">
+              <SurfaceCard key={i} variant="metric">
                 <div className="flex items-center gap-2">
                   <Skeleton className="h-2.5 w-2.5 rounded-full" />
                   <Skeleton className="h-4 w-20" />
                 </div>
                 <Skeleton className="h-4 w-8" />
-              </div>
+              </SurfaceCard>
             ))}
           </div>
         </div>


### PR DESCRIPTION
Part of #181 (phase 5 — final cluster). **Closes out the surface drift cleanup series.**

## Migrated sites

| File | Primitive |
|---|---|
| `app/extras/page.tsx` (search wrapper) | `InputFrame` |
| `components/dashboard/library-overview.tsx` (search wrapper) | `InputFrame` |
| `app/admin/page.tsx` (user list item) | `SurfaceCard variant="admin-item"` |
| `components/skeletons/dashboard-skeleton.tsx` (insight legend skeleton) | `SurfaceCard variant="metric"` |

## Series complete

| PR | Cluster | Sites |
|---|---|---|
| #198 | Primitives (SurfaceCard + InputFrame) | — |
| #199 | Empty states | 4 |
| #200 | List rows | 5 |
| #201 | Subcards | 4 |
| **#202** (this PR) | Inputs + admin + metric | 4 |
| **Total migrated** | | **17 sites** |

## Grep verification

Running the original drift query across the repo after this PR returns **only** the canonical definitions:

- `components/ui/surface-card.tsx` and `components/ui/input-frame.tsx` — the primitives themselves
- `components/dashboard/dashboard-insights.tsx` — `METRIC_LEGEND_BASE` constant and `InsightChartFrame` local helper (deduplicated in #182, kept as local semantic helpers)
- `app/admin/page.tsx:135` — a raw form `<input>` element with `rounded-md` + `py-2` styling. Different shape from the drift, out of scope for #181.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 44 files / 395 tests passing
- [x] `pnpm build` — clean
- [ ] Visual spot-check before merge:
  - `/extras` → search box renders with same h-9 border + focus-within accent
  - `/games` → same
  - `/admin` → user list items render correctly
  - `/dashboard` during cold load → legend skeleton rows

## Closes

Closes #181 (all drift sites migrated to primitives).