### PR TITLE
feat: FirstSyncModal uses Radix Dialog

### DIFF
--- a/components/first-sync-modal.tsx
+++ b/components/first-sync-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import { Loader2, RefreshCw } from "lucide-react"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
 import { invalidateSteamData } from "@/hooks/use-steam-data"
 
 type SyncStatusResponse = {
@@ -91,13 +92,18 @@ export function FirstSyncModal({ onComplete }: { onComplete: () => void }) {
   const timeLabel = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="first-sync-modal-title"
-      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/80 backdrop-blur-sm"
-    >
-      <div className="border-surface-4 bg-card mx-4 w-full max-w-md space-y-6 rounded-2xl border p-8 text-center shadow-2xl">
+    <Dialog open>
+      <DialogContent
+        showCloseButton={false}
+        // Sync is mandatory — block Escape and outside-click dismissal so
+        // the user can't accidentally close the modal mid-sync. The modal
+        // dismisses itself automatically when phase === "done" via
+        // onComplete().
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+        className="border-surface-4 bg-card max-w-md gap-6 rounded-2xl p-8 text-center shadow-2xl sm:max-w-md"
+      >
         <div className="flex justify-center">
           {phase === "done" ? (
             <div className="bg-success/15 text-success flex h-16 w-16 items-center justify-center rounded-full">
@@ -115,14 +121,13 @@ export function FirstSyncModal({ onComplete }: { onComplete: () => void }) {
         </div>
 
         <div className="space-y-2">
-          <h2 id="first-sync-modal-title" className="text-xl font-semibold tracking-tight">
-            First-time sync
-          </h2>
-          {/* aria-live so AT users hear phase changes during the multi-minute
-              wait. Polite (not assertive) so it doesn't interrupt. */}
-          <p className="text-muted-foreground text-sm" aria-live="polite">
+          <DialogTitle className="text-xl font-semibold tracking-tight">First-time sync</DialogTitle>
+          {/* DialogDescription wires aria-describedby automatically. The
+              aria-live="polite" announces phase changes during the
+              multi-minute wait without interrupting. */}
+          <DialogDescription className="text-muted-foreground text-sm" aria-live="polite">
             {PHASE_LABELS[phase]}
-          </p>
+          </DialogDescription>
         </div>
 
         {phase !== "done" && phase !== "error" && (
@@ -153,7 +158,7 @@ export function FirstSyncModal({ onComplete }: { onComplete: () => void }) {
             </button>
           </div>
         )}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
Closes #214. Migrates FirstSyncModal from a custom div+ARIA to shadcn Dialog (Radix). Adds focus trap, body scroll lock, restore-focus-on-close, and proper aria-describedby wiring — all for free from Radix. Modal stays mandatory (Escape + outside-click locked). 411 tests passing. Visual smoke after merge.