### PR TITLE
feat: bulk-seed games table from Steam app catalog

### DIFF
--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -6,6 +6,7 @@ import type { SteamAchievementView } from "@/lib/types/steam"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { isStale, nowIso } from "@/lib/server/steam-store-utils"
 import { ACHIEVEMENTS_STALE_MS } from "@/lib/server/steam-achievements-sync"
+import { populateGamesFromSteamCatalog } from "@/lib/server/steam-app-catalog"
 import { logger } from "@/lib/server/logger"
 
 export type ExtraGame = {
@@ -109,6 +110,14 @@ function decodeBasicHtmlEntities(s: string): string {
  */
 export async function hydrateMissingExtraNames(steamId: string) {
   const db = getSqliteDatabase()
+
+  // Bulk-seed `games` from the canonical Steam catalog first. This is a
+  // once-per-week no-op for every user after the first, and covers the
+  // entire 200k-app catalog in one shot (Tools / Software / SDK entries
+  // included). The per-appid loop below becomes a safety net for the few
+  // apps the catalog genuinely doesn't cover.
+  await populateGamesFromSteamCatalog()
+
   const rows = db
     .prepare(
       `

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -190,6 +190,17 @@ function createBaseSchema(db: DatabaseSync) {
       FOREIGN KEY (steam_id) REFERENCES steam_profile(steam_id)
     );
 
+    -- Single-row tracking table for the bulk import of Steam's canonical
+    -- app catalog (IStoreService/GetAppList). Records when we last seeded
+    -- the games table with the 200k+ entries that cover Tools, Software
+    -- and SDK apps the per-appid resolution endpoints cannot name. Used
+    -- by the populate routine to throttle itself to one run per week.
+    CREATE TABLE IF NOT EXISTS app_catalog_meta (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      populated_at TEXT NOT NULL,
+      entry_count INTEGER NOT NULL
+    );
+
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id ON user_games(steam_id);
     CREATE INDEX IF NOT EXISTS idx_user_games_steam_id_owned ON user_games(steam_id, owned);
     CREATE INDEX IF NOT EXISTS idx_stats_snapshot_steam_id ON stats_snapshot(steam_id);

--- a/lib/server/steam-app-catalog.ts
+++ b/lib/server/steam-app-catalog.ts
@@ -1,0 +1,193 @@
+import "server-only"
+
+import { getSqliteDatabase } from "@/lib/server/sqlite"
+import { nowIso } from "@/lib/server/steam-store-utils"
+import { logger } from "@/lib/server/logger"
+
+const STEAM_API_BASE = "https://api.steampowered.com"
+const CATALOG_TTL_MS = 24 * 60 * 60 * 1000
+const FAILURE_COOLDOWN_MS = 5 * 60 * 1000
+const MAX_PAGES = 50
+const DB_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000
+
+let cached: { map: Map<number, string>; fetchedAt: number } | null = null
+let failedUntil = 0
+let inflight: Promise<Map<number, string> | null> | null = null
+
+type GetAppListResponse = {
+  response?: {
+    apps?: Array<{ appid: number; name: string }>
+    have_more_results?: boolean
+    last_appid?: number
+  }
+}
+
+/**
+ * Returns a Map<appid, name> for every app currently published on Steam —
+ * including Tools, Software and SDK entries that `store.steampowered.com/api/appdetails`
+ * reports as `success=false` and that have no achievement schema or community
+ * page (e.g. appid 745, "Dota 2 Workshop Tools"). This is the only endpoint
+ * that enumerates those apps with their public names.
+ *
+ * The catalog is large (200k+ entries across ~5 paginated calls) and is
+ * cached in-memory for 24h. Concurrent callers share an in-flight promise
+ * so we never fetch twice in parallel. Failures apply a 5-minute cooldown
+ * so a broken endpoint can't be hammered repeatedly.
+ *
+ * Returns null when the catalog is unavailable so callers can fall through
+ * gracefully.
+ */
+export async function getSteamAppCatalog(): Promise<Map<number, string> | null> {
+  const now = Date.now()
+  if (cached && now - cached.fetchedAt < CATALOG_TTL_MS) {
+    return cached.map
+  }
+  if (now < failedUntil) {
+    return null
+  }
+  if (inflight) {
+    return inflight
+  }
+
+  inflight = fetchCatalogFromSteam()
+    .then((map) => {
+      if (map && map.size > 0) {
+        cached = { map, fetchedAt: Date.now() }
+      } else {
+        failedUntil = Date.now() + FAILURE_COOLDOWN_MS
+      }
+      return map
+    })
+    .finally(() => {
+      inflight = null
+    })
+  return inflight
+}
+
+async function fetchCatalogFromSteam(): Promise<Map<number, string> | null> {
+  const apiKey = process.env.STEAM_API_KEY
+  if (!apiKey) return null
+
+  const map = new Map<number, string>()
+  let lastAppid = 0
+  let pages = 0
+
+  try {
+    while (pages < MAX_PAGES) {
+      pages++
+      const url = new URL(`${STEAM_API_BASE}/IStoreService/GetAppList/v1/`)
+      url.searchParams.set("key", apiKey)
+      url.searchParams.set("format", "json")
+      url.searchParams.set("include_games", "1")
+      url.searchParams.set("include_dlc", "1")
+      url.searchParams.set("include_software", "1")
+      url.searchParams.set("include_hardware", "1")
+      url.searchParams.set("include_videos", "0")
+      url.searchParams.set("max_results", "50000")
+      if (lastAppid > 0) url.searchParams.set("last_appid", String(lastAppid))
+
+      const response = await fetch(url.toString(), { cache: "no-store" })
+      if (!response.ok) {
+        logger.warn(
+          { status: response.status, pages, entriesSoFar: map.size },
+          "IStoreService/GetAppList returned non-OK — aborting catalog fetch",
+        )
+        return null
+      }
+
+      const data = (await response.json()) as GetAppListResponse
+      const apps = data.response?.apps ?? []
+      for (const app of apps) {
+        if (app.name) map.set(app.appid, app.name)
+      }
+
+      if (!data.response?.have_more_results || !data.response?.last_appid) break
+      if (data.response.last_appid === lastAppid) break
+      lastAppid = data.response.last_appid
+    }
+
+    logger.info({ entries: map.size, pages }, "Fetched Steam app catalog")
+    return map
+  } catch (error) {
+    logger.warn({ err: error }, "Failed to fetch Steam app catalog")
+    return null
+  }
+}
+
+/**
+ * Bulk-seeds the shared `games` table from Steam's canonical app catalog.
+ *
+ * The Steam Web API has no single-app endpoint that reliably names Tools,
+ * Software and SDK entries (`store.steampowered.com/api/appdetails` returns
+ * `success=false` for them, `GetSchemaForGame` requires achievements, and
+ * `steamcommunity.com/app/<id>` redirects to the homepage). The only source
+ * that enumerates these apps is `IStoreService/GetAppList/v1/`, which
+ * returns the entire Steam catalog — 200k+ entries spread across ~5
+ * paginated calls.
+ *
+ * Runs at most once every 7 days across the whole deployment, tracked via
+ * the single-row `app_catalog_meta` table. The first user whose sync hits
+ * this path pays the ~5s fetch cost; every subsequent caller in the next
+ * week is an O(1) no-op via the `populated_at` check.
+ *
+ * Uses `INSERT OR IGNORE` so rows already populated by per-user syncs
+ * (with their Spanish-localized `name` and image URLs) stay intact.
+ * Newly-inserted rows land with English catalog names and NULL images;
+ * when a user subsequently owns one of those apps, the normal library
+ * sync upserts the localized name and images on top.
+ *
+ * Swallows all errors and returns 0 when the fetch fails or is throttled.
+ * The per-appid resolution chain in `hydrateMissingExtraNames` remains
+ * the safety net for apps the catalog genuinely doesn't cover.
+ *
+ * Returns the number of rows newly inserted into `games`.
+ */
+export async function populateGamesFromSteamCatalog(): Promise<number> {
+  const db = getSqliteDatabase()
+
+  const meta = db.prepare(`SELECT populated_at FROM app_catalog_meta WHERE id = 1`).get() as
+    | { populated_at: string }
+    | undefined
+
+  if (meta?.populated_at) {
+    const ageMs = Date.now() - Date.parse(meta.populated_at)
+    if (ageMs < DB_REFRESH_INTERVAL_MS) {
+      return 0
+    }
+  }
+
+  const catalog = await getSteamAppCatalog()
+  if (!catalog || catalog.size === 0) return 0
+
+  const now = nowIso()
+  const insert = db.prepare(`INSERT OR IGNORE INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)`)
+
+  let inserted = 0
+  db.exec("BEGIN")
+  try {
+    for (const [appid, name] of catalog) {
+      const result = insert.run(appid, name, now, now)
+      if (result.changes > 0) inserted++
+    }
+    db.prepare(
+      `INSERT INTO app_catalog_meta (id, populated_at, entry_count)
+       VALUES (1, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET populated_at = excluded.populated_at, entry_count = excluded.entry_count`,
+    ).run(now, catalog.size)
+    db.exec("COMMIT")
+  } catch (error) {
+    db.exec("ROLLBACK")
+    logger.warn({ err: error }, "populateGamesFromSteamCatalog failed")
+    return 0
+  }
+
+  logger.info({ inserted, catalogSize: catalog.size }, "Seeded games table from Steam app catalog")
+  return inserted
+}
+
+/** Test-only: reset in-memory state between test cases. */
+export function __resetSteamAppCatalogForTests() {
+  cached = null
+  failedUntil = 0
+  inflight = null
+}

--- a/test/steam-app-catalog.test.ts
+++ b/test/steam-app-catalog.test.ts
@@ -1,0 +1,271 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+let tmpDir: string
+const ORIGINAL_FETCH = globalThis.fetch
+const ORIGINAL_KEY = process.env.STEAM_API_KEY
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-catalog-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  process.env.STEAM_API_KEY = "test-key"
+  vi.resetModules()
+})
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  delete process.env.SQLITE_PATH
+  if (ORIGINAL_KEY === undefined) delete process.env.STEAM_API_KEY
+  else process.env.STEAM_API_KEY = ORIGINAL_KEY
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/**
+ * Mocks IStoreService/GetAppList as a single page of results. Any non-API
+ * host gets a fail response so the caller crashes loudly if something other
+ * than the catalog fetch tries to use the network.
+ */
+function mockCatalogPage(apps: Array<{ appid: number; name: string }>) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = new URL(String(input))
+    if (url.hostname !== "api.steampowered.com") {
+      return { ok: false, status: 404, json: async () => ({}), text: async () => "" } as unknown as Response
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        response: { apps, have_more_results: false },
+      }),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+}
+
+describe("populateGamesFromSteamCatalog", () => {
+  it("inserts every catalog entry into games on the first call", async () => {
+    mockCatalogPage([
+      { appid: 745, name: "Dota 2 Workshop Tools" },
+      { appid: 620, name: "Portal 2" },
+      { appid: 440, name: "Team Fortress 2" },
+    ])
+
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const { populateGamesFromSteamCatalog } = await import("@/lib/server/steam-app-catalog")
+
+    const inserted = await populateGamesFromSteamCatalog()
+    expect(inserted).toBe(3)
+
+    const rows = db.prepare("SELECT appid, name FROM games ORDER BY appid").all() as Array<{
+      appid: number
+      name: string
+    }>
+    expect(rows).toEqual([
+      { appid: 440, name: "Team Fortress 2" },
+      { appid: 620, name: "Portal 2" },
+      { appid: 745, name: "Dota 2 Workshop Tools" },
+    ])
+
+    const meta = db.prepare("SELECT entry_count FROM app_catalog_meta WHERE id = 1").get() as {
+      entry_count: number
+    }
+    expect(meta.entry_count).toBe(3)
+  })
+
+  it("is a no-op on subsequent calls inside the 7-day TTL", async () => {
+    mockCatalogPage([{ appid: 745, name: "Dota 2 Workshop Tools" }])
+
+    const { populateGamesFromSteamCatalog } = await import("@/lib/server/steam-app-catalog")
+
+    const first = await populateGamesFromSteamCatalog()
+    expect(first).toBe(1)
+
+    const callsBefore = (globalThis.fetch as unknown as { mock: { calls: unknown[] } }).mock.calls.length
+
+    const second = await populateGamesFromSteamCatalog()
+    expect(second).toBe(0)
+
+    const callsAfter = (globalThis.fetch as unknown as { mock: { calls: unknown[] } }).mock.calls.length
+    expect(callsAfter).toBe(callsBefore)
+  })
+
+  it("re-fetches after the 7-day TTL has elapsed", async () => {
+    mockCatalogPage([{ appid: 745, name: "Dota 2 Workshop Tools" }])
+
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const { populateGamesFromSteamCatalog, __resetSteamAppCatalogForTests } =
+      await import("@/lib/server/steam-app-catalog")
+
+    await populateGamesFromSteamCatalog()
+
+    // Back-date the meta row so the TTL check treats it as stale.
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    db.prepare("UPDATE app_catalog_meta SET populated_at = ? WHERE id = 1").run(eightDaysAgo)
+
+    // Clear the in-memory catalog cache so we exercise the full fetch path.
+    __resetSteamAppCatalogForTests()
+
+    mockCatalogPage([
+      { appid: 745, name: "Dota 2 Workshop Tools" },
+      { appid: 12345, name: "Brand New Tool" },
+    ])
+
+    const secondInserted = await populateGamesFromSteamCatalog()
+    expect(secondInserted).toBe(1)
+
+    const newRow = db.prepare("SELECT name FROM games WHERE appid = 12345").get() as { name: string }
+    expect(newRow.name).toBe("Brand New Tool")
+  })
+
+  it("does not overwrite existing games rows with catalog data (INSERT OR IGNORE)", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const now = new Date().toISOString()
+
+    db.prepare(
+      `INSERT INTO games (appid, name, image_landscape_url, created_at, updated_at)
+       VALUES (620, 'Portal 2 ES', 'https://cdn.example/portal2.jpg', ?, ?)`,
+    ).run(now, now)
+
+    mockCatalogPage([{ appid: 620, name: "Portal 2" }])
+
+    const { populateGamesFromSteamCatalog } = await import("@/lib/server/steam-app-catalog")
+    await populateGamesFromSteamCatalog()
+
+    const row = db.prepare("SELECT name, image_landscape_url FROM games WHERE appid = 620").get() as {
+      name: string
+      image_landscape_url: string | null
+    }
+    expect(row.name).toBe("Portal 2 ES")
+    expect(row.image_landscape_url).toBe("https://cdn.example/portal2.jpg")
+  })
+
+  it("returns 0 and writes nothing when the catalog fetch fails", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return { ok: false, status: 500, json: async () => ({}), text: async () => "" } as unknown as Response
+    }) as unknown as typeof fetch
+
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const { populateGamesFromSteamCatalog } = await import("@/lib/server/steam-app-catalog")
+
+    const inserted = await populateGamesFromSteamCatalog()
+    expect(inserted).toBe(0)
+
+    const count = db.prepare("SELECT COUNT(*) as c FROM games").get() as { c: number }
+    expect(count.c).toBe(0)
+
+    const meta = db.prepare("SELECT populated_at FROM app_catalog_meta WHERE id = 1").get()
+    expect(meta).toBeUndefined()
+  })
+
+  it("paginates through multiple catalog pages via last_appid", async () => {
+    const pages = [
+      {
+        apps: [{ appid: 100, name: "Game 100" }],
+        have_more_results: true,
+        last_appid: 100,
+      },
+      {
+        apps: [{ appid: 200, name: "Game 200" }],
+        have_more_results: true,
+        last_appid: 200,
+      },
+      {
+        apps: [{ appid: 300, name: "Game 300" }],
+        have_more_results: false,
+      },
+    ]
+    let pageIndex = 0
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      if (url.hostname !== "api.steampowered.com") {
+        return { ok: false, status: 404, json: async () => ({}), text: async () => "" } as unknown as Response
+      }
+      const page = pages[pageIndex++] ?? pages[pages.length - 1]
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ response: page }),
+      } as unknown as Response
+    }) as unknown as typeof fetch
+
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const { populateGamesFromSteamCatalog } = await import("@/lib/server/steam-app-catalog")
+
+    const inserted = await populateGamesFromSteamCatalog()
+    expect(inserted).toBe(3)
+    const rows = db.prepare("SELECT appid FROM games ORDER BY appid").all() as Array<{ appid: number }>
+    expect(rows.map((r) => r.appid)).toEqual([100, 200, 300])
+  })
+})
+
+describe("hydrateMissingExtraNames + catalog bulk-populate", () => {
+  const STEAM_ID = "76561198023709299"
+
+  async function seedProfileWithExtra(appId: number) {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const now = new Date().toISOString()
+    db.prepare("INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)").run(STEAM_ID, now, now)
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, synced_at, created_at, updated_at)
+       VALUES (?, ?, 500, ?, ?, ?)`,
+    ).run(STEAM_ID, appId, now, now, now)
+    return db
+  }
+
+  it("resolves a Tool appid via the catalog without hitting store/schema/community", async () => {
+    const db = await seedProfileWithExtra(745)
+
+    const hosts: string[] = []
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      hosts.push(url.hostname)
+      if (url.hostname === "api.steampowered.com") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            response: {
+              apps: [{ appid: 745, name: "Dota 2 Workshop Tools" }],
+              have_more_results: false,
+            },
+          }),
+        } as unknown as Response
+      }
+      return { ok: false, status: 500, json: async () => ({}), text: async () => "" } as unknown as Response
+    }) as unknown as typeof fetch
+
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+
+    const row = db.prepare("SELECT name FROM games WHERE appid = 745").get() as { name: string } | undefined
+    expect(row?.name).toBe("Dota 2 Workshop Tools")
+
+    // No per-appid fallback calls should have fired, since the bulk populate
+    // landed the name before the per-appid loop got a chance to look.
+    expect(hosts).not.toContain("store.steampowered.com")
+    expect(hosts).not.toContain("steamcommunity.com")
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a one-shot bulk-populate of the shared `games` table from Steam's canonical `IStoreService/GetAppList/v1/` catalog. Fixes the long-standing "extras without a name" problem for Tools / Software / SDK entries (e.g. appid 745, "Dota 2 Workshop Tools") that the existing store → schema → community chain can't resolve because they have no public store page, no achievement schema, and their community URL redirects to the Steam homepage.
- New single-row `app_catalog_meta` table throttles the bulk populate to once every 7 days across the whole deployment. The first user who syncs after deploy pays the ~5s catalog fetch; the next 7 days of syncs are an O(1) no-op via the `populated_at` check.
- `INSERT OR IGNORE` preserves rows already populated by per-user syncs (Spanish-localized names + image URLs). The catalog only fills the long-tail apps the per-user path can't reach. The existing three per-appid sources in `hydrateMissingExtraNames` remain as a safety net.
- Catalog fetch is memoized in-process for 24h, with a 5-minute failure cooldown and a shared in-flight promise so concurrent callers never fetch twice.

## Test plan

- [x] `pnpm test` — 418/418 passing (7 new tests in `test/steam-app-catalog.test.ts`)
- [x] `pnpm lint` (oxlint + typecheck) — clean
- [ ] Deploy to staging, trigger a sync, confirm `app_catalog_meta` row lands, confirm app 745 renders with "Dota 2 Workshop Tools" instead of "App #745"
- [ ] Re-sync within the same week, confirm no extra `IStoreService/GetAppList` requests fire (watch logs for "Seeded games table from Steam app catalog" — should appear only once)