### PR TITLE
refactor: CardTitle defaults to <h3> for screen reader heading nav

### DIFF
--- a/components/dashboard/user-profile.tsx
+++ b/components/dashboard/user-profile.tsx
@@ -170,7 +170,10 @@ export function UserProfile({ user, stats, statsLoading = false, syncLabel }: Us
     <Card className="border-surface-4 overflow-hidden bg-[linear-gradient(135deg,rgba(88,198,255,0.14),transparent_35%),linear-gradient(180deg,rgba(255,255,255,0.04),transparent)]">
       <CardHeader className="pb-0">
         <div className="flex items-start justify-between">
-          <CardTitle className="flex items-start gap-4">
+          {/* as="div" because the inner <h2> for the display name is the
+              real semantic heading. We don't want CardTitle defaulting to
+              <h3> and creating a nested-heading conflict. */}
+          <CardTitle as="div" className="flex items-start gap-4">
             <img
               src={user.avatar || "/placeholder.svg"}
               alt={`${user.displayName}'s Steam avatar`}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -28,8 +28,22 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="card-title" className={cn("leading-none font-semibold", className)} {...props} />
+type CardTitleElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "div"
+
+/**
+ * CardTitle defaults to <h3> so it shows up in screen reader heading
+ * navigation (rotor / cmd+opt+u). Cards typically live inside a section
+ * with a higher-level heading (h1 page title + h2 section), so h3 is the
+ * sensible mid-level. Override via `as` for cases where the inner content
+ * already contains a real heading (use `as="div"`) or the card is the
+ * top-level section heading on its page (use `as="h2"`).
+ */
+function CardTitle({
+  as: Component = "h3",
+  className,
+  ...props
+}: React.ComponentProps<"div"> & { as?: CardTitleElement }) {
+  return <Component data-slot="card-title" className={cn("leading-none font-semibold", className)} {...props} />
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {


### PR DESCRIPTION
Closes #212. Adds an `as` prop to shadcn CardTitle defaulting to `<h3>`. Promotes 5 existing call sites to real headings automatically. user-profile.tsx uses `as="div"` because it wraps an explicit `<h2>` for the display name. Zero visual change, real AT win. 411 tests passing.