### PR TITLE
feat(games): platform badges to disambiguate same-named editions

### DIFF
--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -110,6 +110,24 @@ export function LibraryOverview({
     [games, achievementsMap, order],
   )
 
+  // Names that appear on more than one appid in this library. Steam returns
+  // separate entries per platform edition (e.g. GTA III Mac vs Windows are
+  // appids 12220 and 12210), so showing platform badges only on these rows
+  // disambiguates them without cluttering the typical Windows-only card.
+  const duplicateNames = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const game of gamesWithStats) {
+      const key = game.name.trim().toLowerCase()
+      if (!key) continue
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+    const dupes = new Set<string>()
+    for (const [name, count] of counts) {
+      if (count > 1) dupes.add(name)
+    }
+    return dupes
+  }, [gamesWithStats])
+
   const visibleGames = useMemo(() => {
     let filtered = gamesWithStats
 
@@ -382,6 +400,7 @@ export function LibraryOverview({
                   serverUnlocked={game.unlockedAchievements}
                   serverPerfect={game.completed}
                   onHide={handleHideGame}
+                  platforms={duplicateNames.has(game.name.trim().toLowerCase()) ? game.platforms : null}
                 />
               </div>
             )

--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { Clock, EyeOff, Trophy } from "lucide-react"
+import { Apple, Clock, EyeOff, Monitor, Terminal, Trophy } from "lucide-react"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { GameImage } from "@/components/ui/game-image"
 import { Progress } from "@/components/ui/progress"
@@ -29,6 +29,12 @@ interface GameCardProps {
   serverPerfect?: boolean
   onHide?: (appId: number) => void
   actions?: React.ReactNode
+  /**
+   * Platform availability badges. Only rendered when set — the library view
+   * passes this only for games whose name collides with another in the same
+   * library, so the typical Windows-only card stays visually clean.
+   */
+  platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
 }
 
 // Responsive thumbnail container: portrait (2:3 Steam library capsule)
@@ -52,6 +58,7 @@ export function GameCard({
   serverPerfect = false,
   onHide,
   actions,
+  platforms,
 }: GameCardProps) {
   // Use detailed achievements if available, fall back to server-side counts
   const hasDetail = achievements.length > 0
@@ -105,6 +112,14 @@ export function GameCard({
                   <span className="text-foreground/75 font-medium">-</span>
                 </div>
               )
+            ) : null}
+
+            {platforms ? (
+              <div className="text-muted-foreground flex items-center gap-1.5" aria-label="Available platforms">
+                {platforms.windows ? <Monitor className="h-3.5 w-3.5" aria-label="Windows" /> : null}
+                {platforms.mac ? <Apple className="h-3.5 w-3.5" aria-label="macOS" /> : null}
+                {platforms.linux ? <Terminal className="h-3.5 w-3.5" aria-label="Linux" /> : null}
+              </div>
             ) : null}
           </div>
         )}

--- a/lib/games-mapping.ts
+++ b/lib/games-mapping.ts
@@ -12,6 +12,7 @@ type GameBase = {
   unlocked_count: number
   total_count: number
   perfect_game: boolean
+  platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
 }
 
 /**
@@ -35,6 +36,7 @@ export function mapOwnedGamesToGameCards(
       unlocked_count: game.unlocked_count ?? 0,
       total_count: game.total_count ?? 0,
       perfect_game: game.perfect_game ?? false,
+      platforms: game.platforms ?? null,
     }))
 }
 

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -68,6 +68,10 @@ function createBaseSchema(db: DatabaseSync) {
       images_synced_at TEXT,
       has_community_visible_stats INTEGER,
       schema_synced_at TEXT,
+      -- JSON object {windows: bool, mac: bool, linux: bool} sourced from
+      -- store appdetails. NULL means we haven't probed this appid yet.
+      platforms TEXT,
+      platforms_synced_at TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -297,6 +301,10 @@ function applyAdditiveMigrations(db: DatabaseSync) {
   addColumnIfMissing(db, "extra_games", "perfect_game", "INTEGER NOT NULL DEFAULT 0")
   // Provenance of games.name. See CREATE TABLE comment above.
   addColumnIfMissing(db, "games", "name_source", "TEXT NOT NULL DEFAULT 'auto'")
+  // Platform support (windows/mac/linux) sourced from store appdetails. Used
+  // by the UI to disambiguate same-named games across platforms.
+  addColumnIfMissing(db, "games", "platforms", "TEXT")
+  addColumnIfMissing(db, "games", "platforms_synced_at", "TEXT")
   runVersionedMigrations(db)
 }
 

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -10,6 +10,7 @@ import {
   persistExtraGames,
   syncExtraAchievements,
 } from "@/lib/server/extra-games"
+import { syncGamePlatforms } from "@/lib/server/steam-platforms-sync"
 import { isPlaceholderName } from "@/lib/server/placeholder-names"
 import { logger } from "@/lib/server/logger"
 import {
@@ -40,6 +41,21 @@ export type GameRow = {
   unlocked_count: number | null
   total_count: number | null
   perfect_game: number | null
+  platforms: string | null
+}
+
+function parsePlatforms(raw: string | null): SteamGame["platforms"] {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as { windows?: unknown; mac?: unknown; linux?: unknown }
+    return {
+      windows: Boolean(parsed.windows),
+      mac: Boolean(parsed.mac),
+      linux: Boolean(parsed.linux),
+    }
+  } catch {
+    return null
+  }
 }
 
 /** Converts a SQLite game row into a SteamGame object. */
@@ -61,6 +77,7 @@ export function mapRowToSteamGame(row: GameRow): SteamGame {
     unlocked_count: row.unlocked_count ?? undefined,
     total_count: row.total_count ?? undefined,
     perfect_game: row.perfect_game === 1,
+    platforms: parsePlatforms(row.platforms),
   }
 }
 
@@ -85,7 +102,8 @@ export function getStoredOwnedGames(steamId: string): SteamGame[] {
       g.has_community_visible_stats,
       ug.unlocked_count,
       ug.total_count,
-      ug.perfect_game
+      ug.perfect_game,
+      g.platforms
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.owned = 1
@@ -116,7 +134,8 @@ export function getStoredGame(steamId: string, appId: number): SteamGame | null 
       g.image_icon_url,
       g.image_landscape_url,
       g.image_portrait_url,
-      g.has_community_visible_stats
+      g.has_community_visible_stats,
+      g.platforms
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.appid = ? AND ug.owned = 1
@@ -317,6 +336,11 @@ async function runHeavyOwnedGamesSync(steamId: string, existingGames: SteamGame[
   // appdetails endpoint. Truly delisted no-achievement apps stay nameless
   // and render as "App #{appid}".
   await hydrateMissingExtraNames(steamId)
+  // Probe store appdetails for platform support (windows/mac/linux). Used by
+  // the UI to disambiguate same-named games across editions (e.g. GTA III
+  // Mac vs Windows). Throttled to 200 fetches per run with a 30-day
+  // staleness floor, so steady-state cost is essentially zero.
+  await syncGamePlatforms(steamId)
   const finalGames = getStoredOwnedGames(steamId)
   // Image probes: both owned and extras share the `games` cache, so running
   // ensureGameImages across the union fills in headers/portraits for every
@@ -383,7 +407,8 @@ export async function getRecentlyPlayedGamesForUser(steamId: string, options?: {
       g.has_community_visible_stats,
       ug.unlocked_count,
       ug.total_count,
-      ug.perfect_game
+      ug.perfect_game,
+      g.platforms
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.owned = 1 AND ug.rtime_last_played > 0

--- a/lib/server/steam-platforms-sync.ts
+++ b/lib/server/steam-platforms-sync.ts
@@ -1,0 +1,126 @@
+import "server-only"
+
+import { getSqliteDatabase } from "@/lib/server/sqlite"
+import { isStale, nowIso } from "@/lib/server/steam-store-utils"
+import { logger } from "@/lib/server/logger"
+
+export type GamePlatforms = {
+  windows: boolean
+  mac: boolean
+  linux: boolean
+}
+
+const PLATFORMS_STALE_MS = 30 * 24 * 60 * 60 * 1000
+
+// Same delay as hydrateMissingExtraNames — single-appid calls only, ~150ms
+// keeps us safely under Steam's community-measured ~200req/5min ceiling.
+const STORE_DELAY_MS = 150
+
+// Hard ceiling per sync run so a one-time first pass on a 3000-game library
+// doesn't block other syncs for 8 minutes. Anything left over gets picked up
+// on the next sync tick.
+const MAX_FETCHES_PER_RUN = 200
+
+type StoreAppDetailsPlatforms = {
+  success?: boolean
+  data?: {
+    platforms?: {
+      windows?: boolean
+      mac?: boolean
+      linux?: boolean
+    }
+  }
+}
+
+/**
+ * Fetches platform availability (windows/mac/linux) from store appdetails for
+ * every appid in the user's library that hasn't been synced in the last 30
+ * days. Used to disambiguate same-named games across platforms in the UI
+ * (e.g. GTA III for Mac vs Windows have different appids but identical names).
+ *
+ * Reuses the rate-limit + backoff pattern from `hydrateMissingExtraNames`:
+ * sequential calls with 150ms gap, abort after 10 consecutive failures.
+ *
+ * Negative caching: when appdetails reports `success=false` (delisted, no
+ * store page), we still write `platforms_synced_at` with `platforms=NULL` so
+ * we don't retry every sync. Truly delisted games render without badges.
+ */
+export async function syncGamePlatforms(steamId: string) {
+  const db = getSqliteDatabase()
+
+  const rows = db
+    .prepare(
+      `
+      SELECT g.appid, g.platforms_synced_at
+      FROM games g
+      INNER JOIN user_games ug ON ug.appid = g.appid
+      WHERE ug.steam_id = ? AND ug.owned = 1
+      ORDER BY ug.playtime_forever DESC
+      `,
+    )
+    .all(steamId) as Array<{ appid: number; platforms_synced_at: string | null }>
+
+  const candidates = rows.filter((row) => isStale(row.platforms_synced_at, PLATFORMS_STALE_MS))
+  if (candidates.length === 0) return
+
+  const targets = candidates.slice(0, MAX_FETCHES_PER_RUN)
+
+  const upsert = db.prepare(`
+    UPDATE games
+    SET platforms = ?,
+        platforms_synced_at = ?,
+        updated_at = ?
+    WHERE appid = ?
+  `)
+
+  let consecutiveFailures = 0
+
+  for (const { appid } of targets) {
+    if (consecutiveFailures >= 10) {
+      logger.warn(
+        { steamId, remaining: targets.length, lastAppid: appid },
+        "Store appdetails returned 10 consecutive failures — backing off syncGamePlatforms",
+      )
+      return
+    }
+
+    let platforms: GamePlatforms | null = null
+    let storeRespondedCleanly = false
+
+    try {
+      const url = new URL("https://store.steampowered.com/api/appdetails")
+      url.searchParams.set("appids", String(appid))
+      url.searchParams.set("filters", "basic")
+      const response = await fetch(url.toString(), { cache: "no-store" })
+
+      if (!response.ok) {
+        consecutiveFailures++
+      } else {
+        consecutiveFailures = 0
+        const payload = (await response.json()) as Record<string, StoreAppDetailsPlatforms>
+        const entry = payload[String(appid)]
+        if (entry?.success && entry.data?.platforms) {
+          storeRespondedCleanly = true
+          platforms = {
+            windows: Boolean(entry.data.platforms.windows),
+            mac: Boolean(entry.data.platforms.mac),
+            linux: Boolean(entry.data.platforms.linux),
+          }
+        } else if (entry && entry.success === false) {
+          // Delisted / unknown to the store. Cache as null so we don't retry.
+          storeRespondedCleanly = true
+        }
+      }
+    } catch (error) {
+      consecutiveFailures++
+      logger.warn({ err: error, appid }, "Store appdetails platforms call failed")
+    }
+
+    if (storeRespondedCleanly) {
+      const now = nowIso()
+      upsert.run(platforms ? JSON.stringify(platforms) : null, now, now, appid)
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, STORE_DELAY_MS))
+  }
+}

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -14,6 +14,7 @@ export interface SteamGame {
   unlocked_count?: number
   total_count?: number
   perfect_game?: boolean
+  platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
 }
 
 export interface SteamAchievement {

--- a/lib/types/steam.ts
+++ b/lib/types/steam.ts
@@ -33,6 +33,7 @@ export interface SteamGameCardModel {
   completed: boolean
   totalAchievements: number
   unlockedAchievements: number
+  platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
 }
 
 export type SteamGamesResponse = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",


### PR DESCRIPTION
Closes #239.

## Summary
- Adds `platforms` (JSON `{windows, mac, linux}`) and `platforms_synced_at` columns to the `games` table via additive migration.
- New `lib/server/steam-platforms-sync.ts` fetches platform info from `store.steampowered.com/api/appdetails`, mirroring the rate-limit + 10-failure backoff pattern from `extra-games.ts`. 30-day staleness floor and a 200-fetch-per-run ceiling keep first-sync cost bounded; steady-state cost is ~0.
- Hooks into `runHeavyOwnedGamesSync` after the extras pass.
- Threads `platforms` through `SteamGame` → `GameRow` → `SteamGameCardModel` → `GameCard`.
- `LibraryOverview` computes a `Set` of name collisions and only passes `platforms` to cards whose name appears more than once — so the typical Windows-only card stays clean and badges show up exactly where the user needs to disambiguate (e.g. GTA III Mac vs Windows).

## Test plan
- [ ] After deploy, run a forced sync; verify `games.platforms_synced_at` populates over time (capped at 200/run).
- [ ] In `/games`, confirm that duplicate-named pairs (GTA III, GTA: Vice City, Bastion, etc.) show platform icons and Windows-only games do not.
- [ ] Check that delisted appids don't permanently retry (cached as null with timestamp set).
- [ ] Verify build, lint, typecheck, and 470 vitest tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)