### PR TITLE
fix(extras): schema fallback for achievements + strip Valve placeholder names

### DIFF
--- a/lib/server/extra-games.ts
+++ b/lib/server/extra-games.ts
@@ -7,6 +7,7 @@ import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { isStale, nowIso } from "@/lib/server/steam-store-utils"
 import { ACHIEVEMENTS_STALE_MS } from "@/lib/server/steam-achievements-sync"
 import { populateGamesFromSteamCatalog } from "@/lib/server/steam-app-catalog"
+import { isPlaceholderName, PLACEHOLDER_NAME_SQL_MATCH } from "@/lib/server/placeholder-names"
 import { logger } from "@/lib/server/logger"
 
 export type ExtraGame = {
@@ -167,7 +168,12 @@ export async function hydrateMissingExtraNames(steamId: string) {
       FROM extra_games e
       LEFT JOIN games g ON g.appid = e.appid
       WHERE e.steam_id = ?
-        AND (g.appid IS NULL OR g.name IS NULL OR g.name = '')
+        AND (
+          g.appid IS NULL
+          OR g.name IS NULL
+          OR g.name = ''
+          OR ${PLACEHOLDER_NAME_SQL_MATCH}
+        )
         AND (g.name_source IS NULL OR g.name_source != 'manual')
       ORDER BY e.playtime_forever DESC
     `,
@@ -212,7 +218,12 @@ export async function hydrateMissingExtraNames(steamId: string) {
         consecutiveStoreFailures = 0
         const payload = (await response.json()) as Record<string, StoreAppDetails>
         const entry = payload[String(appid)]
-        resolvedName = entry?.success && entry.data?.name ? entry.data.name : null
+        const candidate = entry?.success && entry.data?.name ? entry.data.name : null
+        // Drop placeholder names so later sources get a chance to
+        // produce the real title.
+        if (candidate && !isPlaceholderName(candidate)) {
+          resolvedName = candidate
+        }
       }
     } catch (error) {
       consecutiveStoreFailures++
@@ -223,7 +234,7 @@ export async function hydrateMissingExtraNames(steamId: string) {
     if (!resolvedName) {
       try {
         const schema = await getGameSchema(appid)
-        if (schema?.gameName) {
+        if (schema?.gameName && !isPlaceholderName(schema.gameName)) {
           resolvedName = schema.gameName
         }
       } catch {
@@ -242,7 +253,10 @@ export async function hydrateMissingExtraNames(steamId: string) {
     if (!resolvedName && consecutiveSupportFailures < 5) {
       const result = await fetchSupportGameName(appid)
       if (result.kind === "ok") {
-        resolvedName = result.name
+        // Support's HTML title is normally human-readable but apply
+        // the same safety filter in case Valve ever starts echoing
+        // internal placeholders through it too.
+        if (!isPlaceholderName(result.name)) resolvedName = result.name
         consecutiveSupportFailures = 0
       } else if (result.kind === "empty") {
         consecutiveSupportFailures = 0
@@ -260,7 +274,7 @@ export async function hydrateMissingExtraNames(steamId: string) {
     if (!resolvedName && consecutiveCommunityFailures < 5) {
       const result = await fetchCommunityGameName(appid)
       if (result.kind === "ok") {
-        resolvedName = result.name
+        if (!isPlaceholderName(result.name)) resolvedName = result.name
         consecutiveCommunityFailures = 0
       } else if (result.kind === "empty") {
         consecutiveCommunityFailures = 0
@@ -393,9 +407,12 @@ export function persistExtraAchievements(
   db.exec("BEGIN")
   try {
     // Cache the game name on the shared games table so the UI can show it.
-    // This is the authoritative name source for delisted games — far more
-    // reliable than the public store appdetails API.
-    if (gameName) {
+    // Valve's Web API occasionally returns internal placeholder names
+    // (ValveTestAppX, UntitledApp, InvitedPartnerAppX) for unowned-but-
+    // played games; those are skipped so hydrateMissingExtraNames can
+    // resolve the real name via Steam Support instead of our cache
+    // permanently sticking to the placeholder.
+    if (gameName && !isPlaceholderName(gameName)) {
       db.prepare(
         `
         INSERT INTO games (appid, name, created_at, updated_at)
@@ -495,12 +512,49 @@ export async function syncExtraAchievements(steamId: string) {
         // extras whose appid isn't in `games` yet, which on a fresh database
         // was preventing every extras sync from persisting anything.
         const playerAchievements = await getPlayerAchievements(steamId, row.appid)
-        if (!playerAchievements) {
-          // Mark as known-broken so we don't retry every sync.
-          persistExtraAchievements(steamId, row.appid, "", [])
+        if (playerAchievements) {
+          persistExtraAchievements(
+            steamId,
+            row.appid,
+            playerAchievements.gameName,
+            playerAchievements.achievements ?? [],
+          )
           continue
         }
-        persistExtraAchievements(steamId, row.appid, playerAchievements.gameName, playerAchievements.achievements ?? [])
+
+        // Fallback: GetPlayerAchievements refuses unowned-but-played
+        // games with "Profile is not public" (even when the profile is
+        // public — it's how Valve signals "you don't own this"). In
+        // that case the schema endpoint still returns the full list of
+        // defined achievements, so we can at least record the total
+        // count. The user's actual unlocked count is unknowable via
+        // the Web API here, so it stays at 0 — the UI shows "0/N (0%)"
+        // instead of a bare "-", which is strictly more honest than
+        // the previous "known-broken" sentinel.
+        //
+        // Schema responses for these apps frequently carry a placeholder
+        // gameName like "ValveTestApp43110" — persistExtraAchievements
+        // filters those out so the hydrate chain can resolve the real
+        // name later via Steam Support.
+        const schema = await getGameSchema(row.appid)
+        const schemaAchievements = schema?.availableGameStats?.achievements ?? []
+        if (schemaAchievements.length > 0) {
+          persistExtraAchievements(
+            steamId,
+            row.appid,
+            schema?.gameName ?? "",
+            // Synthesize a placeholder achievement row per schema entry
+            // with achieved=0 — persistExtraAchievements counts length
+            // as total and only increments unlocked on achieved === 1.
+            schemaAchievements.map((a) => ({ apiname: a.name, achieved: 0 })),
+          )
+          continue
+        }
+
+        // Neither endpoint knows the game — mark as broken (0/0) so we
+        // don't retry on every sync. Matches the pre-fix behaviour for
+        // genuinely achievement-less apps (tools, SDKs, servers).
+        persistExtraAchievements(steamId, row.appid, "", [])
       } catch (error) {
         logger.warn({ err: error, appId: row.appid }, "Per-extras achievements sync failed — will retry on next sync")
       }

--- a/lib/server/orphan-names.ts
+++ b/lib/server/orphan-names.ts
@@ -1,5 +1,6 @@
 import "server-only"
 
+import { PLACEHOLDER_NAME_SQL_MATCH } from "@/lib/server/placeholder-names"
 import { getSqliteDatabase } from "@/lib/server/sqlite"
 import { nowIso } from "@/lib/server/steam-store-utils"
 
@@ -63,7 +64,12 @@ export function listOrphanNames(): OrphanName[] {
         MAX(r.rtime_last_played) AS rtime_last_played
       FROM referenced r
       LEFT JOIN games g ON g.appid = r.appid
-      WHERE (g.appid IS NULL OR g.name IS NULL OR g.name = '')
+      WHERE (
+        g.appid IS NULL
+        OR g.name IS NULL
+        OR g.name = ''
+        OR ${PLACEHOLDER_NAME_SQL_MATCH}
+      )
       GROUP BY r.appid
       ORDER BY playtime_forever DESC
       `,

--- a/lib/server/placeholder-names.ts
+++ b/lib/server/placeholder-names.ts
@@ -1,0 +1,42 @@
+import "server-only"
+
+/**
+ * Internal placeholder names Valve's Web API returns for apps whose
+ * public title hasn't been set (or has been withheld). These show up
+ * via GetPlayerAchievements.gameName and GetSchemaForGame.gameName
+ * most commonly for unowned-but-played games (family share, refunded,
+ * delisted) where Valve serves a developer-time internal name instead
+ * of the customer-facing title. Steam Support's "Help with game"
+ * wizard knows the real name for these, so our hydrate chain can
+ * resolve them — but only if we actually flag them as placeholders
+ * and skip writing them to `games.name`.
+ *
+ * Observed examples in the wild:
+ *   ValveTestApp43110      (Metro 2033)
+ *   UntitledApp            (generic placeholder)
+ *   InvitedPartnerApp102   (partner-submitted entries)
+ *
+ * Patterns duplicated in SQL form because SQLite's GLOB syntax is a
+ * subset of regex — keeps the WHERE clauses below readable and in
+ * sync with this list.
+ */
+
+export const PLACEHOLDER_NAME_PATTERNS: RegExp[] = [/^ValveTestApp\d+$/, /^UntitledApp$/, /^InvitedPartnerApp\d+$/]
+
+/**
+ * SQL fragment — expand into a WHERE clause with `OR` joins. Uses
+ * GLOB (case-sensitive) because Valve returns these names verbatim.
+ * Keep in sync with PLACEHOLDER_NAME_PATTERNS above.
+ */
+export const PLACEHOLDER_NAME_SQL_MATCH =
+  "(g.name GLOB 'ValveTestApp[0-9]*' OR g.name = 'UntitledApp' OR g.name GLOB 'InvitedPartnerApp[0-9]*')"
+
+/**
+ * Returns true when `name` is one of Valve's internal placeholders
+ * rather than a real game title. Used to short-circuit upserts to
+ * `games.name` so the hydrate chain can retry with Steam Support.
+ */
+export function isPlaceholderName(name: string | null | undefined): boolean {
+  if (!name) return false
+  return PLACEHOLDER_NAME_PATTERNS.some((rx) => rx.test(name))
+}

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -295,6 +295,50 @@ function applyAdditiveMigrations(db: DatabaseSync) {
   addColumnIfMissing(db, "extra_games", "perfect_game", "INTEGER NOT NULL DEFAULT 0")
   // Provenance of games.name. See CREATE TABLE comment above.
   addColumnIfMissing(db, "games", "name_source", "TEXT NOT NULL DEFAULT 'auto'")
+  resetPlaceholderGameNames(db)
+}
+
+/**
+ * Idempotent self-healing sweep: any `games` row whose `name` matches one
+ * of Valve's internal placeholders (ValveTestAppX, UntitledApp,
+ * InvitedPartnerAppX) is reset so the extras hydrate chain can re-resolve
+ * the real title via the Steam Support wizard on the next sync. Manual
+ * admin names (`name_source='manual'`) are preserved.
+ *
+ * Also clears the corresponding `extra_games` achievement cache
+ * (`achievements_synced_at = NULL`, counts → NULL) so the sync path
+ * re-runs through the new schema fallback and gets the correct total
+ * achievement count the next time it fires.
+ *
+ * Runs on every DB open. Cheap UPDATE, no-op once no placeholder names
+ * remain.
+ */
+function resetPlaceholderGameNames(db: DatabaseSync) {
+  const PLACEHOLDER_WHERE =
+    "(name GLOB 'ValveTestApp[0-9]*' OR name = 'UntitledApp' OR name GLOB 'InvitedPartnerApp[0-9]*')"
+
+  // Clear cached achievement counts on any extras that reference a
+  // placeholder-named row. Must run BEFORE the games UPDATE so the
+  // subquery still sees the placeholder names.
+  db.exec(`
+    UPDATE extra_games
+    SET achievements_synced_at = NULL,
+        unlocked_count = NULL,
+        total_count = NULL,
+        perfect_game = 0
+    WHERE appid IN (SELECT appid FROM games WHERE ${PLACEHOLDER_WHERE});
+  `)
+
+  // Reset placeholder names to empty so hydrateMissingExtraNames'
+  // WHERE — which matches both empty AND placeholder rows — picks
+  // them up on the next sync. Preserve admin-set manual names.
+  db.exec(`
+    UPDATE games
+    SET name = '',
+        updated_at = COALESCE(updated_at, '1970-01-01T00:00:00Z')
+    WHERE ${PLACEHOLDER_WHERE}
+      AND (name_source IS NULL OR name_source != 'manual');
+  `)
 }
 
 export function getSqliteDatabase() {

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -10,6 +10,7 @@ import {
   persistExtraGames,
   syncExtraAchievements,
 } from "@/lib/server/extra-games"
+import { isPlaceholderName } from "@/lib/server/placeholder-names"
 import { logger } from "@/lib/server/logger"
 import {
   nowIso,
@@ -184,9 +185,15 @@ export function persistOwnedGames(steamId: string, games: SteamGame[]) {
     markMissingAsUnowned.run(now, steamId)
 
     for (const game of games) {
+      // Valve occasionally returns internal placeholder names here too
+      // (ValveTestAppX, etc) for partner-uploaded entries. Persist an
+      // empty string instead so hydrateMissingExtraNames' WHERE —
+      // which also matches empty names — resolves the real title via
+      // the Steam Support chain on the next sync tick.
+      const safeName = isPlaceholderName(game.name) ? "" : game.name
       insertGame.run(
         game.appid,
-        game.name,
+        safeName,
         nullIfUndefined(game.img_icon_url),
         nullIfUndefined(game.img_logo_url),
         typeof game.has_community_visible_stats === "boolean" ? Number(game.has_community_visible_stats) : null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -356,6 +356,63 @@ describe("syncExtraAchievements", () => {
     expect(row.achievements_synced_at).toBeTruthy()
   })
 
+  it("falls back to GetSchemaForGame when GetPlayerAchievements refuses (profile-not-public)", async () => {
+    // Simulates an unowned-but-played game: GetPlayerAchievements
+    // returns null ("Profile is not public" sentinel), but the schema
+    // endpoint still exposes the full achievement list. The sync path
+    // should record the total from the schema and leave unlocked at 0
+    // so the UI shows "0/N (0%)" instead of a bare "-".
+    mockSteamApi({
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getGameSchema: vi.fn().mockResolvedValue({
+        gameName: "Metro 2033",
+        availableGameStats: {
+          achievements: Array.from({ length: 48 }, (_, i) => ({ name: `ACH_${i}` })),
+        },
+      }),
+    })
+    const db = await seedExtra(43110)
+    const { syncExtraAchievements } = await import("@/lib/server/extra-games")
+    await syncExtraAchievements(STEAM_ID)
+    const row = db
+      .prepare("SELECT unlocked_count, total_count, achievements_synced_at FROM extra_games WHERE appid=43110")
+      .get() as { unlocked_count: number; total_count: number; achievements_synced_at: string }
+    expect(row.total_count).toBe(48)
+    expect(row.unlocked_count).toBe(0)
+    expect(row.achievements_synced_at).toBeTruthy()
+    const game = db.prepare("SELECT name FROM games WHERE appid=43110").get() as { name: string }
+    expect(game.name).toBe("Metro 2033")
+  })
+
+  it("skips the games.name write when schema returns a placeholder gameName", async () => {
+    // Valve often returns "ValveTestApp<id>" for unowned-but-played
+    // games. persistExtraAchievements must NOT write that placeholder
+    // to the shared games cache so hydrateMissingExtraNames can
+    // resolve the real title via the Steam Support chain later.
+    mockSteamApi({
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getGameSchema: vi.fn().mockResolvedValue({
+        gameName: "ValveTestApp43110",
+        availableGameStats: {
+          achievements: [{ name: "ACH_1" }, { name: "ACH_2" }],
+        },
+      }),
+    })
+    const db = await seedExtra(43110)
+    const { syncExtraAchievements } = await import("@/lib/server/extra-games")
+    await syncExtraAchievements(STEAM_ID)
+
+    // Totals still recorded from the schema — we got the count even
+    // though we refused to cache the name.
+    const row = db.prepare("SELECT total_count FROM extra_games WHERE appid=43110").get() as { total_count: number }
+    expect(row.total_count).toBe(2)
+
+    // games.name left empty (or never written) so the hydrate pass
+    // has a chance to resolve the real title.
+    const game = db.prepare("SELECT name FROM games WHERE appid=43110").get() as { name: string } | undefined
+    expect(game?.name ?? "").toBe("")
+  })
+
   it("skips known-broken rows (synced once with total_count=0) without hitting Steam", async () => {
     const getPlayerAchievements = vi.fn()
     mockSteamApi({ getPlayerAchievements })
@@ -486,6 +543,55 @@ describe("hydrateMissingExtraNames", () => {
     await hydrateMissingExtraNames(STEAM_ID)
     const row = db.prepare("SELECT name FROM games WHERE appid=111").get() as { name: string }
     expect(row.name).toBe("Resolved 111")
+  })
+
+  it("retries rows whose games.name is a Valve placeholder", async () => {
+    const db = await seedExtraWithoutName(43110)
+    const now = new Date().toISOString()
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (43110, 'ValveTestApp43110', ?, ?)`).run(
+      now,
+      now,
+    )
+    mockStoreSingle((appid) => ({ success: true, data: { name: `Resolved ${appid}` } }))
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=43110").get() as { name: string }
+    expect(row.name).toBe("Resolved 43110")
+  })
+
+  it("refuses to overwrite games.name with another placeholder returned by store", async () => {
+    const db = await seedExtraWithoutName(43110)
+    const now = new Date().toISOString()
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (43110, 'ValveTestApp43110', ?, ?)`).run(
+      now,
+      now,
+    )
+    // Store returns another placeholder; GetSchemaForGame returns one
+    // too; both should be rejected so the row stays flagged for the
+    // next run to retry via Support/community.
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const u = new URL(String(input))
+      if (u.hostname === "store.steampowered.com") {
+        const appid = u.searchParams.get("appids") ?? "0"
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ [appid]: { success: true, data: { name: "ValveTestApp43110" } } }),
+          text: async () => "",
+        } as unknown as Response
+      }
+      return { ok: false, status: 404, json: async () => ({}), text: async () => "" } as unknown as Response
+    }) as unknown as typeof fetch
+    vi.doMock("@/lib/steam-api", () => ({
+      getGameSchema: vi.fn().mockResolvedValue({ gameName: "ValveTestApp43110" }),
+      getPlayerAchievements: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    const { hydrateMissingExtraNames } = await import("@/lib/server/extra-games")
+    await hydrateMissingExtraNames(STEAM_ID)
+    const row = db.prepare("SELECT name FROM games WHERE appid=43110").get() as { name: string }
+    expect(row.name).toBe("ValveTestApp43110") // left as-is, will retry next run
   })
 
   it("upserts the real name when the store API returns success=true", async () => {

--- a/test/placeholder-names.test.ts
+++ b/test/placeholder-names.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest"
+
+import { isPlaceholderName } from "@/lib/server/placeholder-names"
+
+describe("isPlaceholderName", () => {
+  it("matches ValveTestApp followed by digits", () => {
+    expect(isPlaceholderName("ValveTestApp43110")).toBe(true)
+    expect(isPlaceholderName("ValveTestApp1")).toBe(true)
+    expect(isPlaceholderName("ValveTestApp203190")).toBe(true)
+  })
+
+  it("matches UntitledApp exactly", () => {
+    expect(isPlaceholderName("UntitledApp")).toBe(true)
+  })
+
+  it("matches InvitedPartnerApp followed by digits", () => {
+    expect(isPlaceholderName("InvitedPartnerApp102")).toBe(true)
+    expect(isPlaceholderName("InvitedPartnerApp9")).toBe(true)
+  })
+
+  it("does not match real game names", () => {
+    expect(isPlaceholderName("Portal 2")).toBe(false)
+    expect(isPlaceholderName("Counter-Strike 2")).toBe(false)
+    expect(isPlaceholderName("Metro 2033")).toBe(false)
+    expect(isPlaceholderName("Half-Life: Alyx")).toBe(false)
+  })
+
+  it("does not match variants with trailing text (case-sensitive by design)", () => {
+    expect(isPlaceholderName("ValveTestApp")).toBe(false) // no digits
+    expect(isPlaceholderName("ValveTestApp43110 (Beta)")).toBe(false)
+    expect(isPlaceholderName("valvetestapp43110")).toBe(false) // lowercase — different binary
+    expect(isPlaceholderName("UntitledApp2")).toBe(false) // UntitledApp doesn't take a numeric suffix
+    expect(isPlaceholderName("InvitedPartnerApp")).toBe(false)
+  })
+
+  it("returns false for empty, null or undefined", () => {
+    expect(isPlaceholderName("")).toBe(false)
+    expect(isPlaceholderName(null)).toBe(false)
+    expect(isPlaceholderName(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Two user-reported extras bugs fixed in one pass.

### Bug 1 — extras with achievements showing `-` instead of `0/X`

`GetPlayerAchievements` refuses unowned-but-played games with a `success=false` + `"Profile is not public"` sentinel (even when the profile is public — Valve uses that error to signal "you don't own this"). The extras sync worker was treating every null response as "known-broken", persisting `total_count=0`, and the game card was falling through to the `-` branch for games like Metro 2033, Starbound, DC Universe Online, etc.

**Fix**: when `GetPlayerAchievements` returns null, fall back to `GetSchemaForGame` which still exposes the full achievement list for unowned games. Total count is recorded, unlocked stays at 0 → UI shows `0/N (0%)` instead of `-`. If the schema also has 0 achievements (genuinely achievement-less tools/SDKs/servers), the old "known-broken" sentinel still applies.

### Bug 2 — games named `ValveTestApp<id>`, `UntitledApp`, `InvitedPartnerApp<n>`

Valve's internal placeholder names were bleeding into `games.name` via:
- `persistExtraAchievements` accepting `playerAchievements.gameName` without filtering
- `hydrateMissingExtraNames`' sources (store appdetails, schema) echoing placeholders for some delisted apps

Every public source Steam offers has the real name for these (SteamDB, Support wizard, often the community page too). Our Support chain was never retrying them because the SQL `WHERE` only looked for `NULL` / empty names.

**Fix**:
- New `lib/server/placeholder-names.ts` with `isPlaceholderName()` + a reusable `PLACEHOLDER_NAME_SQL_MATCH` string (SQLite GLOB)
- `persistExtraAchievements`, `hydrateMissingExtraNames`, `persistOwnedGames` all filter placeholder gameNames before upserting
- `hydrateMissingExtraNames` WHERE gains an OR branch that treats placeholder-named rows the same as empty-name rows so the Support chain actually retries them
- `listOrphanNames` SQL applies the same match so the admin panel surfaces placeholder-named apps as resolvable orphans
- `resetPlaceholderGameNames` runs on every DB open: clears existing placeholder rows (unless `name_source='manual'`) and resets the corresponding `extra_games` achievement cache so stale rows actually re-run through the new sync path

## Test plan

- [x] `pnpm test` — **464/464** passing (+10 new)
  - `test/placeholder-names.test.ts`: 6 unit tests on the helper
  - `test/extra-games.test.ts`: 2 new sync tests (schema fallback happy path, placeholder gameName filtered out) + 2 new hydrate tests (placeholder rows retried, another placeholder from store not overwritten)
- [x] `pnpm lint` + `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] Manual verification after deploy: force-sync, check /extras for Metro 2033 / Starbound / DC Universe Online → should show `0/N (0%)` with real names

## Version

Bumped to **0.10.3** — sync fix + name resolution, no schema columns added, self-healing migration via `resetPlaceholderGameNames` on DB open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)