### PR TITLE
fix(ui): detail page backdrop sandwich, row opacity, solid footer (v0.10.9)

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -87,7 +87,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
       <main id="main-content" tabIndex={-1} className="min-h-screen outline-none">
         {children}
       </main>
-      <footer className="border-surface-4 border-t py-8">
+      <footer className="border-surface-4 bg-background relative border-t py-8">
         <div className="container mx-auto flex flex-col items-center gap-3 px-4 text-center">
           <p className="text-muted-foreground text-sm">
             Made with{" "}

--- a/app/extras/[id]/page.tsx
+++ b/app/extras/[id]/page.tsx
@@ -126,7 +126,7 @@ export default function ExtraGameDetailPage() {
   }
 
   return (
-    <div className="min-h-screen">
+    <div className="from-background/95 to-background/80 min-h-screen bg-gradient-to-br">
       <div className="container mx-auto px-4 py-8">
         {loading ? (
           <div className="mb-8 flex items-center gap-6">

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -131,7 +131,7 @@ export default function GameDetailPage() {
   }
 
   return (
-    <div className="min-h-screen">
+    <div className="from-background/95 to-background/80 min-h-screen bg-gradient-to-br">
       <div className="container mx-auto px-4 py-8">
         {loadingGames ? (
           <div className="mb-8 flex items-center gap-6">

--- a/components/ui/achievement-row.tsx
+++ b/components/ui/achievement-row.tsx
@@ -47,7 +47,7 @@ export function AchievementRow({ achievement: ach }: AchievementRowProps) {
   return (
     <li
       className={`border-surface-4 flex items-center gap-4 rounded-lg border p-4 transition-colors ${
-        isUnlocked ? "bg-surface-1" : "bg-white/2 opacity-70"
+        isUnlocked ? "bg-card/80" : "bg-card/60 opacity-90"
       }`}
     >
       <img

--- a/components/ui/game-hero.tsx
+++ b/components/ui/game-hero.tsx
@@ -28,10 +28,13 @@ import { Skeleton } from "@/components/ui/skeleton"
  *       children on the right. Uses <GameImage> so the portrait chain
  *       (2x retina → 1x → branded placeholder) still applies.
  *
- * On top of both layouts, `page_bg_generated_v6b.jpg` is probed in
- * parallel and rendered as a heavily blurred, semi-transparent backdrop
- * fixed to the viewport (not scoped to the hero box) so the game's
- * ambient color bleeds into the whole page, not just the hero.
+ * On top of both layouts, a blurred backdrop is rendered fixed to the
+ * viewport so the game's ambient colour bleeds into the whole page.
+ * The bg URL is resolved via a fallback chain so we have an image for
+ * nearly every app: page_bg_generated_v6b.jpg (modern) → _generated.jpg
+ * (older) → library_hero.jpg (always present for modern entries). The
+ * backdrop has no dark overlay of its own — the tinting comes from the
+ * page wrapper's semi-transparent gradient sitting above it.
  *
  * Probing is entirely client-side so nothing hits the DB or sync
  * pipeline. Worst case is a ~300 ms flash during which a banner-shaped
@@ -79,12 +82,12 @@ interface GameHeroProps {
 
 export function GameHero({ appId, name, title, portraitUrl, children }: GameHeroProps) {
   const [mode, setMode] = useState<HeroMode>("probing")
-  const [bgOk, setBgOk] = useState(false)
+  const [bgUrl, setBgUrl] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     setMode("probing")
-    setBgOk(false)
+    setBgUrl(null)
 
     Promise.all([probeImage(`${CDN}/${appId}/library_hero.jpg`), probeImage(`${CDN}/${appId}/logo.png`)]).then(
       ([heroOk, logoOk]) => {
@@ -93,27 +96,45 @@ export function GameHero({ appId, name, title, portraitUrl, children }: GameHero
       },
     )
 
-    probeImage(`${CDN}/${appId}/page_bg_generated_v6b.jpg`).then((ok) => {
-      if (!cancelled) setBgOk(ok)
-    })
+    // Backdrop asset fallback chain. Prefer `page_bg_generated.jpg` (the
+    // less-processed variant — cleaner colour) since the page wrapper already
+    // layers a dark translucent gradient on top. `v6b` is heavily
+    // blurred/desaturated and goes muddy under the overlay. library_hero.jpg
+    // is the last resort — always present for modern entries and still works
+    // blurred as an ambient bleed below.
+    ;(async () => {
+      const candidates = [
+        `${CDN}/${appId}/page_bg_generated.jpg`,
+        `${CDN}/${appId}/page_bg_generated_v6b.jpg`,
+        `${CDN}/${appId}/library_hero.jpg`,
+      ]
+      for (const url of candidates) {
+        const ok = await probeImage(url)
+        if (cancelled) return
+        if (ok) {
+          setBgUrl(url)
+          return
+        }
+      }
+    })()
 
     return () => {
       cancelled = true
     }
   }, [appId])
 
-  // Backdrop is fixed to the viewport (not absolute inside the hero box)
-  // so the game's ambient color fills the whole detail page, including
-  // the area below the banner that scrolls. `-z-10` keeps it behind
-  // in-flow content; the body::before/::after CRT overlays stay above.
-  const backdrop = bgOk ? (
+  // Backdrop is fixed to the viewport (not absolute inside the hero box) so
+  // the game's ambient colour fills the whole detail page, including the area
+  // below the banner that scrolls. `-z-10` keeps it behind in-flow content
+  // (including the page wrapper's translucent gradient that tints it); the
+  // body::before/::after CRT overlays stay above.
+  const backdrop = bgUrl ? (
     <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden" aria-hidden="true">
       <img
-        src={`${CDN}/${appId}/page_bg_generated_v6b.jpg`}
+        src={bgUrl}
         alt=""
-        className="h-full w-full scale-110 object-cover opacity-40 blur-2xl brightness-75 saturate-150"
+        className="h-full w-full scale-110 object-cover opacity-100 blur-[2px] brightness-110 saturate-[1.75]"
       />
-      <div className="from-background/50 via-background/30 to-background/80 absolute inset-0 bg-gradient-to-b" />
     </div>
   ) : null
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",
@@ -69,6 +69,7 @@
     "lint-staged": "^16.4.0",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
+    "playwright": "^1.59.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       oxlint:
         specifier: ^1.60.0
         version: 1.60.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -2491,8 +2494,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5013,12 +5026,20 @@ snapshots:
   playwright-core@1.58.2:
     optional: true
 
+  playwright-core@1.59.1: {}
+
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
     optional: true
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
Closes #235

## Summary

- **Layered backdrop with translucent page tint.** The full-page game art backdrop (added in v0.10.8) was invisible over the dark CRT body bg. Re-introduced a translucent page wrapper gradient (\`from-background/95 to-background/80 bg-gradient-to-br\`) that sits above the image and provides the dark tint content needs to be readable, while letting the game's ambient colour bleed through at the bottom-right corner. The image ends up as a subtle atmospheric accent rather than a full visible backdrop, which was what we wanted.
- **Backdrop URL fallback chain.** \`page_bg_generated.jpg\` (cleaner colour, preferred) → \`page_bg_generated_v6b.jpg\` (more processed, widely available) → \`library_hero.jpg\` (always present for modern apps). Older games now get a backdrop too.
- **Dropped the in-backdrop dark overlay.** The page wrapper alone provides the tint now — no need to double-darken.
- **Achievement row opacity bumped** from \`bg-surface-1\` / \`bg-white/2\` to \`bg-card/80\` / \`bg-card/60\` so text on rows stays readable over the backdrop.
- **Footer is now solid** (\`bg-background\`) so the viewport-fixed backdrop doesn't bleed past the content area.
- **Added Playwright as a devDep.** Used it to debug the layered-stacking issue here (captured DOM / computed styles / screenshots at multiple resolutions). Keeping it available for future UI debugging.

## Test plan

- [ ] \`/game/271590\` (GTA V): banner + logo visible up top, content area below has a subtle game-bg tint on the right side, text is readable.
- [ ] Games without \`page_bg_generated.jpg\`: backdrop probes fall through to \`_v6b.jpg\` or \`library_hero.jpg\`.
- [ ] Games without any of those: no backdrop renders (\`bgUrl\` stays null) — body CRT bg shows as before.
- [ ] Scroll: footer is fully opaque, no backdrop bleed.
- [ ] Achievement rows readable regardless of backdrop tint behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)