### PR TITLE
chore: drop playwright devDep to fix Dokploy build (v0.10.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",
@@ -69,7 +69,6 @@
     "lint-staged": "^16.4.0",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
-    "playwright": "^1.59.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,6 @@ importers:
       oxlint:
         specifier: ^1.60.0
         version: 1.60.0
-      playwright:
-        specifier: ^1.59.1
-        version: 1.59.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -2494,18 +2491,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5026,20 +5013,12 @@ snapshots:
   playwright-core@1.58.2:
     optional: true
 
-  playwright-core@1.59.1: {}
-
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
     optional: true
-
-  playwright@1.59.1:
-    dependencies:
-      playwright-core: 1.59.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
## Why

v0.10.9 added Playwright as a devDep to debug the detail-page backdrop stacking issue. Its postinstall hook downloads ~300 MB of Chromium on every install, which broke the Dokploy production deploy and slowed GitHub Actions CI. There are no Playwright tests in the repo — it was a one-session debugging tool.

## What

- \`pnpm remove playwright\`
- Version bump to 0.10.10

If we need Playwright to reproduce a UI bug later, it's one \`pnpm add -D playwright\` away.

## Test plan

- [ ] CI green
- [ ] Dokploy deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)