### PR TITLE
feat(achievements): rarity badge + search + sort by rarity + percent parse fix (v0.10.10)

### DIFF
--- a/app/extras/[id]/page.tsx
+++ b/app/extras/[id]/page.tsx
@@ -2,13 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useParams, useRouter } from "next/navigation"
-import { Database, ExternalLink, LifeBuoy, Lock, Trophy } from "lucide-react"
+import { Database, ExternalLink, LifeBuoy, Lock, Search, Trophy } from "lucide-react"
 
 import { useCurrentUser } from "@/hooks/use-current-user"
 import { LoadingMessage } from "@/components/ui/loading-message"
 import { EmptyState } from "@/components/ui/empty-state"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
+import { InputFrame } from "@/components/ui/input-frame"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { GameHero } from "@/components/ui/game-hero"
@@ -44,6 +45,21 @@ function sortByUnlockDateDesc(a: SteamAchievementView, b: SteamAchievementView) 
   return b.unlocktime - a.unlocktime
 }
 
+function sortByGlobalPercentDesc(a: SteamAchievementView, b: SteamAchievementView) {
+  const ap = a.globalPercent
+  const bp = b.globalPercent
+  if (ap == null && bp == null) return 0
+  if (ap == null) return 1
+  if (bp == null) return -1
+  return bp - ap
+}
+
+function matchesSearch(ach: SteamAchievementView, query: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  return ach.displayName.toLowerCase().includes(q) || (ach.description ?? "").toLowerCase().includes(q)
+}
+
 export default function ExtraGameDetailPage() {
   const params = useParams<{ id: string }>()
   const appId = Number(params.id)
@@ -54,6 +70,7 @@ export default function ExtraGameDetailPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<AchievementTab>("pending")
+  const [search, setSearch] = useState("")
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -92,11 +109,13 @@ export default function ExtraGameDetailPage() {
     }
   }, [loadingUser, router, user])
 
-  const pending = useMemo(() => achievements.filter((a) => !a.achieved).sort(sortByUnlockDateDesc), [achievements])
+  const pending = useMemo(() => achievements.filter((a) => !a.achieved).sort(sortByGlobalPercentDesc), [achievements])
   const unlocked = useMemo(
     () => achievements.filter((a) => a.achieved === 1).sort(sortByUnlockDateDesc),
     [achievements],
   )
+  const filteredPending = useMemo(() => pending.filter((a) => matchesSearch(a, search)), [pending, search])
+  const filteredUnlocked = useMemo(() => unlocked.filter((a) => matchesSearch(a, search)), [unlocked, search])
   const total = achievements.length
   const unlockedCount = unlocked.length
   const percent = total > 0 ? Math.round((unlockedCount / total) * 100) : 0
@@ -192,24 +211,43 @@ export default function ExtraGameDetailPage() {
             </GameHero>
 
             {total > 0 && (
-              <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as AchievementTab)}>
-                <TabsList>
-                  <TabsTrigger value="pending">
-                    <Lock className="h-4 w-4" />
-                    Pending ({pending.length})
-                  </TabsTrigger>
-                  <TabsTrigger value="unlocked">
-                    <Trophy className="h-4 w-4" />
-                    Unlocked ({unlocked.length})
-                  </TabsTrigger>
-                </TabsList>
-                <TabsContent value="pending">
-                  {renderAchievementPanel(pending, "No pending achievements for this game!")}
-                </TabsContent>
-                <TabsContent value="unlocked">
-                  {renderAchievementPanel(unlocked, "No unlocked achievements yet.")}
-                </TabsContent>
-              </Tabs>
+              <>
+                <InputFrame className="mb-4">
+                  <Search className="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search achievements..."
+                    aria-label="Search achievements"
+                    className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
+                  />
+                </InputFrame>
+                <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as AchievementTab)}>
+                  <TabsList>
+                    <TabsTrigger value="pending">
+                      <Lock className="h-4 w-4" />
+                      Pending ({filteredPending.length}/{pending.length})
+                    </TabsTrigger>
+                    <TabsTrigger value="unlocked">
+                      <Trophy className="h-4 w-4" />
+                      Unlocked ({filteredUnlocked.length}/{unlocked.length})
+                    </TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="pending">
+                    {renderAchievementPanel(
+                      filteredPending,
+                      search ? "No pending achievements match your search." : "No pending achievements for this game!",
+                    )}
+                  </TabsContent>
+                  <TabsContent value="unlocked">
+                    {renderAchievementPanel(
+                      filteredUnlocked,
+                      search ? "No unlocked achievements match your search." : "No unlocked achievements yet.",
+                    )}
+                  </TabsContent>
+                </Tabs>
+              </>
             )}
 
             {total === 0 && !loading && (

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -11,9 +11,10 @@ import { EmptyState } from "@/components/ui/empty-state"
 import { useEffect, useMemo, useState } from "react"
 import type { SteamAchievementView } from "@/lib/types/steam"
 import { Button } from "@/components/ui/button"
+import { InputFrame } from "@/components/ui/input-frame"
 import { Progress } from "@/components/ui/progress"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { ExternalLink, Lock, RefreshCw, Trophy } from "lucide-react"
+import { ExternalLink, Lock, RefreshCw, Search, Trophy } from "lucide-react"
 import { formatPlaytime } from "@/lib/utils"
 
 type AchievementTab = "pending" | "unlocked"
@@ -23,6 +24,24 @@ function sortByUnlockDateDesc(a: SteamAchievementView, b: SteamAchievementView) 
   if (!a.unlocktime) return 1
   if (!b.unlocktime) return -1
   return b.unlocktime - a.unlocktime
+}
+
+// Pending achievements ranked by global unlock % DESC — most common (easiest
+// to earn) float to the top. Null percentages (no rarity data yet) sink to the
+// bottom so they don't interleave with known rarities.
+function sortByGlobalPercentDesc(a: SteamAchievementView, b: SteamAchievementView) {
+  const ap = a.globalPercent
+  const bp = b.globalPercent
+  if (ap == null && bp == null) return 0
+  if (ap == null) return 1
+  if (bp == null) return -1
+  return bp - ap
+}
+
+function matchesSearch(ach: SteamAchievementView, query: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  return ach.displayName.toLowerCase().includes(q) || (ach.description ?? "").toLowerCase().includes(q)
 }
 
 export default function GameDetailPage() {
@@ -36,6 +55,7 @@ export default function GameDetailPage() {
   const [syncing, setSyncing] = useState(false)
   const [syncedAchievements, setSyncedAchievements] = useState<SteamAchievementView[] | null>(null)
   const [syncError, setSyncError] = useState<string | null>(null)
+  const [search, setSearch] = useState("")
 
   const game = games.find((g) => g.appid === appId)
 
@@ -74,13 +94,15 @@ export default function GameDetailPage() {
     [effectiveAchievements],
   )
   const pending = useMemo(
-    () => allAchievements.filter((a) => !a.achieved).sort(sortByUnlockDateDesc),
+    () => allAchievements.filter((a) => !a.achieved).sort(sortByGlobalPercentDesc),
     [allAchievements],
   )
   const unlocked = useMemo(
     () => allAchievements.filter((a) => a.achieved === 1).sort(sortByUnlockDateDesc),
     [allAchievements],
   )
+  const filteredPending = useMemo(() => pending.filter((a) => matchesSearch(a, search)), [pending, search])
+  const filteredUnlocked = useMemo(() => unlocked.filter((a) => matchesSearch(a, search)), [unlocked, search])
   const total = allAchievements.length
   const unlockedCount = unlocked.length
   const percent = total > 0 ? Math.round((unlockedCount / total) * 100) : 0
@@ -175,23 +197,45 @@ export default function GameDetailPage() {
           </GameHero>
         )}
 
+        {game && total > 0 && !loadingAchievements && (
+          <InputFrame className="mb-4">
+            <Search className="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search achievements..."
+              aria-label="Search achievements"
+              className="text-foreground placeholder:text-muted-foreground h-full w-full bg-transparent text-sm focus:outline-none"
+            />
+          </InputFrame>
+        )}
+
         {game && (
           <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as AchievementTab)}>
             <TabsList>
               <TabsTrigger value="pending">
                 <Lock className="h-4 w-4" />
-                Pending{!loadingAchievements && ` (${pending.length})`}
+                Pending{!loadingAchievements && ` (${filteredPending.length}/${pending.length})`}
               </TabsTrigger>
               <TabsTrigger value="unlocked">
                 <Trophy className="h-4 w-4" />
-                Unlocked{!loadingAchievements && ` (${unlocked.length})`}
+                Unlocked{!loadingAchievements && ` (${filteredUnlocked.length}/${unlocked.length})`}
               </TabsTrigger>
             </TabsList>
             <TabsContent value="pending">
-              {renderAchievementPanel(pending, "You have no pending achievements for this game!")}
+              {renderAchievementPanel(
+                filteredPending,
+                search
+                  ? "No pending achievements match your search."
+                  : "You have no pending achievements for this game!",
+              )}
             </TabsContent>
             <TabsContent value="unlocked">
-              {renderAchievementPanel(unlocked, "No unlocked achievements yet.")}
+              {renderAchievementPanel(
+                filteredUnlocked,
+                search ? "No unlocked achievements match your search." : "No unlocked achievements yet.",
+              )}
             </TabsContent>
           </Tabs>
         )}

--- a/components/ui/achievement-row.tsx
+++ b/components/ui/achievement-row.tsx
@@ -17,10 +17,33 @@ function formatUnlockTimestamp(unixSeconds: number): { date: string; time: strin
   }
 }
 
-/** Formats the global-% label with 1 decimal under 10% (where rarity differences matter). */
-function formatGlobalPercent(percent: number): string {
-  const value = percent < 10 ? percent.toFixed(1) : Math.round(percent).toString()
-  return `${value}% global`
+/**
+ * Up to 2 decimal places, trailing zeros stripped. JS's Number→string
+ * conversion drops trailing zeros for free, so `82.0 → "82"`, `82.3 → "82.3"`,
+ * `82.35 → "82.35"`. Round first to avoid showing floating-point noise like
+ * "82.29999999".
+ */
+function formatPercent(percent: number): string {
+  return `${Math.round(percent * 100) / 100}%`
+}
+
+/**
+ * Rarity tiers with four visually distinct hues so a glance reads the tier
+ * before the number. The dark theme already leans cyan for both `accent` and
+ * `muted-foreground`, so we route ultra-rare to `danger` (magenta) and common
+ * to a plain chroma-less gray (`text-foreground/60`) to avoid two blue-ish
+ * badges sitting next to each other.
+ *
+ *   <5%   — ultra rare   → danger (magenta/pink)
+ *   <15%  — very rare    → warning (amber)
+ *   <40%  — uncommon     → success (green)
+ *   ≥40%  — common       → neutral gray
+ */
+function rarityBadgeClass(percent: number): string {
+  if (percent < 5) return "bg-danger/15 text-danger border-danger/40"
+  if (percent < 15) return "bg-warning/15 text-warning border-warning/40"
+  if (percent < 40) return "bg-success/15 text-success border-success/40"
+  return "bg-surface-3 text-foreground/60 border-surface-4"
 }
 
 interface AchievementRowProps {
@@ -35,7 +58,9 @@ interface AchievementRowProps {
  * Hidden behaviour: unlocked achievements always show their full name +
  * description regardless of the `hidden` flag (the game dev only wants them
  * hidden until earned). Locked + hidden rows gate the text behind a "Revelar"
- * button; the user can toggle reveal per-row, matching Steam's own UX.
+ * button; the user can toggle reveal per-row, matching Steam's own UX. The
+ * rarity badge is always shown when globalPercent is known — rarity is
+ * metadata about the game, not the hidden achievement's identity.
  */
 export function AchievementRow({ achievement: ach }: AchievementRowProps) {
   const [revealed, setRevealed] = useState(false)
@@ -43,6 +68,15 @@ export function AchievementRow({ achievement: ach }: AchievementRowProps) {
   const showFullText = isUnlocked || ach.hidden !== 1 || revealed
 
   const timestamp = isUnlocked && ach.unlocktime ? formatUnlockTimestamp(ach.unlocktime) : null
+
+  const rarityBadge =
+    ach.globalPercent != null ? (
+      <span
+        className={`inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs font-medium ${rarityBadgeClass(ach.globalPercent)}`}
+      >
+        {formatPercent(ach.globalPercent)}
+      </span>
+    ) : null
 
   return (
     <li
@@ -58,12 +92,18 @@ export function AchievementRow({ achievement: ach }: AchievementRowProps) {
       <div className="min-w-0 flex-1">
         {showFullText ? (
           <>
-            <div className="truncate font-semibold">{ach.displayName}</div>
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate font-semibold">{ach.displayName}</span>
+              {rarityBadge}
+            </div>
             {ach.description && <div className="text-muted-foreground text-sm">{ach.description}</div>}
           </>
         ) : (
           <>
-            <div className="text-muted-foreground truncate font-semibold italic">Logro oculto</div>
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="text-muted-foreground truncate font-semibold italic">Logro oculto</span>
+              {rarityBadge}
+            </div>
             <button
               type="button"
               onClick={() => setRevealed(true)}
@@ -74,17 +114,10 @@ export function AchievementRow({ achievement: ach }: AchievementRowProps) {
           </>
         )}
       </div>
-      {(timestamp || ach.globalPercent != null) && (
+      {timestamp && (
         <div className="text-muted-foreground shrink-0 space-y-0.5 text-right text-xs">
-          {timestamp && (
-            <>
-              <div>{timestamp.date}</div>
-              <div>{timestamp.time}</div>
-            </>
-          )}
-          {ach.globalPercent != null && (
-            <div className={timestamp ? "pt-1" : ""}>{formatGlobalPercent(ach.globalPercent)}</div>
-          )}
+          <div>{timestamp.date}</div>
+          <div>{timestamp.time}</div>
         </div>
       )}
     </li>

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -242,11 +242,16 @@ export async function getGlobalAchievementPercentages(appId: number): Promise<Gl
     })
     const arr = data?.achievementpercentages?.achievements
     if (!Array.isArray(arr)) return null
-    return arr.filter(
-      (a: unknown): a is GlobalAchievementPercent =>
-        typeof (a as GlobalAchievementPercent)?.name === "string" &&
-        typeof (a as GlobalAchievementPercent)?.percent === "number",
-    )
+    // Steam serves `percent` as a string ("82.3"), not a number, so coerce via
+    // Number() and drop non-finite results (malformed rows or NaN).
+    const result: GlobalAchievementPercent[] = []
+    for (const entry of arr as Array<{ name?: unknown; percent?: unknown }>) {
+      if (typeof entry.name !== "string") continue
+      const percent = typeof entry.percent === "number" ? entry.percent : Number(entry.percent)
+      if (!Number.isFinite(percent)) continue
+      result.push({ name: entry.name, percent })
+    }
+    return result
   } catch (error) {
     if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403 || error.status === 404)) {
       return null

--- a/test/steam-api-global-percentages.test.ts
+++ b/test/steam-api-global-percentages.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Keep env access happy without forcing a real .env in tests.
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+beforeEach(() => {
+  vi.resetModules()
+  process.env.STEAM_API_KEY = "test-key"
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("getGlobalAchievementPercentages", () => {
+  it("coerces Steam's string percent values into numbers", async () => {
+    // Steam's live API serves percent as a string ("82.3"), which the original
+    // typeguard treated as an invalid entry and silently dropped — leaving
+    // game_achievements.global_percent permanently null. Regression guard.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          achievementpercentages: {
+            achievements: [
+              { name: "ACH00", percent: "82.3" },
+              { name: "ACH01", percent: "39.2" },
+              { name: "ACH_NOPE", percent: "not-a-number" },
+              { name: "ACH_NUMERIC", percent: 12.5 },
+            ],
+          },
+        }),
+      } as unknown as Response),
+    )
+
+    const { getGlobalAchievementPercentages } = await import("@/lib/steam-api")
+    const result = await getGlobalAchievementPercentages(271590)
+
+    expect(result).toEqual([
+      { name: "ACH00", percent: 82.3 },
+      { name: "ACH01", percent: 39.2 },
+      { name: "ACH_NUMERIC", percent: 12.5 },
+    ])
+  })
+
+  it("returns null when the response shape is unexpected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ achievementpercentages: {} }),
+      } as unknown as Response),
+    )
+
+    const { getGlobalAchievementPercentages } = await import("@/lib/steam-api")
+    expect(await getGlobalAchievementPercentages(271590)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Five related changes to the achievement list on \`/game/[id]\` and \`/extras/[id]\`:

1. **Parser fix for global unlock %.** \`getGlobalAchievementPercentages\` accepted only numeric percents, but Steam serves them as strings (\`\"82.3\"\`). Every row was silently dropped and \`game_achievements.global_percent\` stayed \`NULL\` forever. Coerce via \`Number()\` + \`isFinite()\` and add a regression test.
2. **Rarity badge next to the title.** Moved the percent off the timestamp column into a coloured pill next to the achievement name. Four-tier palette chosen for distinctness in the dark theme: **magenta** (\`<5%\`, ultra rare) → **amber** (\`<15%\`) → **green** (\`<40%\`) → **neutral gray** (\`≥40%\`). Uses the app's semantic tokens so tier colours track the theme.
3. **Percent format:** up to 2 decimals, trailing zeros stripped. \`82.0 → "82"\`, \`82.3 → "82.3"\`, \`4.25 → "4.25"\`. \`Math.round(x * 100) / 100\` + JS's native \`Number→string\` stripping trailing zeros.
4. **Sort changes.** Pending achievements are now sorted by \`globalPercent\` DESC (most-common first, i.e. closest to earned). Unlocked stay by unlock date DESC.
5. **Search input** above the Tabs on both detail pages. Filters pending and unlocked by \`displayName\` / \`description\`. Tab counters show \`filtered / total\` so the filter being active is obvious. Empty state messages adapt when the search yielded zero results.

Hidden achievements still show the rarity badge even before \"Revelar\" is clicked — rarity is metadata about the game, not the hidden achievement's identity.

## Test plan

- [ ] Hit \"Update achievements\" on a game → \`game_achievements.global_percent\` is now populated (verify via \`sqlite3 .data/steam-backlog-hunter.sqlite\`).
- [ ] Rarity badge appears next to each achievement name with the right tier colour.
- [ ] Pending list: ultra-rare achievements at bottom, most-common at top.
- [ ] Unlocked list: recent unlocks at top.
- [ ] Search by partial displayName or description — both tabs filter; counters show \`(X/Y)\`.
- [ ] Hidden locked achievement: badge is still visible with its rarity colour; \"Revelar\" still toggles the text.
- [ ] Percent format cases: 82 → \"82%\", 82.3 → \"82.3%\", 4.25 → \"4.25%\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)