### PR TITLE
fix(ui): bump game card title size one step

### DIFF
--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -81,7 +81,7 @@ export function GameCard({
         />
       </div>
       <div className="min-w-0 flex-1">
-        <h3 className="flex items-center gap-2 truncate text-base font-semibold tracking-tight">{name}</h3>
+        <h3 className="flex items-center gap-2 truncate text-lg font-semibold tracking-tight">{name}</h3>
         {(playtime !== undefined || !achievementsLoading) && (
           <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
             {playtime !== undefined ? (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",


### PR DESCRIPTION
## Summary

`GameCard`'s title `<h3>` was `text-base` (16px), which read a bit cramped next to the responsive thumbnail and the metadata row on both mobile and desktop. Bumped to `text-lg` (18px) so the game name is the clear visual anchor of each row without overwhelming the progress bar or achievement counter below it.

No layout changes — the existing `truncate` handles long names just as before at the new size.

## Test plan

- [x] `pnpm test` — 464/464 passing
- [x] `pnpm lint` + `pnpm typecheck` clean
- [x] Verified visually via Playwright screenshots at 375 / 1280 px on `/games`: title prominence improved, no wrapping or overflow regressions.

## Version

Bumped to **0.10.4** — 1-line visual polish, no schema / config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)