### PR TITLE
fix(ui): left-align hero logo, page-wide backdrop, banner skeleton (v0.10.8)

### DIFF
--- a/components/ui/game-hero.tsx
+++ b/components/ui/game-hero.tsx
@@ -15,8 +15,10 @@ import { Skeleton } from "@/components/ui/skeleton"
  *       via the `w-screen` + `left-1/2` + `-ml-[50vw]` pattern.
  *     - `-mt-8` negates the page's top padding so the banner sits
  *       flush against the sticky header with no gap.
- *     - Steam's transparent logo.png is overlaid bottom-center on top
- *       of a subtle bottom-up gradient for legibility.
+ *     - Steam's transparent logo.png is overlaid bottom-LEFT, horizontally
+ *       aligned with the page container's content edge so it lines up
+ *       with playtime / achievement progress rendered below — mirrors
+ *       Steam's own library detail layout.
  *     - Requires BOTH library_hero.jpg AND logo.png to exist — if
  *       either is missing we fall back to Layout B so we never render
  *       a bare banner without the game's wordmark.
@@ -27,13 +29,16 @@ import { Skeleton } from "@/components/ui/skeleton"
  *       (2x retina → 1x → branded placeholder) still applies.
  *
  * On top of both layouts, `page_bg_generated_v6b.jpg` is probed in
- * parallel and rendered as a heavily blurred, semi-transparent
- * backdrop if it exists. Gives the card ambient color without ever
- * obscuring content (pointer-events-none, z-index below).
+ * parallel and rendered as a heavily blurred, semi-transparent backdrop
+ * fixed to the viewport (not scoped to the hero box) so the game's
+ * ambient color bleeds into the whole page, not just the hero.
  *
  * Probing is entirely client-side so nothing hits the DB or sync
- * pipeline. Worst case is a ~300 ms flash during which the portrait
- * skeleton is shown before the final layout resolves.
+ * pipeline. Worst case is a ~300 ms flash during which a banner-shaped
+ * skeleton is shown before the final layout resolves. We bet on the
+ * banner skeleton because it matches the shape of most modern Steam
+ * library entries; for old apps without banner+logo we take a one-frame
+ * layout shift into the portrait layout.
  */
 
 // Use `shared.fastly.steamstatic.com` because it is on the app's CSP
@@ -97,8 +102,12 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
     }
   }, [appId])
 
+  // Backdrop is fixed to the viewport (not absolute inside the hero box)
+  // so the game's ambient color fills the whole detail page, including
+  // the area below the banner that scrolls. `-z-10` keeps it behind
+  // in-flow content; the body::before/::after CRT overlays stay above.
   const backdrop = bgOk ? (
-    <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-lg" aria-hidden="true">
+    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden" aria-hidden="true">
       <img
         src={`${CDN}/${appId}/page_bg_generated_v6b.jpg`}
         alt=""
@@ -108,17 +117,18 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
     </div>
   ) : null
 
-  // While probing we render the Layout B skeleton so the page has
-  // content immediately, then upgrade to the banner variant once the
-  // library_hero probe resolves positively. Swap happens in ~200–500 ms.
+  // Banner-shaped skeleton during probing. Matches the final banner
+  // layout so there's no visual jump when the banner resolves. For apps
+  // that fall back to portrait we accept a one-frame shift.
   if (mode === "probing") {
     return (
-      <div className="relative mb-8 flex items-start gap-6">
+      <div className="relative mb-8">
         {backdrop}
-        <Skeleton className="aspect-[2/3] h-auto w-44 shrink-0 rounded-lg" />
-        <div className="flex-1 space-y-4 pt-1">
-          <Skeleton className="h-7 w-64" />
-          <Skeleton className="h-4 w-48" />
+        <div className="relative left-1/2 -mt-8 -ml-[50vw] aspect-[3840/1240] w-screen overflow-hidden">
+          <Skeleton className="h-full w-full rounded-none" />
+        </div>
+        <div className="mt-6 space-y-4">
+          <Skeleton className="h-4 w-40" />
           <Skeleton className="h-2 w-full" />
         </div>
       </div>
@@ -149,9 +159,9 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
   // Layout A — banner + logo. Full-bleed (w-screen + centered via
   // left-1/2 + -ml-[50vw]) so it escapes the page container's max-width
   // on 2K+ displays. -mt-8 sits it flush with the sticky header. Logo
-  // overlays bottom-center with a bottom-up gradient for contrast.
-  // An sr-only h1 (or caller-provided `title`) preserves the semantic
-  // heading even though the logo image supplies the visible wordmark.
+  // overlay uses an inner `container mx-auto px-4` so its left edge
+  // lines up with the page content below (playtime, progress, buttons),
+  // matching Steam's own library detail layout.
   const heroUrl = `${CDN}/${appId}/library_hero.jpg`
   const logoUrl = `${CDN}/${appId}/logo.png`
   return (
@@ -160,12 +170,14 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
       <div className="relative left-1/2 -mt-8 -ml-[50vw] aspect-[3840/1240] w-screen overflow-hidden">
         <img src={heroUrl} alt="" className="h-full w-full object-cover" />
         <div className="from-background/80 via-background/10 pointer-events-none absolute inset-0 bg-gradient-to-t to-transparent" />
-        <div className="pointer-events-none absolute inset-0 flex items-end justify-center p-4 sm:p-8 md:p-12 lg:p-16">
-          <img
-            src={logoUrl}
-            alt={`${name} logo`}
-            className="max-h-[55%] max-w-[70%] object-contain drop-shadow-[0_4px_16px_rgba(0,0,0,0.6)]"
-          />
+        <div className="pointer-events-none absolute inset-0">
+          <div className="container mx-auto flex h-full items-end px-4 pb-6 md:pb-10 lg:pb-14">
+            <img
+              src={logoUrl}
+              alt={`${name} logo`}
+              className="max-h-[50%] max-w-[50%] object-contain object-left-bottom drop-shadow-[0_4px_16px_rgba(0,0,0,0.6)]"
+            />
+          </div>
         </div>
       </div>
       <div className="mt-6 space-y-4">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",


### PR DESCRIPTION
Closes #231

## Summary

- **Logo left-aligned with page content.** Wrapped the banner's logo overlay in an inner `container mx-auto px-4 ... items-end` so its left edge matches the page content edge below (playtime, achievement progress, buttons). Mirrors Steam's own library detail layout.
- **Backdrop fills the whole page.** Changed `page_bg_generated_v6b.jpg` backdrop from `absolute inset-0` (hero-scoped) to `fixed inset-0` so the game's ambient blurred art bleeds across the entire detail page, not just the hero box.
- **Banner-shaped skeleton during probe.** Replaced the portrait+title skeleton with a full-bleed banner skeleton so the common case has no layout shift when the banner resolves. Apps that fall back to portrait take a one-frame shift.

## Test plan

- [ ] `/game/[id]` for a game with both hero and logo: logo sits bottom-left, left-aligned with the playtime/progress text below (not centered).
- [ ] Backdrop blur is visible behind the achievement list / tabs area below the banner.
- [ ] Probing skeleton shows a banner-shaped block (not portrait+title).
- [ ] Portrait fallback unchanged for games without both assets.
- [ ] Body CRT scanlines + vignette still render above the backdrop.
- [ ] Mobile (<768px): logo isn't too big, backdrop doesn't cause horizontal scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)