### PR TITLE
refactor: type getGameSchema properly + drop unsafe casts

### DIFF
--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -167,7 +167,7 @@ export async function hydrateMissingExtraNames(steamId: string) {
     // Source 2: GetSchemaForGame (works for delisted apps the store rejects)
     if (!resolvedName) {
       try {
-        const schema = (await getGameSchema(appid)) as { gameName?: string } | null
+        const schema = await getGameSchema(appid)
         if (schema?.gameName) {
           resolvedName = schema.gameName
         }

--- a/lib/server/steam-achievements-sync.ts
+++ b/lib/server/steam-achievements-sync.ts
@@ -1,6 +1,6 @@
 import "server-only"
 
-import { getGameSchema, getPlayerAchievements, type SteamAchievement } from "@/lib/steam-api"
+import { getGameSchema, getPlayerAchievements, type GameSchema, type SteamAchievement } from "@/lib/steam-api"
 import type { SteamAchievementView } from "@/lib/types/steam"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { nowIso, isStale } from "@/lib/server/steam-store-utils"
@@ -39,21 +39,6 @@ function mapJoinRowToView(row: AchievementJoinRow): SteamAchievementView {
     displayName: row.display_name ?? row.apiname,
     icon: row.icon ?? "",
     icongray: row.icon_gray ?? "",
-  }
-}
-
-type SchemaAchievement = {
-  name: string
-  displayName?: string
-  description?: string
-  icon?: string
-  icongray?: string
-  hidden?: number
-}
-
-type GameSchema = {
-  availableGameStats?: {
-    achievements?: SchemaAchievement[]
   }
 }
 
@@ -289,7 +274,7 @@ export async function ensureSchema(appId: number, options?: { forceRefresh?: boo
     return
   }
 
-  const schema = (await getGameSchema(appId)) as GameSchema | null
+  const schema = await getGameSchema(appId)
   persistSchema(appId, schema)
 }
 

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -42,6 +42,36 @@ export interface PlayerStats {
   success: boolean
 }
 
+/** Single achievement entry as returned by ISteamUserStats/GetSchemaForGame. */
+export interface SchemaAchievement {
+  name: string
+  displayName?: string
+  description?: string
+  icon?: string
+  icongray?: string
+  hidden?: number
+  defaultvalue?: number
+}
+
+/**
+ * Game schema as returned by ISteamUserStats/GetSchemaForGame, after the
+ * `{ game: ... }` envelope is unwrapped. Used for both achievement metadata
+ * (display names, icons) and as a name-resolution fallback for delisted apps
+ * via `gameName`.
+ */
+export interface GameSchema {
+  gameName?: string
+  gameVersion?: string
+  availableGameStats?: {
+    achievements?: SchemaAchievement[]
+    stats?: Array<{
+      name: string
+      defaultvalue?: number
+      displayName?: string
+    }>
+  }
+}
+
 const STEAM_API_BASE = "https://api.steampowered.com"
 
 class SteamAPIError extends Error {
@@ -192,13 +222,13 @@ export async function getLastPlayedTimes(steamId: string): Promise<LastPlayedGam
 }
 
 /** Fetches the game schema (achievement and stat definitions) from the Steam API. */
-export async function getGameSchema(appId: number): Promise<unknown> {
+export async function getGameSchema(appId: number): Promise<GameSchema | null> {
   try {
     const data = await steamAPIRequest("/ISteamUserStats/GetSchemaForGame/v2/", {
       appid: appId.toString(),
     })
 
-    return data.game || null
+    return (data.game as GameSchema | undefined) ?? null
   } catch (error) {
     // Same story as getPlayerAchievements: 400/403 just means the app has no
     // publishable schema. Let the caller treat it as an empty schema without


### PR DESCRIPTION
Promote local GameSchema/SchemaAchievement types from steam-achievements-sync.ts to lib/steam-api.ts and add the missing gameName field. getGameSchema now returns Promise<GameSchema | null> instead of Promise<unknown>. Drops the two type assertions in extra-games.ts and steam-achievements-sync.ts. Zero runtime change. 411 tests passing.