### PR TITLE
fix(extras): catch GreenlightApp / trailing-digit placeholders + re-migrate stale rows

### DIFF
--- a/lib/server/placeholder-names.ts
+++ b/lib/server/placeholder-names.ts
@@ -13,23 +13,40 @@ import "server-only"
  *
  * Observed examples in the wild:
  *   ValveTestApp43110      (Metro 2033)
- *   UntitledApp            (generic placeholder)
+ *   UntitledApp / UntitledApp0   (generic placeholder, bare or numbered)
+ *   GreenlightApp0         (Greenlight-era submission)
  *   InvitedPartnerApp102   (partner-submitted entries)
+ *
+ * Each prefix allows either the exact base text or the base followed
+ * by any run of digits (`\d*` in regex, `[0-9]*` in SQLite GLOB).
+ * Non-digit suffixes are rejected so we don't misfire on real titles
+ * that happen to start with one of the prefixes (e.g. a hypothetical
+ * "GreenlightApplication").
  *
  * Patterns duplicated in SQL form because SQLite's GLOB syntax is a
  * subset of regex — keeps the WHERE clauses below readable and in
  * sync with this list.
  */
 
-export const PLACEHOLDER_NAME_PATTERNS: RegExp[] = [/^ValveTestApp\d+$/, /^UntitledApp$/, /^InvitedPartnerApp\d+$/]
+const PLACEHOLDER_PREFIXES = ["ValveTestApp", "UntitledApp", "GreenlightApp", "InvitedPartnerApp"] as const
+
+export const PLACEHOLDER_NAME_PATTERNS: RegExp[] = PLACEHOLDER_PREFIXES.map((prefix) => new RegExp(`^${prefix}\\d*$`))
 
 /**
- * SQL fragment — expand into a WHERE clause with `OR` joins. Uses
- * GLOB (case-sensitive) because Valve returns these names verbatim.
- * Keep in sync with PLACEHOLDER_NAME_PATTERNS above.
+ * SQL fragment — drop into a WHERE clause as a prefixed OR group.
+ * Matches each prefix either exactly or followed by a run of digits.
+ * Kept in one string so every caller uses the same pattern set.
  */
 export const PLACEHOLDER_NAME_SQL_MATCH =
-  "(g.name GLOB 'ValveTestApp[0-9]*' OR g.name = 'UntitledApp' OR g.name GLOB 'InvitedPartnerApp[0-9]*')"
+  "(" + PLACEHOLDER_PREFIXES.map((p) => `g.name = '${p}' OR g.name GLOB '${p}[0-9]*'`).join(" OR ") + ")"
+
+/**
+ * Same fragment as {@link PLACEHOLDER_NAME_SQL_MATCH} but without the
+ * `g.` alias — for queries that reference `games` unqualified
+ * (e.g. migration UPDATEs that don't use a JOIN).
+ */
+export const PLACEHOLDER_NAME_SQL_MATCH_BARE =
+  "(" + PLACEHOLDER_PREFIXES.map((p) => `name = '${p}' OR name GLOB '${p}[0-9]*'`).join(" OR ") + ")"
 
 /**
  * Returns true when `name` is one of Valve's internal placeholders

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -4,6 +4,8 @@ import { accessSync, constants, mkdirSync } from "node:fs"
 import { DatabaseSync } from "node:sqlite"
 import { dirname, join } from "node:path"
 
+import { PLACEHOLDER_NAME_SQL_MATCH_BARE } from "@/lib/server/placeholder-names"
+
 let database: DatabaseSync | null = null
 
 function getDatabasePath() {
@@ -295,50 +297,102 @@ function applyAdditiveMigrations(db: DatabaseSync) {
   addColumnIfMissing(db, "extra_games", "perfect_game", "INTEGER NOT NULL DEFAULT 0")
   // Provenance of games.name. See CREATE TABLE comment above.
   addColumnIfMissing(db, "games", "name_source", "TEXT NOT NULL DEFAULT 'auto'")
-  resetPlaceholderGameNames(db)
+  runVersionedMigrations(db)
 }
 
 /**
- * Idempotent self-healing sweep: any `games` row whose `name` matches one
- * of Valve's internal placeholders (ValveTestAppX, UntitledApp,
- * InvitedPartnerAppX) is reset so the extras hydrate chain can re-resolve
- * the real title via the Steam Support wizard on the next sync. Manual
- * admin names (`name_source='manual'`) are preserved.
+ * Version-gated migrations tracked via SQLite's built-in
+ * `PRAGMA user_version`. Each migration runs once per database and
+ * bumps the stored version. Fresh installs jump straight to the
+ * latest version on first open; upgraded installs replay every
+ * migration whose index is greater than the currently stored
+ * version, in order.
  *
- * Also clears the corresponding `extra_games` achievement cache
- * (`achievements_synced_at = NULL`, counts → NULL) so the sync path
- * re-runs through the new schema fallback and gets the correct total
- * achievement count the next time it fires.
- *
- * Runs on every DB open. Cheap UPDATE, no-op once no placeholder names
- * remain.
+ * Adding a new migration: append an entry to MIGRATIONS below and
+ * bump its index. Never modify or reorder existing entries — this
+ * is an append-only history.
  */
-function resetPlaceholderGameNames(db: DatabaseSync) {
-  const PLACEHOLDER_WHERE =
-    "(name GLOB 'ValveTestApp[0-9]*' OR name = 'UntitledApp' OR name GLOB 'InvitedPartnerApp[0-9]*')"
+const MIGRATIONS: Array<{ version: number; name: string; run: (db: DatabaseSync) => void }> = [
+  {
+    version: 1,
+    name: "reset-placeholder-game-names",
+    /**
+     * Any `games` row whose `name` matches one of Valve's internal
+     * placeholders (ValveTestAppX, UntitledApp, GreenlightAppX,
+     * InvitedPartnerAppX) is reset so the extras hydrate chain can
+     * re-resolve the real title via the Steam Support wizard on the
+     * next sync. Manual admin names (`name_source='manual'`) are
+     * preserved. Also clears the corresponding `extra_games`
+     * achievement cache so the sync path re-runs through the schema
+     * fallback and gets the correct total.
+     */
+    run(db) {
+      db.exec(`
+        UPDATE extra_games
+        SET achievements_synced_at = NULL,
+            unlocked_count = NULL,
+            total_count = NULL,
+            perfect_game = 0
+        WHERE appid IN (SELECT appid FROM games WHERE ${PLACEHOLDER_NAME_SQL_MATCH_BARE});
+      `)
+      db.exec(`
+        UPDATE games
+        SET name = '',
+            updated_at = COALESCE(updated_at, '1970-01-01T00:00:00Z')
+        WHERE ${PLACEHOLDER_NAME_SQL_MATCH_BARE}
+          AND (name_source IS NULL OR name_source != 'manual');
+      `)
+    },
+  },
+  {
+    version: 2,
+    name: "reset-stale-broken-extras",
+    /**
+     * Before v0.10.3, syncExtraAchievements stored total_count=0 with
+     * achievements_synced_at set as a "known-broken" sentinel whenever
+     * GetPlayerAchievements refused the request (for unowned-but-played
+     * games — DC Universe Online, Metro 2033, Starbound, etc). v0.10.3
+     * added a schema fallback that can populate those games correctly,
+     * but the stale filter in syncExtraAchievements skips any row where
+     * achievements_synced_at is set AND total_count=0, so the new code
+     * path never reached the already-marked-broken rows.
+     *
+     * This migration clears the sentinel on every such row exactly
+     * once, so the next sync re-runs them through the new fallback.
+     * Genuinely achievement-less apps (tools, SDKs, servers) will
+     * re-settle at total=0 after one extra schema probe; the games
+     * that are recoverable via schema will populate their real total.
+     */
+    run(db) {
+      db.exec(`
+        UPDATE extra_games
+        SET achievements_synced_at = NULL,
+            unlocked_count = NULL,
+            total_count = NULL,
+            perfect_game = 0
+        WHERE achievements_synced_at IS NOT NULL
+          AND (total_count IS NULL OR total_count = 0);
+      `)
+    },
+  },
+]
 
-  // Clear cached achievement counts on any extras that reference a
-  // placeholder-named row. Must run BEFORE the games UPDATE so the
-  // subquery still sees the placeholder names.
-  db.exec(`
-    UPDATE extra_games
-    SET achievements_synced_at = NULL,
-        unlocked_count = NULL,
-        total_count = NULL,
-        perfect_game = 0
-    WHERE appid IN (SELECT appid FROM games WHERE ${PLACEHOLDER_WHERE});
-  `)
+function runVersionedMigrations(db: DatabaseSync) {
+  const row = db.prepare("PRAGMA user_version").get() as { user_version: number }
+  const currentVersion = row?.user_version ?? 0
 
-  // Reset placeholder names to empty so hydrateMissingExtraNames'
-  // WHERE — which matches both empty AND placeholder rows — picks
-  // them up on the next sync. Preserve admin-set manual names.
-  db.exec(`
-    UPDATE games
-    SET name = '',
-        updated_at = COALESCE(updated_at, '1970-01-01T00:00:00Z')
-    WHERE ${PLACEHOLDER_WHERE}
-      AND (name_source IS NULL OR name_source != 'manual');
-  `)
+  for (const migration of MIGRATIONS) {
+    if (migration.version <= currentVersion) continue
+    db.exec("BEGIN")
+    try {
+      migration.run(db)
+      db.exec(`PRAGMA user_version = ${migration.version}`)
+      db.exec("COMMIT")
+    } catch (error) {
+      db.exec("ROLLBACK")
+      throw error
+    }
+  }
 }
 
 export function getSqliteDatabase() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",

--- a/test/placeholder-names.test.ts
+++ b/test/placeholder-names.test.ts
@@ -4,19 +4,21 @@ import { describe, expect, it } from "vitest"
 import { isPlaceholderName } from "@/lib/server/placeholder-names"
 
 describe("isPlaceholderName", () => {
-  it("matches ValveTestApp followed by digits", () => {
-    expect(isPlaceholderName("ValveTestApp43110")).toBe(true)
-    expect(isPlaceholderName("ValveTestApp1")).toBe(true)
-    expect(isPlaceholderName("ValveTestApp203190")).toBe(true)
-  })
-
-  it("matches UntitledApp exactly", () => {
+  it("matches each prefix exactly (no trailing digits)", () => {
+    expect(isPlaceholderName("ValveTestApp")).toBe(true)
     expect(isPlaceholderName("UntitledApp")).toBe(true)
+    expect(isPlaceholderName("GreenlightApp")).toBe(true)
+    expect(isPlaceholderName("InvitedPartnerApp")).toBe(true)
   })
 
-  it("matches InvitedPartnerApp followed by digits", () => {
+  it("matches each prefix followed by any run of digits", () => {
+    expect(isPlaceholderName("ValveTestApp43110")).toBe(true)
+    expect(isPlaceholderName("ValveTestApp0")).toBe(true)
+    expect(isPlaceholderName("UntitledApp0")).toBe(true)
+    expect(isPlaceholderName("UntitledApp42")).toBe(true)
+    expect(isPlaceholderName("GreenlightApp0")).toBe(true)
+    expect(isPlaceholderName("GreenlightApp1234")).toBe(true)
     expect(isPlaceholderName("InvitedPartnerApp102")).toBe(true)
-    expect(isPlaceholderName("InvitedPartnerApp9")).toBe(true)
   })
 
   it("does not match real game names", () => {
@@ -26,12 +28,11 @@ describe("isPlaceholderName", () => {
     expect(isPlaceholderName("Half-Life: Alyx")).toBe(false)
   })
 
-  it("does not match variants with trailing text (case-sensitive by design)", () => {
-    expect(isPlaceholderName("ValveTestApp")).toBe(false) // no digits
+  it("does not match variants with trailing non-digit text (case-sensitive)", () => {
     expect(isPlaceholderName("ValveTestApp43110 (Beta)")).toBe(false)
     expect(isPlaceholderName("valvetestapp43110")).toBe(false) // lowercase — different binary
-    expect(isPlaceholderName("UntitledApp2")).toBe(false) // UntitledApp doesn't take a numeric suffix
-    expect(isPlaceholderName("InvitedPartnerApp")).toBe(false)
+    expect(isPlaceholderName("ValveTestAppA")).toBe(false) // letter suffix
+    expect(isPlaceholderName("GreenlightApplication")).toBe(false) // real word happens to share prefix
   })
 
   it("returns false for empty, null or undefined", () => {

--- a/test/sqlite-migrations.test.ts
+++ b/test/sqlite-migrations.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-migration-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.SQLITE_PATH
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe("versioned migrations", () => {
+  it("bumps PRAGMA user_version to the latest migration after first open", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const { user_version } = db.prepare("PRAGMA user_version").get() as { user_version: number }
+    // Latest migration index is 2 at the time of writing. Bumping this
+    // on new entries is intentional — it catches append-only history
+    // violations.
+    expect(user_version).toBeGreaterThanOrEqual(2)
+  })
+
+  it("migration v1 resets placeholder-named games + their extras cache", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    // The DB opens with all migrations already applied, so to test v1
+    // we rewind the version and re-seed some placeholder rows, then
+    // re-run the migration loop by re-importing the module. Simpler:
+    // seed rows that the migration would still catch on a second
+    // invocation — the migration is idempotent.
+    const now = new Date().toISOString()
+    db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES ('1', ?, ?)`).run(now, now)
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (111, 'UntitledApp0', ?, ?)`).run(
+      now,
+      now,
+    )
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (222, 'GreenlightApp42', ?, ?)`).run(
+      now,
+      now,
+    )
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (333, 'Portal 2', ?, ?)`).run(now, now)
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, total_count, achievements_synced_at, synced_at, created_at, updated_at)
+       VALUES ('1', 111, 100, 5, ?, ?, ?, ?), ('1', 222, 100, 3, ?, ?, ?, ?)`,
+    ).run(now, now, now, now, now, now, now, now)
+
+    // Rewind and re-run migrations.
+    db.exec("PRAGMA user_version = 0")
+    vi.resetModules()
+    await import("@/lib/server/sqlite").then((m) => m.getSqliteDatabase())
+
+    const row111 = db.prepare(`SELECT name FROM games WHERE appid = 111`).get() as { name: string }
+    const row222 = db.prepare(`SELECT name FROM games WHERE appid = 222`).get() as { name: string }
+    const row333 = db.prepare(`SELECT name FROM games WHERE appid = 333`).get() as { name: string }
+    expect(row111.name).toBe("")
+    expect(row222.name).toBe("")
+    expect(row333.name).toBe("Portal 2") // not a placeholder — left alone
+
+    const cache111 = db
+      .prepare(`SELECT total_count, achievements_synced_at FROM extra_games WHERE steam_id = '1' AND appid = 111`)
+      .get() as { total_count: number | null; achievements_synced_at: string | null }
+    expect(cache111.total_count).toBeNull()
+    expect(cache111.achievements_synced_at).toBeNull()
+  })
+
+  it("migration v1 preserves manual names (name_source='manual')", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const now = new Date().toISOString()
+    // Seed a placeholder row that was manually named afterwards — the
+    // admin panel flow. Migration must not clobber the admin's work.
+    db.prepare(
+      `INSERT INTO games (appid, name, name_source, created_at, updated_at) VALUES (444, 'ValveTestApp444', 'manual', ?, ?)`,
+    ).run(now, now)
+
+    db.exec("PRAGMA user_version = 0")
+    vi.resetModules()
+    await import("@/lib/server/sqlite").then((m) => m.getSqliteDatabase())
+
+    const row = db.prepare(`SELECT name, name_source FROM games WHERE appid = 444`).get() as {
+      name: string
+      name_source: string
+    }
+    // Even though the name matches the placeholder pattern, the
+    // manual source protects it.
+    expect(row.name).toBe("ValveTestApp444")
+    expect(row.name_source).toBe("manual")
+  })
+
+  it("migration v2 resets extras with total=0 and synced_at set", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const now = new Date().toISOString()
+    db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES ('1', ?, ?)`).run(now, now)
+
+    // Stale "known-broken" row (pre-v0.10.3 sentinel). Migration v2
+    // should reset the cache so the next sync retries via the schema
+    // fallback path.
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, total_count, achievements_synced_at, synced_at, created_at, updated_at)
+       VALUES ('1', 24200, 100, 0, ?, ?, ?, ?)`,
+    ).run(now, now, now, now)
+
+    // Healthy row with a real total. Migration v2 must NOT touch it.
+    db.prepare(
+      `INSERT INTO extra_games (steam_id, appid, playtime_forever, total_count, unlocked_count, achievements_synced_at, synced_at, created_at, updated_at)
+       VALUES ('1', 321110, 100, 30, 0, ?, ?, ?, ?)`,
+    ).run(now, now, now, now)
+
+    db.exec("PRAGMA user_version = 1")
+    vi.resetModules()
+    await import("@/lib/server/sqlite").then((m) => m.getSqliteDatabase())
+
+    const broken = db
+      .prepare(`SELECT total_count, achievements_synced_at FROM extra_games WHERE appid = 24200`)
+      .get() as { total_count: number | null; achievements_synced_at: string | null }
+    expect(broken.total_count).toBeNull()
+    expect(broken.achievements_synced_at).toBeNull()
+
+    const healthy = db
+      .prepare(`SELECT total_count, achievements_synced_at FROM extra_games WHERE appid = 321110`)
+      .get() as { total_count: number; achievements_synced_at: string }
+    expect(healthy.total_count).toBe(30)
+    expect(healthy.achievements_synced_at).toBeTruthy()
+  })
+
+  it("migrations are not re-run when user_version is already at the latest", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+    const now = new Date().toISOString()
+
+    // After first open, user_version should be at the latest. Seed a
+    // placeholder row AFTER migrations and confirm re-opening the DB
+    // does NOT wipe it (because the migration already ran once).
+    db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (555, 'ValveTestApp555', ?, ?)`).run(
+      now,
+      now,
+    )
+
+    // Re-open without rewinding user_version.
+    vi.resetModules()
+    await import("@/lib/server/sqlite").then((m) => m.getSqliteDatabase())
+
+    const row = db.prepare(`SELECT name FROM games WHERE appid = 555`).get() as { name: string }
+    // Still the placeholder — migration v1 ran once on first open,
+    // user_version bumped, second open skips it.
+    expect(row.name).toBe("ValveTestApp555")
+  })
+})


### PR DESCRIPTION
## Summary

Two user-reported follow-ups to v0.10.3 after more placeholder names surfaced and DC Universe Online-type extras were still showing `-` in the listing despite the schema fallback existing in the sync path.

### Issue 1 — placeholder regex gap

The `isPlaceholderName` patterns previously required:
- `ValveTestApp` followed by ≥1 digit (missed the bare form)
- `InvitedPartnerApp` followed by ≥1 digit (same)
- `UntitledApp` **exactly** (missed `UntitledApp0` and every numeric variant)
- no `GreenlightApp` pattern at all

Observed in the user's DB after v0.10.3:
```
ValveTestApp9930   (old, still caught)
UntitledApp0       (new, NOT caught)
GreenlightApp0     (new, NOT caught)
```

**Fix**: unified all four prefixes to `^Prefix\d*$` so bare + any numeric suffix both match, and added `GreenlightApp`. Patterns are now generated from a single `PLACEHOLDER_PREFIXES` constant so the JS regex and SQL GLOB fragment stay in sync automatically. Added a second bare (un-aliased) SQL variant for migration `UPDATE`s that reference `games` directly.

### Issue 2 — stale "known-broken" extras never re-synced

Before v0.10.3, `syncExtraAchievements` persisted `total_count=0` with `achievements_synced_at` set as a "known-broken" sentinel whenever `GetPlayerAchievements` refused the request. The stale filter then skipped those rows on every subsequent sync, so v0.10.3's schema fallback never reached the already-marked-broken rows. DC Universe Online, Metro 2033, Starbound, etc. were all stuck at `0` in the listing even though the detail page (which calls `ensureSchema` on the fly) correctly resolved their achievements.

**Fix**: introduced a versioned migration system via `PRAGMA user_version`. The previous `resetPlaceholderGameNames` that ran on every DB open is now migration **v1** (runs once). A new migration **v2** — `reset-stale-broken-extras` — clears `achievements_synced_at` / counts on every extras row where `total_count=0 AND synced_at IS NOT NULL`, so the next sync re-runs them through v0.10.3's schema fallback path.

Genuinely achievement-less apps (tools / SDKs / servers) will re-settle at `total=0` after one extra schema probe. Recoverable games populate their real total. After one sync pass following this deploy, DC Universe Online should show `0/202` in the listing.

## Tests

- `test/placeholder-names.test.ts` — rewritten. Covers all 4 prefixes exact + numeric variants, and `GreenlightApplication` negative case.
- `test/sqlite-migrations.test.ts` — 5 new integration tests: latest version reached on first open, v1 resets placeholder rows + extras cache, v1 preserves manual names, v2 resets stale broken extras, migrations do NOT re-run once `user_version` is at the latest.

## Test plan

- [x] `pnpm test` — **468/468** passing
- [x] `pnpm lint` + `pnpm typecheck` clean
- [x] `pnpm build` clean
- [ ] Manual verification after deploy: force-sync, check /extras for DC Universe Online / Metro 2033 → listing should now show `0/N (0%)` with real names, no more `-`.

## Version

Bumped to **0.10.5**. Migrations are append-only and idempotent — one extra schema round-trip per previously-broken extras row on the next sync, then steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)