### PR TITLE
fix: hydrate game names for delisted apps via community page

### DIFF
--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -42,6 +42,46 @@ type StoreAppDetails = {
 }
 
 /**
+ * Last-resort name resolver: scrape the HTML title of the Steam community
+ * page for the given appid. Used for delisted achievement-less apps that
+ * neither store appdetails nor GetSchemaForGame can name (server builds,
+ * soundtracks, demos, experimental indie titles, …). Returns null on any
+ * failure or sentinel response.
+ *
+ * Example: app 502090 ("Invisible Mind") is delisted with no schema, so the
+ * structured endpoints return nothing. The community page still serves a
+ * `<title>Steam Community :: Invisible Mind</title>` for it.
+ */
+async function fetchCommunityGameName(appId: number): Promise<string | null> {
+  try {
+    const response = await fetch(`https://steamcommunity.com/app/${appId}`, {
+      cache: "no-store",
+      redirect: "follow",
+    })
+    if (!response.ok) return null
+    const html = await response.text()
+    const match = html.match(/<title>Steam Community :: ([^<]+)<\/title>/)
+    if (!match) return null
+    const name = decodeBasicHtmlEntities(match[1].trim())
+    // Sentinel values Steam returns for unknown/invalid appids on this URL.
+    if (name === "Error") return null
+    return name
+  } catch {
+    return null
+  }
+}
+
+function decodeBasicHtmlEntities(s: string): string {
+  return s
+    .replaceAll("&amp;", "&")
+    .replaceAll("&#39;", "'")
+    .replaceAll("&apos;", "'")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+}
+
+/**
  * Fallback name hydrator: for any extras row whose `games.name` is still
  * NULL after the achievement sync, probe the public
  * `store.steampowered.com/api/appdetails` endpoint one appid at a time.
@@ -129,6 +169,17 @@ export async function hydrateMissingExtraNames(steamId: string) {
         }
       } catch {
         // non-critical
+      }
+    }
+
+    // Source 3: community page HTML (covers delisted achievement-less apps
+    // that neither store nor schema can name — e.g. dedicated servers,
+    // soundtracks, demos, one-off experimental indies). Different host so
+    // failures don't count toward the store back-off counter.
+    if (!resolvedName) {
+      const communityName = await fetchCommunityGameName(appid)
+      if (communityName) {
+        resolvedName = communityName
       }
     }
 

--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -72,13 +72,17 @@ async function fetchCommunityGameName(appId: number): Promise<string | null> {
 }
 
 function decodeBasicHtmlEntities(s: string): string {
+  // Order matters: &amp; must be replaced LAST so we don't double-decode
+  // strings that contain a literal &amp; followed by another entity (e.g.
+  // "&amp;#39;" should resolve to "&#39;", not "'"). CodeQL flags the
+  // naive ordering as a double-unescape vulnerability.
   return s
-    .replaceAll("&amp;", "&")
     .replaceAll("&#39;", "'")
     .replaceAll("&apos;", "'")
     .replaceAll("&quot;", '"')
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&")
 }
 
 /**

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -586,10 +586,11 @@ describe("hydrateMissingExtraNames", () => {
     // store appdetails endpoint (counts toward the back-off) and the
     // community page fallback (independent host, doesn't count). Only
     // increment storeCalls for the store URL so the back-off assertion
-    // stays meaningful.
+    // stays meaningful. Use URL.hostname for an exact host match — CodeQL
+    // flags substring matching as incomplete URL sanitization.
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url.includes("store.steampowered.com")) storeCalls++
+      const host = new URL(String(input)).hostname
+      if (host === "store.steampowered.com") storeCalls++
       return { ok: false, status: 500, json: async () => ({}), text: async () => "" } as unknown as Response
     }) as unknown as typeof fetch
     vi.doMock("@/lib/steam-api", () => ({
@@ -626,11 +627,12 @@ describe("hydrateMissingExtraNames", () => {
 
   function mockStoreFailAndCommunity(communityHtmlByAppId: Record<number, string>) {
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url.includes("store.steampowered.com")) {
+      const u = new URL(String(input))
+      // Use exact hostname matching — CodeQL flags substring URL checks
+      // as incomplete sanitization.
+      if (u.hostname === "store.steampowered.com") {
         // Force the store fallback to return success=false so the chain
         // proceeds to schema (mocked to null) and then to community.
-        const u = new URL(url)
         const appid = u.searchParams.get("appids") ?? "0"
         return {
           ok: true,
@@ -639,8 +641,8 @@ describe("hydrateMissingExtraNames", () => {
           text: async () => "",
         } as unknown as Response
       }
-      if (url.includes("steamcommunity.com")) {
-        const m = url.match(/\/app\/(\d+)/)
+      if (u.hostname === "steamcommunity.com") {
+        const m = u.pathname.match(/\/app\/(\d+)/)
         const appid = m ? Number(m[1]) : 0
         const html = communityHtmlByAppId[appid] ?? ""
         return { ok: true, status: 200, json: async () => ({}), text: async () => html } as unknown as Response
@@ -721,12 +723,11 @@ describe("hydrateMissingExtraNames", () => {
     const db = await seedExtraWithoutName(100200)
     let communityCalled = false
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url.includes("steamcommunity.com")) {
+      const u = new URL(String(input))
+      if (u.hostname === "steamcommunity.com") {
         communityCalled = true
         return { ok: true, status: 200, json: async () => ({}), text: async () => "" } as unknown as Response
       }
-      const u = new URL(url)
       const appid = u.searchParams.get("appids") ?? "0"
       return {
         ok: true,

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -582,9 +582,15 @@ describe("hydrateMissingExtraNames", () => {
       ).run(STEAM_ID, i, 100 - i, now, now, now)
     }
     let storeCalls = 0
-    globalThis.fetch = vi.fn(async () => {
-      storeCalls++
-      return { ok: false, status: 500, json: async () => ({}) } as unknown as Response
+    // hydrateMissingExtraNames now fetches two hosts per iteration: the
+    // store appdetails endpoint (counts toward the back-off) and the
+    // community page fallback (independent host, doesn't count). Only
+    // increment storeCalls for the store URL so the back-off assertion
+    // stays meaningful.
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("store.steampowered.com")) storeCalls++
+      return { ok: false, status: 500, json: async () => ({}), text: async () => "" } as unknown as Response
     }) as unknown as typeof fetch
     vi.doMock("@/lib/steam-api", () => ({
       getGameSchema: vi.fn().mockResolvedValue(null),
@@ -614,6 +620,126 @@ describe("hydrateMissingExtraNames", () => {
     const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
     await hydrateMissingExtraNames(STEAM_ID)
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  // ---- Source 3: community-page HTML fallback ----
+
+  function mockStoreFailAndCommunity(communityHtmlByAppId: Record<number, string>) {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("store.steampowered.com")) {
+        // Force the store fallback to return success=false so the chain
+        // proceeds to schema (mocked to null) and then to community.
+        const u = new URL(url)
+        const appid = u.searchParams.get("appids") ?? "0"
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ [appid]: { success: false } }),
+          text: async () => "",
+        } as unknown as Response
+      }
+      if (url.includes("steamcommunity.com")) {
+        const m = url.match(/\/app\/(\d+)/)
+        const appid = m ? Number(m[1]) : 0
+        const html = communityHtmlByAppId[appid] ?? ""
+        return { ok: true, status: 200, json: async () => ({}), text: async () => html } as unknown as Response
+      }
+      return { ok: false, status: 404, json: async () => ({}), text: async () => "" } as unknown as Response
+    }) as unknown as typeof fetch
+  }
+
+  it("falls back to the community page when both store and schema return nothing", async () => {
+    const db = await seedExtraWithoutName(502090)
+    mockStoreFailAndCommunity({
+      502090: "<html><head><title>Steam Community :: Invisible Mind</title></head></html>",
+    })
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=502090").get() as { name: string } | undefined
+    expect(row?.name).toBe("Invisible Mind")
+  })
+
+  it("ignores the community page 'Error' sentinel for unknown appids", async () => {
+    const db = await seedExtraWithoutName(999000)
+    mockStoreFailAndCommunity({
+      999000: "<html><head><title>Steam Community :: Error</title></head></html>",
+    })
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=999000").get() as { name: string } | undefined
+    expect(row).toBeUndefined()
+  })
+
+  it("ignores the 'Welcome to Steam' fallback page for nonexistent appids", async () => {
+    const db = await seedExtraWithoutName(999001)
+    mockStoreFailAndCommunity({
+      999001: "<html><head><title>Welcome to Steam</title></head></html>",
+    })
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=999001").get() as { name: string } | undefined
+    expect(row).toBeUndefined()
+  })
+
+  it("decodes basic HTML entities in community-page titles", async () => {
+    const db = await seedExtraWithoutName(123456)
+    mockStoreFailAndCommunity({
+      123456: "<html><head><title>Steam Community :: Tom Clancy&#39;s Splinter Cell</title></head></html>",
+    })
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=123456").get() as { name: string } | undefined
+    expect(row?.name).toBe("Tom Clancy's Splinter Cell")
+  })
+
+  it("does not call the community fallback when the store already returned a name", async () => {
+    const db = await seedExtraWithoutName(100200)
+    let communityCalled = false
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("steamcommunity.com")) {
+        communityCalled = true
+        return { ok: true, status: 200, json: async () => ({}), text: async () => "" } as unknown as Response
+      }
+      const u = new URL(url)
+      const appid = u.searchParams.get("appids") ?? "0"
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ [appid]: { success: true, data: { name: "Resolved by store" } } }),
+        text: async () => "",
+      } as unknown as Response
+    }) as unknown as typeof fetch
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    expect(communityCalled).toBe(false)
+    const row = db.prepare("SELECT name FROM games WHERE appid=100200").get() as { name: string }
+    expect(row.name).toBe("Resolved by store")
   })
 })
 


### PR DESCRIPTION
Closes #205

## Problem

Some apps in the extras list never resolve a name despite SteamDB having one. Reported case: app **502090** ("Invisible Mind", a short delisted walking sim with no Steam achievements).

## Root cause

`hydrateMissingExtraNames` walks two sources:

1. `store.steampowered.com/api/appdetails` → returns `success: false` for delisted apps
2. `GetSchemaForGame` → only works when the publisher uploaded a schema. Achievement-less apps (servers, soundtracks, demos, experimental indies) have no schema.

Apps in the intersection (delisted **and** achievement-less) end up rendered as `App #{appid}` forever. SteamDB sidesteps this by scraping Steam's binary protocol catalog, which isn't available as a Web API.

## Fix

Add a 3rd fallback: scrape the public Steam community app page `https://steamcommunity.com/app/{appid}` for the name in its HTML `<title>`. Verified for the reported case + several controls:

```
730       → "Steam Community :: Counter-Strike 2"
440       → "Steam Community :: Team Fortress 2"
1245620   → "Steam Community :: ELDEN RING"
502090    → "Steam Community :: Invisible Mind"   ← the reported case
999999999 → "Welcome to Steam"                    ← sentinel for nonexistent
```

The new `fetchCommunityGameName` helper:

- Parses the `Steam Community :: {name}` pattern from `<title>`
- Decodes basic HTML entities (`&amp;`, `&#39;`, `&quot;`, etc.)
- Filters the `Error` sentinel Steam returns for invalid appids
- Returns `null` on any failure (network error, non-200, missing tag, sentinel)
- Does **not** count toward the existing `consecutiveStoreFailures` back-off — community is a different host with independent rate limits

Order chosen so the most fragile source (HTML scraping) runs only when the structured sources have nothing.

## Test changes

- 1 existing test updated: the back-off counter now filters by URL host instead of counting all fetches, since `hydrateMissingExtraNames` fetches two hosts per iteration when both store and schema fail
- 5 new tests added:
  - Falls back to community page when both store and schema return nothing
  - Ignores the `Error` sentinel for unknown appids
  - Ignores the `Welcome to Steam` page for nonexistent appids
  - Decodes HTML entities (`&#39;` → `'`)
  - Short-circuits the community fetch when store already returned a name (proves we don't make unnecessary requests)

## Test plan

- [x] `pnpm exec vitest run test/extra-games.test.ts` — 43/43 pass
- [x] `pnpm lint` — clean
- [x] `pnpm test` — **411 tests** pass (was 406)
- [x] `pnpm build` — clean
- [ ] After merge: trigger a sync as the affected user. Apps with `name = NULL` like 502090 should hydrate to their real names on the next `hydrateMissingExtraNames` pass. No backfill migration needed — the fix is forward-only.

## Out of scope

- Replacing the existing structured fallbacks (still authoritative when they work)
- Backfilling owned-library names (`GetOwnedGames` always names them; this only affects extras)