### PR TITLE
feat: profile badges use Radix Tooltip

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation"
 import { Skeleton } from "@/components/ui/skeleton"
 import { usePageTitle } from "@/components/ui/page-title-context"
 import { Toaster } from "@/components/ui/toaster"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { FirstSyncModal } from "@/components/first-sync-modal"
 
 type SyncStatusResponse = {
@@ -57,7 +58,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const isAuthPage = pathname !== "/"
 
   return (
-    <>
+    <TooltipProvider delayDuration={300}>
       <a
         href="#main-content"
         className="focus:ring-accent sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-md focus:bg-slate-900 focus:px-4 focus:py-2 focus:text-white focus:ring-2 focus:outline-none"
@@ -112,6 +113,6 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         </div>
       </footer>
       <Toaster />
-    </>
+    </TooltipProvider>
   )
 }

--- a/components/dashboard/user-profile.tsx
+++ b/components/dashboard/user-profile.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button"
 import { AnimatedNumber } from "@/components/ui/animated-number"
 import { CompletionRing } from "@/components/ui/completion-ring"
 import { surfaceCardVariants } from "@/components/ui/surface-card"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { AlertTriangle, ExternalLink } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { SteamUser } from "@/lib/auth"
@@ -219,37 +220,45 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
               </div>
               <div className="flex items-center gap-2">
                 {yearsOfService != null && user.timecreated && (
-                  <div className="group relative">
-                    <img
-                      src={`${BADGE_CDN}/02_years/steamyears${yearsOfService}_80.png`}
-                      alt={`${yearsOfService} years of service`}
-                      className="h-10 w-10"
-                    />
-                    <span className="bg-popover text-popover-foreground border-surface-4 pointer-events-none absolute top-1/2 left-full z-10 ml-2 hidden -translate-y-1/2 rounded-md border px-3 py-2 text-sm whitespace-nowrap shadow-lg group-hover:block">
+                  <Tooltip>
+                    <TooltipTrigger
+                      type="button"
+                      className="focus-visible:ring-accent inline-flex rounded-md outline-none focus-visible:ring-2"
+                    >
+                      <img
+                        src={`${BADGE_CDN}/02_years/steamyears${yearsOfService}_80.png`}
+                        alt={`${yearsOfService} years of service`}
+                        className="h-10 w-10"
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent>
                       Member since{" "}
                       {new Date(user.timecreated * 1000).toLocaleDateString("en-US", {
                         month: "long",
                         year: "numeric",
                       })}{" "}
                       · {yearsOfService} years of service
-                    </span>
-                  </div>
+                    </TooltipContent>
+                  </Tooltip>
                 )}
                 {(() => {
                   const collector = user.badges?.find((b) => b.badgeid === 13)
                   if (!collector) return null
                   const tier = getBadgeTier(collector.level, GAME_COLLECTOR_TIERS)
                   return (
-                    <div className="group relative">
-                      <img
-                        src={`${BADGE_CDN}/13_gamecollector/${tier}_80.png?v=4`}
-                        alt={`Game Collector level ${collector.level}`}
-                        className="h-10 w-10"
-                      />
-                      <span className="bg-popover text-popover-foreground border-surface-4 pointer-events-none absolute top-1/2 left-full z-10 ml-2 hidden -translate-y-1/2 rounded-md border px-3 py-2 text-sm whitespace-nowrap shadow-lg group-hover:block">
-                        Game Collector · {collector.level} games owned
-                      </span>
-                    </div>
+                    <Tooltip>
+                      <TooltipTrigger
+                        type="button"
+                        className="focus-visible:ring-accent inline-flex rounded-md outline-none focus-visible:ring-2"
+                      >
+                        <img
+                          src={`${BADGE_CDN}/13_gamecollector/${tier}_80.png?v=4`}
+                          alt={`Game Collector level ${collector.level}`}
+                          className="h-10 w-10"
+                        />
+                      </TooltipTrigger>
+                      <TooltipContent>Game Collector · {collector.level} games owned</TooltipContent>
+                    </Tooltip>
                   )
                 })()}
               </div>

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({ delayDuration = 0, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/test/user-profile.test.tsx
+++ b/test/user-profile.test.tsx
@@ -15,6 +15,16 @@ vi.mock("@/components/ui/animated-number", () => ({
   AnimatedNumber: ({ value }: { value: number }) => <>{value}</>,
 }))
 
+// Stub Radix Tooltip — tests render UserProfile in isolation, so there's no
+// TooltipProvider in the tree. Pass-through TooltipTrigger as a button so
+// the wrapped <img> still ends up in the DOM with its alt text intact.
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children, ...props }: React.ComponentProps<"button">) => <button {...props}>{children}</button>,
+  TooltipContent: () => null,
+}))
+
 import { UserProfile } from "@/components/dashboard/user-profile"
 import type { SteamUser } from "@/lib/auth"
 import type { SteamStatsResponse } from "@/lib/types/steam"


### PR DESCRIPTION
Closes #213. Profile badges (years-of-service + Game Collector) now use Radix Tooltip instead of CSS group-hover, gaining keyboard activation, touch support, and aria-describedby wiring. Single TooltipProvider added to client-layout. Test mock for the tooltip module so user-profile tests stay isolated. 411 tests passing.