### PR TITLE
test: add smoke tests for DashboardSkeleton and LibrarySkeleton

### DIFF
--- a/test/skeletons.test.tsx
+++ b/test/skeletons.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { DashboardSkeleton } from "@/components/skeletons/dashboard-skeleton"
+import { LibrarySkeleton } from "@/components/skeletons/library-skeleton"
+
+afterEach(() => {
+  cleanup()
+})
+
+// Smoke tests — these skeletons are purely visual (no hooks, no state, no
+// async code) so a single render assertion is enough to catch accidental
+// breakage like a typo in a className, a missing Fragment wrapper, or a
+// removed prop. They also lift the files from 0% to 100% coverage since
+// there are no branches to cover.
+describe("skeletons", () => {
+  it("DashboardSkeleton renders without throwing", () => {
+    const { container } = render(<DashboardSkeleton />)
+    expect(container.firstChild).not.toBeNull()
+  })
+
+  it("LibrarySkeleton renders without throwing", () => {
+    const { container } = render(<LibrarySkeleton />)
+    expect(container.firstChild).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Cheap coverage win — both skeleton components are purely visual (no hooks, no state, no async) so a single `render() && expect(firstChild).not.toBeNull()` per file covers every statement.

## Coverage delta

| | Before | After | Δ |
|---|---|---|---|
| Statements | 91.16 | 91.74 | +0.58 |
| Branches | 84.68 | 84.68 | — |
| Functions | 85.88 | 88.95 | +3.07 |
| Lines | 92.83 | 93.45 | +0.62 |
| `components/skeletons/` | 0% | 100% | |

## Test plan

- [x] `pnpm exec vitest run test/skeletons.test.tsx` — 2 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm test:coverage` — full suite green with new totals

## Why so minimal

These components have literally zero branches — if they render once, they render correctly for all inputs (there are no props). The smoke test catches import errors, typos in class strings, missing `</Fragment>` closes, etc. — which is all you can ask of a test against a pure-presentation component.