### PR TITLE
fix(ui): desktop title bump + edge-to-edge hero + footer GitHub icon

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -99,16 +99,26 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
               href="https://github.com/finallyjay"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-foreground inline-flex items-center gap-1.5 underline underline-offset-4 transition-colors"
+              className="hover:text-foreground underline underline-offset-4 transition-colors"
             >
-              <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-              </svg>
               finallyjay
             </a>
           </p>
-          <p className="text-muted-foreground/60 text-xs">
-            v{process.env.NEXT_PUBLIC_APP_VERSION} · Not affiliated with Valve Corporation
+          <p className="text-muted-foreground/60 inline-flex items-center gap-2 text-xs">
+            <span>v{process.env.NEXT_PUBLIC_APP_VERSION}</span>
+            <a
+              href="https://github.com/finallyjay/steam-backlog-hunter"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Source code on GitHub"
+              className="hover:text-foreground inline-flex items-center transition-colors"
+            >
+              <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+            </a>
+            <span aria-hidden="true">·</span>
+            <span>Not affiliated with Valve Corporation</span>
           </p>
         </div>
       </footer>

--- a/app/extras/[id]/page.tsx
+++ b/app/extras/[id]/page.tsx
@@ -5,7 +5,6 @@ import { useParams, useRouter } from "next/navigation"
 import { Database, ExternalLink, LifeBuoy, Lock, Trophy } from "lucide-react"
 
 import { useCurrentUser } from "@/hooks/use-current-user"
-import { usePageTitle } from "@/components/ui/page-title-context"
 import { LoadingMessage } from "@/components/ui/loading-message"
 import { EmptyState } from "@/components/ui/empty-state"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -49,7 +48,6 @@ export default function ExtraGameDetailPage() {
   const appId = Number(params.id)
   const { user, loading: loadingUser } = useCurrentUser()
   const router = useRouter()
-  const { setTitle } = usePageTitle()
   const [game, setGame] = useState<ExtraGameDetail | null>(null)
   const [achievements, setAchievements] = useState<SteamAchievementView[]>([])
   const [loading, setLoading] = useState(true)
@@ -92,13 +90,6 @@ export default function ExtraGameDetailPage() {
       router.push("/")
     }
   }, [loadingUser, router, user])
-
-  useEffect(() => {
-    if (game?.name) {
-      setTitle(`${game.name} - Steam Backlog Hunter`)
-    }
-    return () => setTitle("")
-  }, [game?.name, setTitle])
 
   const pending = useMemo(() => achievements.filter((a) => !a.achieved).sort(sortByUnlockDateDesc), [achievements])
   const unlocked = useMemo(

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -8,7 +8,6 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { LoadingMessage } from "@/components/ui/loading-message"
 import { EmptyState } from "@/components/ui/empty-state"
 import { useEffect, useMemo, useState } from "react"
-import { usePageTitle } from "@/components/ui/page-title-context"
 import type { SteamAchievementView } from "@/lib/types/steam"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
@@ -32,20 +31,12 @@ export default function GameDetailPage() {
   const { games, loading: loadingGames } = useSteamGames("all")
   const { user, loading: loadingUser } = useCurrentUser()
   const router = useRouter()
-  const { setTitle } = usePageTitle()
   const [activeTab, setActiveTab] = useState<AchievementTab>("pending")
   const [syncing, setSyncing] = useState(false)
   const [syncedAchievements, setSyncedAchievements] = useState<SteamAchievementView[] | null>(null)
   const [syncError, setSyncError] = useState<string | null>(null)
 
   const game = games.find((g) => g.appid === appId)
-
-  useEffect(() => {
-    if (game?.name) {
-      setTitle(`${game.name} - Steam Backlog Hunter`)
-    }
-    return () => setTitle("")
-  }, [game?.name, setTitle])
 
   useEffect(() => {
     window.scrollTo(0, 0)

--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -81,7 +81,7 @@ export function GameCard({
         />
       </div>
       <div className="min-w-0 flex-1">
-        <h3 className="flex items-center gap-2 truncate text-lg font-semibold tracking-tight">{name}</h3>
+        <h3 className="flex items-center gap-2 truncate text-lg font-semibold tracking-tight lg:text-xl">{name}</h3>
         {(playtime !== undefined || !achievementsLoading) && (
           <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
             {playtime !== undefined ? (

--- a/components/ui/game-hero.tsx
+++ b/components/ui/game-hero.tsx
@@ -11,12 +11,10 @@ import { Skeleton } from "@/components/ui/skeleton"
  * depending on what's available:
  *
  *   Layout A — banner hero (library_hero.jpg, 3840×1240)
- *     - If logo.png also loads, it's overlaid bottom-center Steam-style.
- *     - If logo.png is missing, the game name is rendered over a
- *       gradient at the bottom of the banner instead.
- *     - The caller's `children` (playtime, achievements bar, action
- *       buttons, etc.) are rendered below the banner in a content
- *       block.
+ *     - Clean full-width banner with no overlays.
+ *     - Game title rendered BELOW the banner, left-aligned, as the
+ *       first element of the content block so it sits right above
+ *       playtime / achievements / action buttons.
  *
  *   Layout B — portrait fallback
  *     - Pixel-identical to the previous detail page markup: portrait
@@ -42,7 +40,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 // asset under `/store_item_assets/`.
 const CDN = "https://shared.fastly.steamstatic.com/store_item_assets/steam/apps"
 
-type HeroMode = "probing" | "banner-with-logo" | "banner-only" | "portrait"
+type HeroMode = "probing" | "banner" | "portrait"
 
 function probeImage(url: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -81,14 +79,10 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
     setMode("probing")
     setBgOk(false)
 
-    Promise.all([probeImage(`${CDN}/${appId}/library_hero.jpg`), probeImage(`${CDN}/${appId}/logo.png`)]).then(
-      ([heroOk, logoOk]) => {
-        if (cancelled) return
-        if (heroOk && logoOk) setMode("banner-with-logo")
-        else if (heroOk) setMode("banner-only")
-        else setMode("portrait")
-      },
-    )
+    probeImage(`${CDN}/${appId}/library_hero.jpg`).then((heroOk) => {
+      if (cancelled) return
+      setMode(heroOk ? "banner" : "portrait")
+    })
 
     probeImage(`${CDN}/${appId}/page_bg_generated_v6b.jpg`).then((ok) => {
       if (!cancelled) setBgOk(ok)
@@ -148,30 +142,22 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
     )
   }
 
-  // Layout A — banner hero
+  // Layout A — banner hero. The banner is rendered clean (no logo
+  // overlay, no gradient, no inline title) and the game title sits
+  // below it, left-aligned, just above the children block. Negative
+  // horizontal margins break the banner out of the PageContainer
+  // padding so it spans the full content width edge-to-edge.
   const heroUrl = `${CDN}/${appId}/library_hero.jpg`
-  const logoUrl = `${CDN}/${appId}/logo.png`
   return (
-    <div className="relative mb-8 overflow-hidden rounded-lg">
+    <div className="relative mb-8 space-y-4">
       {backdrop}
-      <div className="border-surface-4 relative aspect-[3840/1240] overflow-hidden rounded-lg border">
-        <img src={heroUrl} alt={`Hero art for ${name}`} className="absolute inset-0 h-full w-full object-cover" />
-        {/* Bottom gradient anchors either the logo or the plain title
-            so it stays legible regardless of the hero art. */}
-        <div className="absolute inset-x-0 bottom-0 h-2/3 bg-gradient-to-t from-black/85 via-black/30 to-transparent" />
-        {mode === "banner-with-logo" ? (
-          <img
-            src={logoUrl}
-            alt={name}
-            className="absolute inset-x-0 bottom-4 mx-auto max-h-[40%] w-auto max-w-[55%] object-contain drop-shadow-2xl sm:bottom-6"
-          />
-        ) : (
-          <h1 className="absolute inset-x-0 bottom-4 px-6 text-center text-2xl font-bold tracking-tight drop-shadow-lg sm:bottom-6 sm:text-3xl md:text-4xl">
-            {name}
-          </h1>
-        )}
+      <div className="border-surface-4 -mx-4 aspect-[3840/1240] overflow-hidden border-y md:-mx-6 md:rounded-lg md:border-x lg:-mx-8">
+        <img src={heroUrl} alt={`Hero art for ${name}`} className="h-full w-full object-cover" />
       </div>
-      <div className="space-y-4 pt-6">{children}</div>
+      <div className="space-y-4">
+        {title ?? <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">{name}</h1>}
+        {children}
+      </div>
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",


### PR DESCRIPTION
## Summary

Three small polish items bundled for v0.10.6:

### 1. GameCard title size on desktop only

Bump the h3 from `text-lg` to `text-xl` at `lg` (1024 px+) while keeping mobile and tablet at `text-lg`. Desktop rows now have a clearer visual anchor, narrow viewports are unchanged.

### 2. GameHero Layout A reworked — edge-to-edge banner

Banner hero is now clean full-width edge-to-edge. Negative horizontal margins break it out of the PageContainer padding at each breakpoint (`-mx-4 md:-mx-6 lg:-mx-8`). Removed the logo overlay, the bottom gradient, and the centred in-banner title.

Game title is rendered **below** the banner, left-aligned, as the first element of the content block — right above playtime / achievements bar / action buttons. Simpler hierarchy, matches mobile-first detail conventions.

Side effect: the probing chain simplified — we no longer need to distinguish `banner-with-logo` / `banner-only`, so `logo.png` is no longer probed at mount. Modes reduced to `probing | banner | portrait`.

Bonus: the "Portal 2 - Steam Backlog Hunter" centred header that used to sit **above** the banner came from the page-title context. Both `/game/[id]` and `/extras/[id]` stopped setting that title — `GameHero` now owns the single title rendering, no duplication.

### 3. Footer restructure

- Removed the GitHub icon that was inlined next to the author link ("finallyjay"). The link is now plain underlined text so it doesn't pull focus from the author name.
- Added a new GitHub icon link to the **second footer line** next to the version number, pointing at the public repo ([`finallyjay/steam-backlog-hunter`](https://github.com/finallyjay/steam-backlog-hunter)). Sits between `v0.10.6` and the "Not affiliated with Valve Corporation" disclaimer.

## Test plan

- [x] `pnpm test` — **468/468** passing
- [x] `pnpm lint` + `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] Playwright screenshots verified at 375 / 768 / 1280 px on `/dashboard`, `/games`, `/game/620` (Portal 2), `/game/730` (CS2), `/extras/489890` (delisted → portrait fallback)
  - Mobile/tablet title unchanged; desktop has the subtle bump
  - Hero banner stretches edge-to-edge in all three widths
  - Title now sits left-aligned below the banner
  - Footer shows the new GitHub icon on the version line

## Version

Bumped to **0.10.6** — UI polish only, no schema / config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)