### PR TITLE
feat: in-memory stats cache with sync-time invalidation

### DIFF
--- a/app/api/steam/sync/route.ts
+++ b/app/api/steam/sync/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server"
 import { getCurrentUser } from "@/app/lib/server-auth"
 import { rateLimit } from "@/lib/server/rate-limit"
 import { getUserSyncStatus, synchronizeUserData } from "@/lib/server/steam-store"
+import { invalidateStatsCache } from "@/lib/steam-stats"
 import { logger } from "@/lib/server/logger"
 
 /**
@@ -55,6 +56,10 @@ export async function POST() {
     }
 
     const result = await synchronizeUserData(user.steamId)
+    // Drop the in-memory stats cache so a follow-up GET /api/steam/stats
+    // recomputes from the freshly-synced database instead of returning a
+    // stale snapshot.
+    invalidateStatsCache(user.steamId)
     return NextResponse.json(result)
   } catch (error) {
     logger.error({ err: error, endpoint: "steam/sync" }, "Steam sync API error")

--- a/lib/steam-stats.ts
+++ b/lib/steam-stats.ts
@@ -4,10 +4,43 @@ import { getStatsForUser } from "@/lib/server/steam-store"
 import { logger } from "@/lib/server/logger"
 import type { SteamStatsResponse } from "@/lib/types/steam"
 
-/** Fetches aggregate user stats, returning zeroed defaults on failure. */
+// In-memory stats cache. Shared across requests within the same Node process.
+// Doesn't survive a process restart and doesn't sync across multi-instance
+// deployments — both acceptable for this single-user whitelist app.
+//
+// We tried the Next 16 Cache Components approach (`'use cache'` directive +
+// `cacheTag` + `updateTag`) but enabling `cacheComponents: true` requires
+// every cookie-reading API route to be marked `force-dynamic` and every
+// client component that consumes a hook like `useCurrentUser()` to be
+// wrapped in a `<Suspense>` boundary. That's a multi-PR migration. This
+// module-level Map gives the same observable behavior for /api/steam/stats
+// (cached for ~1h, invalidated on sync) without the framework migration.
+const STATS_CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+type CacheEntry = { stats: SteamStatsResponse; expiresAt: number }
+const statsCache = new Map<string, CacheEntry>()
+
+/** Drops the cached stats entry for a user. Called from the sync route after a successful sync. */
+export function invalidateStatsCache(steamId: string): void {
+  statsCache.delete(steamId)
+}
+
+/**
+ * Fetches aggregate user stats, returning zeroed defaults on failure. When
+ * forceRefresh is set, bypasses the in-memory cache and goes straight to
+ * getStatsForUser (which itself recomputes from the database). Otherwise
+ * serves from the in-memory cache when fresh.
+ */
 export async function getUserStats(steamId: string, options?: { forceRefresh?: boolean }): Promise<SteamStatsResponse> {
   try {
-    return await getStatsForUser(steamId, options)
+    if (!options?.forceRefresh) {
+      const cached = statsCache.get(steamId)
+      if (cached && cached.expiresAt > Date.now()) {
+        return cached.stats
+      }
+    }
+    const stats = await getStatsForUser(steamId, options)
+    statsCache.set(steamId, { stats, expiresAt: Date.now() + STATS_CACHE_TTL_MS })
+    return stats
   } catch (error) {
     logger.error({ err: error }, "Error fetching user stats")
     return {


### PR DESCRIPTION
Add a module-level Map cache to `lib/steam-stats.ts` so `/api/steam/stats` serves repeat requests within an hour without re-running the SQLite snapshot/aggregation logic on every call. The sync route invalidates the entry after a successful `synchronizeUserData()` so the user reads fresh values immediately after triggering a sync.

## Why a Map and not Next 16 Cache Components

Original plan: wrap `getStatsForUser` in a `'use cache'` function and let Next 16's cache layer handle it via `cacheTag` / `updateTag`. Tried that. Enabling `cacheComponents: true` in `next.config.mjs` requires:

- Marking every cookie-reading API route as `force-dynamic` (~10 routes), or the build fails with `During prerendering, cookies() rejects when the prerender is complete`
- Wrapping the `useCurrentUser()` consumer in `client-layout.tsx` inside a `<Suspense>` boundary so the static shell can prerender without blocking on dynamic data
- Probably more issues that surface as you fix the first ones

That's its own multi-PR migration. **Follow-up issue should track proper PPR adoption when there's appetite for the full refactor.** For this PR, the Map gives the same observable behavior:

- `/api/steam/stats` serves cached data within 1h of the first call
- `POST /api/steam/sync` invalidates the entry → next read recomputes
- `forceRefresh` query param still bypasses the cache and re-enters the DB layer

## Tradeoffs vs framework cache

| | Map cache (this PR) | Next 16 cache components |
|---|---|---|
| Survives process restart | ❌ | ✅ |
| Multi-instance sync | ❌ | ✅ (with edge cache) |
| Tag-based invalidation | only by user | ✅ |
| Migration cost | trivial | multi-PR |

For a **single-user whitelist app** running on a single instance, the Map cache is a 95% solution at 5% effort.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 411 tests passing
- [x] `pnpm build` — clean
- [ ] Manual smoke after merge: load `/dashboard` cold (one DB hit), reload (cache hit, no DB query), trigger sync, reload (cache invalidated, fresh DB query)

## Out of scope

Migrating to actual Next 16 Cache Components / PPR (its own multi-PR effort).