### PR TITLE
feat(games): release-year + Legacy badge for indistinguishable duplicates (v0.10.14)

### DIFF
--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -401,6 +401,7 @@ export function LibraryOverview({
                   serverPerfect={game.completed}
                   onHide={handleHideGame}
                   platforms={duplicateNames.has(game.name.trim().toLowerCase()) ? game.platforms : null}
+                  releaseYear={duplicateNames.has(game.name.trim().toLowerCase()) ? game.releaseYear : null}
                 />
               </div>
             )

--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { Apple, Clock, EyeOff, Monitor, Terminal, Trophy } from "lucide-react"
+import { Apple, Archive, Clock, EyeOff, Monitor, Terminal, Trophy } from "lucide-react"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { GameImage } from "@/components/ui/game-image"
 import { Progress } from "@/components/ui/progress"
@@ -35,6 +35,13 @@ interface GameCardProps {
    * library, so the typical Windows-only card stays visually clean.
    */
   platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
+  /**
+   * Release year, surfaced as a secondary disambiguator next to the platform
+   * icons when name collides. `null` on a colliding row signals a stripped
+   * legacy listing (Steam returns an empty release_date for some unified
+   * editions, e.g. GTA III appid 12230) and renders an "Archive" badge.
+   */
+  releaseYear?: number | null
 }
 
 // Responsive thumbnail container: portrait (2:3 Steam library capsule)
@@ -59,6 +66,7 @@ export function GameCard({
   onHide,
   actions,
   platforms,
+  releaseYear,
 }: GameCardProps) {
   // Use detailed achievements if available, fall back to server-side counts
   const hasDetail = achievements.length > 0
@@ -119,6 +127,20 @@ export function GameCard({
                 {platforms.windows ? <Monitor className="h-3.5 w-3.5" aria-label="Windows" /> : null}
                 {platforms.mac ? <Apple className="h-3.5 w-3.5" aria-label="macOS" /> : null}
                 {platforms.linux ? <Terminal className="h-3.5 w-3.5" aria-label="Linux" /> : null}
+                {releaseYear ? (
+                  <span className="text-[0.7rem] font-medium tabular-nums" aria-label={`Released ${releaseYear}`}>
+                    {releaseYear}
+                  </span>
+                ) : releaseYear === null ? (
+                  <span
+                    className="flex items-center gap-1 text-[0.7rem] font-medium"
+                    aria-label="Legacy listing (no store metadata)"
+                    title="Legacy edition — store metadata stripped by Steam"
+                  >
+                    <Archive className="h-3 w-3" aria-hidden="true" />
+                    Legacy
+                  </span>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/lib/games-mapping.ts
+++ b/lib/games-mapping.ts
@@ -13,6 +13,7 @@ type GameBase = {
   total_count: number
   perfect_game: boolean
   platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
+  releaseYear?: number | null
 }
 
 /**
@@ -37,6 +38,7 @@ export function mapOwnedGamesToGameCards(
       total_count: game.total_count ?? 0,
       perfect_game: game.perfect_game ?? false,
       platforms: game.platforms ?? null,
+      releaseYear: game.releaseYear ?? null,
     }))
 }
 

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -72,6 +72,11 @@ function createBaseSchema(db: DatabaseSync) {
       -- store appdetails. NULL means we haven't probed this appid yet.
       platforms TEXT,
       platforms_synced_at TEXT,
+      -- Release year parsed from store appdetails. NULL means either we
+      -- haven't probed yet OR Steam reports an empty release_date (a
+      -- common signal that a duplicate-named appid is a stripped legacy
+      -- listing kept for ownership only — see GTA III 12230).
+      release_year INTEGER,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -305,6 +310,10 @@ function applyAdditiveMigrations(db: DatabaseSync) {
   // by the UI to disambiguate same-named games across platforms.
   addColumnIfMissing(db, "games", "platforms", "TEXT")
   addColumnIfMissing(db, "games", "platforms_synced_at", "TEXT")
+  // Release year sourced from the same appdetails probe as platforms —
+  // used by the UI as a secondary disambiguator when same-named editions
+  // share identical platform support.
+  addColumnIfMissing(db, "games", "release_year", "INTEGER")
   runVersionedMigrations(db)
 }
 
@@ -380,6 +389,31 @@ const MIGRATIONS: Array<{ version: number; name: string; run: (db: DatabaseSync)
             perfect_game = 0
         WHERE achievements_synced_at IS NOT NULL
           AND (total_count IS NULL OR total_count = 0);
+      `)
+    },
+  },
+  {
+    version: 3,
+    name: "backfill-release-year-on-synced-platforms",
+    /**
+     * v0.10.13 added syncGamePlatforms with `filters=platforms`. v0.10.14
+     * extends it to also pull `release_date` so the UI can fall back to a
+     * release-year (or "Legacy") badge when same-named editions share
+     * identical platform support (e.g. GTA III appids 12100 and 12230,
+     * both reported as Windows-only by Steam today).
+     *
+     * Existing rows that synced under v0.10.13 have `platforms` populated
+     * but `release_year` NULL — indistinguishable from a legacy stripped
+     * listing. This migration nulls `platforms_synced_at` on exactly those
+     * rows so the next sync run re-fetches and populates the year.
+     * Rows that were negative-cached as delisted (platforms IS NULL) are
+     * left alone — they don't need re-fetching.
+     */
+    run(db) {
+      db.exec(`
+        UPDATE games
+        SET platforms_synced_at = NULL
+        WHERE platforms IS NOT NULL AND release_year IS NULL;
       `)
     },
   },

--- a/lib/server/steam-games-sync.ts
+++ b/lib/server/steam-games-sync.ts
@@ -42,6 +42,7 @@ export type GameRow = {
   total_count: number | null
   perfect_game: number | null
   platforms: string | null
+  release_year: number | null
 }
 
 function parsePlatforms(raw: string | null): SteamGame["platforms"] {
@@ -78,6 +79,7 @@ export function mapRowToSteamGame(row: GameRow): SteamGame {
     total_count: row.total_count ?? undefined,
     perfect_game: row.perfect_game === 1,
     platforms: parsePlatforms(row.platforms),
+    releaseYear: row.release_year,
   }
 }
 
@@ -103,7 +105,8 @@ export function getStoredOwnedGames(steamId: string): SteamGame[] {
       ug.unlocked_count,
       ug.total_count,
       ug.perfect_game,
-      g.platforms
+      g.platforms,
+      g.release_year
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.owned = 1
@@ -135,7 +138,8 @@ export function getStoredGame(steamId: string, appId: number): SteamGame | null 
       g.image_landscape_url,
       g.image_portrait_url,
       g.has_community_visible_stats,
-      g.platforms
+      g.platforms,
+      g.release_year
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.appid = ? AND ug.owned = 1
@@ -408,7 +412,8 @@ export async function getRecentlyPlayedGamesForUser(steamId: string, options?: {
       ug.unlocked_count,
       ug.total_count,
       ug.perfect_game,
-      g.platforms
+      g.platforms,
+      g.release_year
     FROM user_games ug
     INNER JOIN games g ON g.appid = ug.appid
     WHERE ug.steam_id = ? AND ug.owned = 1 AND ug.rtime_last_played > 0

--- a/lib/server/steam-platforms-sync.ts
+++ b/lib/server/steam-platforms-sync.ts
@@ -21,7 +21,7 @@ const STORE_DELAY_MS = 150
 // on the next sync tick.
 const MAX_FETCHES_PER_RUN = 200
 
-type StoreAppDetailsPlatforms = {
+type StoreAppDetailsResponse = {
   success?: boolean
   data?: {
     platforms?: {
@@ -29,21 +29,40 @@ type StoreAppDetailsPlatforms = {
       mac?: boolean
       linux?: boolean
     }
+    release_date?: {
+      date?: string
+      coming_soon?: boolean
+    }
   }
 }
 
+// Steam's `release_date.date` is a localized free-form string ("4 Jan, 2008",
+// "Jan 4, 2008", "2008", "To be announced", ""). Pull the first 4-digit run
+// that looks like a release year. Returns null when the listing has been
+// stripped (empty string) or marked as TBA — both signals we surface as a
+// "Legacy" badge in the UI for same-named editions.
+function parseReleaseYear(raw: string | null | undefined): number | null {
+  if (!raw) return null
+  const match = raw.match(/\b(19|20)\d{2}\b/)
+  if (!match) return null
+  const year = Number(match[0])
+  return Number.isFinite(year) ? year : null
+}
+
 /**
- * Fetches platform availability (windows/mac/linux) from store appdetails for
- * every appid in the user's library that hasn't been synced in the last 30
- * days. Used to disambiguate same-named games across platforms in the UI
- * (e.g. GTA III for Mac vs Windows have different appids but identical names).
+ * Fetches platform availability (windows/mac/linux) AND release year from
+ * store appdetails for every appid in the user's library that hasn't been
+ * synced in the last 30 days. Used to disambiguate same-named games in the
+ * UI (e.g. GTA III for Mac vs Windows have different appids but identical
+ * names).
  *
  * Reuses the rate-limit + backoff pattern from `hydrateMissingExtraNames`:
  * sequential calls with 150ms gap, abort after 10 consecutive failures.
  *
  * Negative caching: when appdetails reports `success=false` (delisted, no
- * store page), we still write `platforms_synced_at` with `platforms=NULL` so
- * we don't retry every sync. Truly delisted games render without badges.
+ * store page), we still write `platforms_synced_at` with `platforms=NULL`
+ * and `release_year=NULL` so we don't retry every sync. Truly delisted
+ * games render without badges.
  */
 export async function syncGamePlatforms(steamId: string) {
   const db = getSqliteDatabase()
@@ -68,6 +87,7 @@ export async function syncGamePlatforms(steamId: string) {
   const upsert = db.prepare(`
     UPDATE games
     SET platforms = ?,
+        release_year = ?,
         platforms_synced_at = ?,
         updated_at = ?
     WHERE appid = ?
@@ -85,24 +105,24 @@ export async function syncGamePlatforms(steamId: string) {
     }
 
     let platforms: GamePlatforms | null = null
+    let releaseYear: number | null = null
     let storeRespondedCleanly = false
 
     try {
       const url = new URL("https://store.steampowered.com/api/appdetails")
       url.searchParams.set("appids", String(appid))
       // `filters=basic` does NOT include the `platforms` field — it
-      // returns name/description/requirements only. The dedicated
-      // `filters=platforms` value is the smallest payload that actually
-      // contains what we need (≈90% smaller than the unfiltered
-      // response).
-      url.searchParams.set("filters", "platforms")
+      // returns name/description/requirements only. We pass the two
+      // dedicated filter values we actually consume; this stays ≈90%
+      // smaller than the unfiltered payload.
+      url.searchParams.set("filters", "platforms,release_date")
       const response = await fetch(url.toString(), { cache: "no-store" })
 
       if (!response.ok) {
         consecutiveFailures++
       } else {
         consecutiveFailures = 0
-        const payload = (await response.json()) as Record<string, StoreAppDetailsPlatforms>
+        const payload = (await response.json()) as Record<string, StoreAppDetailsResponse>
         const entry = payload[String(appid)]
         if (entry?.success && entry.data?.platforms) {
           storeRespondedCleanly = true
@@ -111,6 +131,7 @@ export async function syncGamePlatforms(steamId: string) {
             mac: Boolean(entry.data.platforms.mac),
             linux: Boolean(entry.data.platforms.linux),
           }
+          releaseYear = parseReleaseYear(entry.data.release_date?.date)
         } else if (entry && entry.success === false) {
           // Delisted / unknown to the store. Cache as null so we don't retry.
           storeRespondedCleanly = true
@@ -123,7 +144,7 @@ export async function syncGamePlatforms(steamId: string) {
 
     if (storeRespondedCleanly) {
       const now = nowIso()
-      upsert.run(platforms ? JSON.stringify(platforms) : null, now, now, appid)
+      upsert.run(platforms ? JSON.stringify(platforms) : null, releaseYear, now, now, appid)
     }
 
     await new Promise((resolve) => setTimeout(resolve, STORE_DELAY_MS))

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -15,6 +15,7 @@ export interface SteamGame {
   total_count?: number
   perfect_game?: boolean
   platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
+  releaseYear?: number | null
 }
 
 export interface SteamAchievement {

--- a/lib/types/steam.ts
+++ b/lib/types/steam.ts
@@ -34,6 +34,7 @@ export interface SteamGameCardModel {
   totalAchievements: number
   unlockedAchievements: number
   platforms?: { windows: boolean; mac: boolean; linux: boolean } | null
+  releaseYear?: number | null
 }
 
 export type SteamGamesResponse = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steam-backlog-hunter",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "private": true,
   "scripts": {
     "build": "next build && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",

--- a/test/steam-platforms-sync.test.ts
+++ b/test/steam-platforms-sync.test.ts
@@ -55,7 +55,7 @@ async function seed(appid: number) {
 }
 
 describe("syncGamePlatforms", () => {
-  it("requests filters=platforms (basic does NOT include the platforms field)", async () => {
+  it("requests filters=platforms,release_date (basic does NOT include those fields)", async () => {
     await seed(12100)
     const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
@@ -69,28 +69,101 @@ describe("syncGamePlatforms", () => {
     await syncGamePlatforms(STEAM_ID)
 
     const url = String(fetchSpy.mock.calls[0]?.[0])
-    expect(url).toContain("filters=platforms")
+    expect(url).toContain("filters=platforms%2Crelease_date")
     expect(url).not.toContain("filters=basic")
   })
 
-  it("persists platforms JSON when the store responds with a platforms field", async () => {
+  it("persists platforms JSON and release year when the store responds with both", async () => {
     const db = await seed(12100)
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
-        "12100": { success: true, data: { platforms: { windows: true, mac: true, linux: false } } },
+        "12100": {
+          success: true,
+          data: {
+            platforms: { windows: true, mac: true, linux: false },
+            release_date: { coming_soon: false, date: "4 Jan, 2008" },
+          },
+        },
       }),
     }) as unknown as typeof fetch
 
     const { syncGamePlatforms } = await import("@/lib/server/steam-platforms-sync")
     await syncGamePlatforms(STEAM_ID)
 
-    const row = db.prepare("SELECT platforms, platforms_synced_at FROM games WHERE appid = 12100").get() as {
-      platforms: string | null
-      platforms_synced_at: string | null
-    }
+    const row = db
+      .prepare("SELECT platforms, release_year, platforms_synced_at FROM games WHERE appid = 12100")
+      .get() as { platforms: string | null; release_year: number | null; platforms_synced_at: string | null }
     expect(row.platforms).toBe(JSON.stringify({ windows: true, mac: true, linux: false }))
+    expect(row.release_year).toBe(2008)
     expect(row.platforms_synced_at).not.toBeNull()
+  })
+
+  it("stores release_year=NULL when Steam returns an empty release_date (legacy stripped listing)", async () => {
+    // GTA III appid 12230 in the wild: success=true, platforms reports
+    // windows-only, but release_date.date is "". This is the signal that
+    // surfaces a "Legacy" badge in the UI when name+platforms collide
+    // with a sibling appid.
+    const db = await seed(12230)
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        "12230": {
+          success: true,
+          data: {
+            platforms: { windows: true, mac: false, linux: false },
+            release_date: { coming_soon: false, date: "" },
+          },
+        },
+      }),
+    }) as unknown as typeof fetch
+
+    const { syncGamePlatforms } = await import("@/lib/server/steam-platforms-sync")
+    await syncGamePlatforms(STEAM_ID)
+
+    const row = db.prepare("SELECT platforms, release_year FROM games WHERE appid = 12230").get() as {
+      platforms: string | null
+      release_year: number | null
+    }
+    expect(row.platforms).toBe(JSON.stringify({ windows: true, mac: false, linux: false }))
+    expect(row.release_year).toBeNull()
+  })
+
+  it("parses just the year out of Steam's localized release_date strings", async () => {
+    const cases: Array<{ raw: string; year: number | null }> = [
+      { raw: "4 Jan, 2008", year: 2008 },
+      { raw: "Jan 4, 2008", year: 2008 },
+      { raw: "2008", year: 2008 },
+      { raw: "Q4 2024", year: 2024 },
+      { raw: "To be announced", year: null },
+      { raw: "", year: null },
+    ]
+
+    for (const { raw, year } of cases) {
+      tmpDir = mkdtempSync(join(tmpdir(), "sbh-platforms-test-"))
+      process.env.SQLITE_PATH = join(tmpDir, "test.sqlite")
+      vi.resetModules()
+
+      const db = await seed(1)
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          "1": {
+            success: true,
+            data: {
+              platforms: { windows: true, mac: false, linux: false },
+              release_date: { coming_soon: false, date: raw },
+            },
+          },
+        }),
+      }) as unknown as typeof fetch
+
+      const { syncGamePlatforms } = await import("@/lib/server/steam-platforms-sync")
+      await syncGamePlatforms(STEAM_ID)
+
+      const row = db.prepare("SELECT release_year FROM games WHERE appid = 1").get() as { release_year: number | null }
+      expect(row.release_year).toBe(year)
+    }
   })
 
   it("negative-caches delisted apps as platforms=NULL with synced_at set", async () => {


### PR DESCRIPTION
## Why
The platform-badges feature shipped in v0.10.11 falls down when Steam reports identical platform support for two same-named editions. GTA III is the canonical case:

- `appid 12100` (originally Windows): Steam reports `windows: true, mac: false, linux: false`, release date `4 Jan, 2008`.
- `appid 12230` (originally Mac): Steam **also** reports `windows: true, mac: false, linux: false`, with an **empty** release date and stripped developer/categories metadata.

When Take-Two unified the GTA III storefront, the legacy Mac listing was stripped of its platform support. So both rows end up with the same Monitor icon, and the disambiguation feature can't disambiguate.

## What
Pull `release_date` alongside `platforms` from the same appdetails probe and surface a secondary disambiguator on collision rows.

| Source state | Badge |
|--|--|
| `release_date.date = "4 Jan, 2008"` | `2008` |
| `release_date.date = ""` (stripped legacy listing) | `📦 Legacy` |
| Not-yet-synced row | (nothing — gated on `platforms` being populated) |

`Legacy` is a reliable signal because Steam zeroes out `release_date.date` for these unified-edition leftovers — the empty string means "kept for ownership only".

## Changes
- **Schema**: new `release_year INTEGER` column on `games`. Migration v3 nulls `platforms_synced_at` for rows that synced under v0.10.13 (platforms set, year NULL) so the next sync backfills. Negative-cached delisted rows (platforms NULL) are left alone.
- **Sync**: `syncGamePlatforms` now requests `filters=platforms,release_date`. `parseReleaseYear` extracts the first 19xx/20xx run from Steam's localized date strings (`"4 Jan, 2008"`, `"Jan 4, 2008"`, `"2008"`, `"Q4 2024"`, `"To be announced"`, `""`).
- **UI**: `game-card` accepts `releaseYear?: number | null`. `library-overview` only passes it for collision rows, matching the existing `platforms` gating.

## Tests
- `parses just the year out of Steam's localized release_date strings` — covers 6 real-world formats.
- `stores release_year=NULL when Steam returns an empty release_date (legacy stripped listing)` — locks in the GTA III 12230 case.
- `persists platforms JSON and release year when the store responds with both` — happy path.
- `requests filters=platforms,release_date` updated.

476/476 tests green. Lint + typecheck clean.

## Test plan
- [x] Unit tests cover sync + parse paths.
- [ ] After deploy + sync, GTA III 12100 shows `2008` and 12230 shows `📦 Legacy`.
- [ ] Non-duplicate games stay clean (no extra badges).
- [ ] Other genuinely platform-distinguished duplicates still differentiate via icons.

## Versioning
Patch bump to **0.10.14** — extension of the v0.10.11 platform-badges feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)