### PR TITLE
fix: a11y audit findings — search labels, charts, focus rings, modal aria

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -81,7 +81,9 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
           user && <DashboardHeader user={user} />
         ))}
       {title && <div className="w-full px-4 pt-7 pb-4 text-center text-3xl font-bold">{title}</div>}
-      <main id="main-content" className="min-h-screen">
+      {/* tabIndex={-1} so the skip-to-content link can move keyboard focus
+          here when activated (otherwise the focus ring stays on the link). */}
+      <main id="main-content" tabIndex={-1} className="min-h-screen outline-none">
         {children}
       </main>
       <footer className="border-surface-4 border-t py-8">

--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -177,7 +177,8 @@ export default function ExtrasPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder={tab === "extras" ? "Search extras\u2026" : "Search hidden games\u2026"}
-              className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
+              aria-label={tab === "extras" ? "Search extras" : "Search hidden games"}
+              className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm outline-none"
             />
           </InputFrame>
           <p className="text-muted-foreground shrink-0 text-sm">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,7 +109,7 @@ export default function HomePage() {
         )}
 
         <div className="space-y-3">
-          <button onClick={handleSteamSignIn} className="group cursor-pointer">
+          <button type="button" onClick={handleSteamSignIn} className="group cursor-pointer">
             <img
               src="/steam-signin.png"
               alt="Sign in with Steam"

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -73,6 +73,7 @@ export function DashboardHeader({ user }: DashboardHeaderProps) {
                 className="text-muted-foreground hover:text-foreground sm:hidden"
                 onClick={() => setMobileMenuOpen((prev) => !prev)}
                 aria-expanded={mobileMenuOpen}
+                aria-controls="mobile-nav"
                 aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
               >
                 {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -123,6 +124,7 @@ export function DashboardHeader({ user }: DashboardHeaderProps) {
       </header>
       {mobileMenuOpen && (
         <nav
+          id="mobile-nav"
           aria-label="Mobile navigation"
           className="border-surface-4 bg-background/95 sticky top-[57px] z-50 border-b backdrop-blur-xl sm:hidden"
         >

--- a/components/dashboard/dashboard-insights.tsx
+++ b/components/dashboard/dashboard-insights.tsx
@@ -132,13 +132,18 @@ function InsightChartFrame({
   insight: string
   children: React.ReactNode
 }) {
+  // <figure> + <figcaption> gives screen readers a real semantic chart with
+  // a caption — Recharts SVGs themselves are unlabeled, so without this
+  // wrapper AT users get nothing meaningful from the donut/bars.
   return (
     <SurfaceCard>
-      <div className="mb-3">
-        <p className="text-foreground text-sm font-semibold">{title}</p>
-        <p className="text-muted-foreground text-sm">{insight}</p>
-      </div>
-      <div className="h-56 min-h-0 min-w-0">{children}</div>
+      <figure className="m-0">
+        <figcaption className="mb-3">
+          <p className="text-foreground text-sm font-semibold">{title}</p>
+          <p className="text-muted-foreground text-sm">{insight}</p>
+        </figcaption>
+        <div className="h-56 min-h-0 min-w-0">{children}</div>
+      </figure>
     </SurfaceCard>
   )
 }

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -317,7 +317,8 @@ export function LibraryOverview({
               }, 300)
             }}
             placeholder="Search games..."
-            className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
+            aria-label="Search games"
+            className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm outline-none"
           />
         </InputFrame>
         <p className="text-muted-foreground shrink-0 text-sm">

--- a/components/first-sync-modal.tsx
+++ b/components/first-sync-modal.tsx
@@ -91,7 +91,12 @@ export function FirstSyncModal({ onComplete }: { onComplete: () => void }) {
   const timeLabel = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
 
   return (
-    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/80 backdrop-blur-sm">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="first-sync-modal-title"
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+    >
       <div className="border-surface-4 bg-card mx-4 w-full max-w-md space-y-6 rounded-2xl border p-8 text-center shadow-2xl">
         <div className="flex justify-center">
           {phase === "done" ? (
@@ -110,8 +115,14 @@ export function FirstSyncModal({ onComplete }: { onComplete: () => void }) {
         </div>
 
         <div className="space-y-2">
-          <h2 className="text-xl font-semibold tracking-tight">First-time sync</h2>
-          <p className="text-muted-foreground text-sm">{PHASE_LABELS[phase]}</p>
+          <h2 id="first-sync-modal-title" className="text-xl font-semibold tracking-tight">
+            First-time sync
+          </h2>
+          {/* aria-live so AT users hear phase changes during the multi-minute
+              wait. Polite (not assertive) so it doesn't interrupt. */}
+          <p className="text-muted-foreground text-sm" aria-live="polite">
+            {PHASE_LABELS[phase]}
+          </p>
         </div>
 
         {phase !== "done" && phase !== "error" && (

--- a/components/ui/input-frame.tsx
+++ b/components/ui/input-frame.tsx
@@ -21,7 +21,11 @@ function InputFrame({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="input-frame"
       className={cn(
-        "border-surface-4 bg-surface-1 focus-within:border-accent flex h-9 items-center gap-2 rounded-lg border px-3 transition-colors",
+        // focus-within:ring-2 gives the inner <input> a real WCAG 1.4.11
+        // focus indicator. The hosted input typically kills its own outline
+        // via `outline-none`, and the 1px accent border alone isn't a
+        // strong enough cue. The ring on the parent frame replaces it.
+        "border-surface-4 bg-surface-1 focus-within:border-accent focus-within:ring-accent/50 flex h-9 items-center gap-2 rounded-lg border px-3 transition-colors focus-within:ring-2",
         className,
       )}
       {...props}


### PR DESCRIPTION
Follow-up to #168 (the basic jsx-a11y violations). After a deeper audit pass, applies the fixes that don't require a new shadcn primitive or sweeping refactor. Bigger items spun out as #212 #213 #214. 411 tests passing.