### PR TITLE
fix(ui): detail hero banner+logo, full-bleed, flush with header (v0.10.7)

### DIFF
--- a/components/ui/game-hero.tsx
+++ b/components/ui/game-hero.tsx
@@ -10,17 +10,21 @@ import { Skeleton } from "@/components/ui/skeleton"
  * Steam library assets client-side and renders one of two layouts
  * depending on what's available:
  *
- *   Layout A — banner hero (library_hero.jpg, 3840×1240)
- *     - Clean full-width banner with no overlays.
- *     - Game title rendered BELOW the banner, left-aligned, as the
- *       first element of the content block so it sits right above
- *       playtime / achievements / action buttons.
+ *   Layout A — banner hero (library_hero.jpg + logo.png)
+ *     - Full-bleed banner that escapes the page container's max-width
+ *       via the `w-screen` + `left-1/2` + `-ml-[50vw]` pattern.
+ *     - `-mt-8` negates the page's top padding so the banner sits
+ *       flush against the sticky header with no gap.
+ *     - Steam's transparent logo.png is overlaid bottom-center on top
+ *       of a subtle bottom-up gradient for legibility.
+ *     - Requires BOTH library_hero.jpg AND logo.png to exist — if
+ *       either is missing we fall back to Layout B so we never render
+ *       a bare banner without the game's wordmark.
  *
  *   Layout B — portrait fallback
- *     - Pixel-identical to the previous detail page markup: portrait
- *       thumbnail on the left (w-44, aspect 2:3), title + children on
- *       the right. Uses <GameImage> so the portrait chain (2x retina →
- *       1x → branded placeholder) still applies.
+ *     - Portrait thumbnail on the left (w-44, aspect 2:3), title +
+ *       children on the right. Uses <GameImage> so the portrait chain
+ *       (2x retina → 1x → branded placeholder) still applies.
  *
  * On top of both layouts, `page_bg_generated_v6b.jpg` is probed in
  * parallel and rendered as a heavily blurred, semi-transparent
@@ -29,8 +33,7 @@ import { Skeleton } from "@/components/ui/skeleton"
  *
  * Probing is entirely client-side so nothing hits the DB or sync
  * pipeline. Worst case is a ~300 ms flash during which the portrait
- * fallback is shown before the banner swaps in for apps that have a
- * library_hero.
+ * skeleton is shown before the final layout resolves.
  */
 
 // Use `shared.fastly.steamstatic.com` because it is on the app's CSP
@@ -53,15 +56,14 @@ function probeImage(url: string): Promise<boolean> {
 
 interface GameHeroProps {
   appId: number | string
-  /** Plain-text name — used for img alt and the Layout A banner title fallback when there's no logo. */
+  /** Plain-text name — used for img alt and the sr-only h1 fallback. */
   name: string
   /**
-   * Optional custom title node rendered in Layout B instead of the
-   * default `<h1>{name}</h1>`. Lets callers compose the title with
-   * extra elements (badges, status pills, etc.) without us having to
-   * bake those into GameHero. Layout A still uses the plain `name`
-   * for the banner — logo or gradient title — since wide banners and
-   * inline badges look awkward together.
+   * Optional custom title node rendered instead of the default
+   * `<h1>{name}</h1>`. Lets callers compose the title with extra
+   * elements (badges, status pills, etc.) without us having to bake
+   * those into GameHero. Rendered below the banner in Layout A and to
+   * the right of the portrait in Layout B.
    */
   title?: React.ReactNode
   /** Portrait URL from the DB (optional). Passed through to GameImage. */
@@ -79,10 +81,12 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
     setMode("probing")
     setBgOk(false)
 
-    probeImage(`${CDN}/${appId}/library_hero.jpg`).then((heroOk) => {
-      if (cancelled) return
-      setMode(heroOk ? "banner" : "portrait")
-    })
+    Promise.all([probeImage(`${CDN}/${appId}/library_hero.jpg`), probeImage(`${CDN}/${appId}/logo.png`)]).then(
+      ([heroOk, logoOk]) => {
+        if (cancelled) return
+        setMode(heroOk && logoOk ? "banner" : "portrait")
+      },
+    )
 
     probeImage(`${CDN}/${appId}/page_bg_generated_v6b.jpg`).then((ok) => {
       if (!cancelled) setBgOk(ok)
@@ -142,20 +146,30 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
     )
   }
 
-  // Layout A — banner hero. The banner is rendered clean (no logo
-  // overlay, no gradient, no inline title) and the game title sits
-  // below it, left-aligned, just above the children block. Negative
-  // horizontal margins break the banner out of the PageContainer
-  // padding so it spans the full content width edge-to-edge.
+  // Layout A — banner + logo. Full-bleed (w-screen + centered via
+  // left-1/2 + -ml-[50vw]) so it escapes the page container's max-width
+  // on 2K+ displays. -mt-8 sits it flush with the sticky header. Logo
+  // overlays bottom-center with a bottom-up gradient for contrast.
+  // An sr-only h1 (or caller-provided `title`) preserves the semantic
+  // heading even though the logo image supplies the visible wordmark.
   const heroUrl = `${CDN}/${appId}/library_hero.jpg`
+  const logoUrl = `${CDN}/${appId}/logo.png`
   return (
-    <div className="relative mb-8 space-y-4">
+    <div className="relative mb-8">
       {backdrop}
-      <div className="border-surface-4 -mx-4 aspect-[3840/1240] overflow-hidden border-y md:-mx-6 md:rounded-lg md:border-x lg:-mx-8">
-        <img src={heroUrl} alt={`Hero art for ${name}`} className="h-full w-full object-cover" />
+      <div className="relative left-1/2 -mt-8 -ml-[50vw] aspect-[3840/1240] w-screen overflow-hidden">
+        <img src={heroUrl} alt="" className="h-full w-full object-cover" />
+        <div className="from-background/80 via-background/10 pointer-events-none absolute inset-0 bg-gradient-to-t to-transparent" />
+        <div className="pointer-events-none absolute inset-0 flex items-end justify-center p-4 sm:p-8 md:p-12 lg:p-16">
+          <img
+            src={logoUrl}
+            alt={`${name} logo`}
+            className="max-h-[55%] max-w-[70%] object-contain drop-shadow-[0_4px_16px_rgba(0,0,0,0.6)]"
+          />
+        </div>
       </div>
-      <div className="space-y-4">
-        {title ?? <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">{name}</h1>}
+      <div className="mt-6 space-y-4">
+        {title ?? <h1 className="sr-only">{name}</h1>}
         {children}
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",


### PR DESCRIPTION
Closes #229

## Summary

- `GameHero` now probes `library_hero.jpg` and `logo.png` in parallel and only switches to the banner layout when **both** exist — if either is missing we fall back to the portrait layout so we never render a bare banner without the wordmark.
- The banner is now true full-bleed: `w-screen` + `left-1/2` + `-ml-[50vw]` escapes the page container's `max-width: 1536px` cap so the banner fills the viewport on 2K+ displays, not just the container.
- Added `-mt-8` so the banner sits flush against the sticky header (no `pt-8` gap).
- Steam's transparent `logo.png` is overlaid bottom-center on a subtle bottom-up gradient for legibility. The `<h1>` is kept as `sr-only` (or the caller-provided `title` for extras) so screen readers still get a heading.

## Test plan

- [ ] `/game/[id]` for a game with both hero and logo (e.g. a recent AAA title): banner spans the full viewport width on a 2560px-wide display, sits flush with the header, logo visible and legible.
- [ ] `/game/[id]` for a game that has a hero but no logo: falls back to portrait layout instead of a bare banner.
- [ ] `/game/[id]` for a game with neither: portrait layout, unchanged.
- [ ] `/extras/[id]` for a game with both assets: banner layout, and the "Extra" badge still shows in the title block below.
- [ ] Skeleton during probe is still portrait-style.
- [ ] Mobile (<768px): banner still looks right — no horizontal scrollbar from `w-screen`.
- [ ] Dark/light theme: gradient contrast on the logo is adequate in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)