### PR TITLE
fix(platforms): use filters=platforms so the sync actually populates the field (v0.10.13)

### DIFF
--- a/lib/server/steam-platforms-sync.ts
+++ b/lib/server/steam-platforms-sync.ts
@@ -90,7 +90,12 @@ export async function syncGamePlatforms(steamId: string) {
     try {
       const url = new URL("https://store.steampowered.com/api/appdetails")
       url.searchParams.set("appids", String(appid))
-      url.searchParams.set("filters", "basic")
+      // `filters=basic` does NOT include the `platforms` field — it
+      // returns name/description/requirements only. The dedicated
+      // `filters=platforms` value is the smallest payload that actually
+      // contains what we need (≈90% smaller than the unfiltered
+      // response).
+      url.searchParams.set("filters", "platforms")
       const response = await fetch(url.toString(), { cache: "no-store" })
 
       if (!response.ok) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",

--- a/test/steam-platforms-sync.test.ts
+++ b/test/steam-platforms-sync.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+vi.mock("@/lib/env", () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        return process.env[prop as string]
+      },
+    },
+  ),
+}))
+
+vi.mock("@/lib/server/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "sbh-platforms-test-"))
+  process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.SQLITE_PATH
+  rmSync(tmpDir, { recursive: true, force: true })
+  // @ts-expect-error restore globals
+  delete globalThis.fetch
+})
+
+const STEAM_ID = "76561198023709299"
+
+async function seed(appid: number) {
+  const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+  const db = getSqliteDatabase()
+  const now = new Date().toISOString()
+  db.prepare(`INSERT INTO steam_profile (steam_id, created_at, updated_at) VALUES (?, ?, ?)`).run(STEAM_ID, now, now)
+  db.prepare(`INSERT INTO games (appid, name, created_at, updated_at) VALUES (?, ?, ?, ?)`).run(
+    appid,
+    `App ${appid}`,
+    now,
+    now,
+  )
+  db.prepare(
+    `INSERT INTO user_games (steam_id, appid, playtime_forever, owned, created_at, updated_at)
+     VALUES (?, ?, 0, 1, ?, ?)`,
+  ).run(STEAM_ID, appid, now, now)
+  return db
+}
+
+describe("syncGamePlatforms", () => {
+  it("requests filters=platforms (basic does NOT include the platforms field)", async () => {
+    await seed(12100)
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        "12100": { success: true, data: { platforms: { windows: true, mac: false, linux: false } } },
+      }),
+    })
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    const { syncGamePlatforms } = await import("@/lib/server/steam-platforms-sync")
+    await syncGamePlatforms(STEAM_ID)
+
+    const url = String(fetchSpy.mock.calls[0]?.[0])
+    expect(url).toContain("filters=platforms")
+    expect(url).not.toContain("filters=basic")
+  })
+
+  it("persists platforms JSON when the store responds with a platforms field", async () => {
+    const db = await seed(12100)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        "12100": { success: true, data: { platforms: { windows: true, mac: true, linux: false } } },
+      }),
+    }) as unknown as typeof fetch
+
+    const { syncGamePlatforms } = await import("@/lib/server/steam-platforms-sync")
+    await syncGamePlatforms(STEAM_ID)
+
+    const row = db.prepare("SELECT platforms, platforms_synced_at FROM games WHERE appid = 12100").get() as {
+      platforms: string | null
+      platforms_synced_at: string | null
+    }
+    expect(row.platforms).toBe(JSON.stringify({ windows: true, mac: true, linux: false }))
+    expect(row.platforms_synced_at).not.toBeNull()
+  })
+
+  it("negative-caches delisted apps as platforms=NULL with synced_at set", async () => {
+    const db = await seed(99999)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ "99999": { success: false } }),
+    }) as unknown as typeof fetch
+
+    const { syncGamePlatforms } = await import("@/lib/server/steam-platforms-sync")
+    await syncGamePlatforms(STEAM_ID)
+
+    const row = db.prepare("SELECT platforms, platforms_synced_at FROM games WHERE appid = 99999").get() as {
+      platforms: string | null
+      platforms_synced_at: string | null
+    }
+    expect(row.platforms).toBeNull()
+    expect(row.platforms_synced_at).not.toBeNull()
+  })
+
+  it("does NOT mark the row synced when the response succeeds but lacks the platforms field", async () => {
+    // Pre-fix regression: with filters=basic the response had success=true
+    // but no platforms key, and the code silently skipped the upsert, so
+    // platforms_synced_at stayed NULL forever. The fix flips the filter to
+    // `platforms`, but this guard locks in the behaviour for any future
+    // payload shape that omits the field.
+    const db = await seed(12100)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ "12100": { success: true, data: { name: "Grand Theft Auto III" } } }),
+    }) as unknown as typeof fetch
+
+    const { syncGamePlatforms } = await import("@/lib/server/steam-platforms-sync")
+    await syncGamePlatforms(STEAM_ID)
+
+    const row = db.prepare("SELECT platforms, platforms_synced_at FROM games WHERE appid = 12100").get() as {
+      platforms: string | null
+      platforms_synced_at: string | null
+    }
+    expect(row.platforms).toBeNull()
+    expect(row.platforms_synced_at).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
The platform-badges sync (introduced in v0.10.11) was hitting Steam appdetails with `filters=basic`, which returns name / description / requirements but **does NOT** include the `platforms` field. So every successful response failed the upsert guard and `platforms_synced_at` stayed `NULL` forever — out of 640 owned games on a real library, only 8 rows ever got written, and those were the delisted ones hitting the negative-cache branch (`success=false`).

Switching to `filters=platforms` returns just the field we actually need (~90% smaller payload than unfiltered).

## Reproduction
```bash
$ curl -s 'https://store.steampowered.com/api/appdetails?appids=12100&filters=basic' \
  | jq '.["12100"].data | has("platforms")'
false

$ curl -s 'https://store.steampowered.com/api/appdetails?appids=12100&filters=platforms' \
  | jq '.["12100"].data'
{ "platforms": { "windows": true, "mac": false, "linux": false } }
```

## Symptom on a real DB
```sql
-- 640 owned games, 8 had platforms_synced_at, ZERO had platforms populated
SELECT COUNT(*) AS total, COUNT(platforms_synced_at) AS synced, COUNT(platforms) AS with_platforms
FROM games g
INNER JOIN user_games ug ON ug.appid = g.appid
WHERE ug.owned = 1;
```
The 8 "synced" rows are correctly cached delisted apps (`success=false` branch). All other rows silently no-op'd on every sync.

## Fix
- `lib/server/steam-platforms-sync.ts`: `filters=basic` → `filters=platforms`.

## Regression test
`test/steam-platforms-sync.test.ts` locks in:
- The request URL contains `filters=platforms` (and not `basic`).
- A clean `success: true` + `platforms` response persists the JSON.
- A `success: false` response writes `platforms=NULL` with `synced_at` set.
- A `success: true` response without a `platforms` field stays unsynced (guards against future payload-shape regressions).

## Test plan
- [x] All 474 existing tests pass.
- [x] New `steam-platforms-sync.test.ts` (4 cases) passes.
- [ ] After deploying, trigger sync from the dashboard and verify `games.platforms` starts populating. Steady-state convergence is ~4 syncs (200 fetches per run × 30s, 640 games), or sooner if syncing actively used games first.

Note: existing rows where `platforms_synced_at` is set but `platforms` is NULL are correctly cached as "delisted/no store page" — no DB cleanup needed.

## Versioning
- Patch bump to **0.10.13** (bug fix on top of v0.10.12).
- Includes the postcss 8.5.6 → 8.5.10 devDep bump from #241 already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)