### PR TITLE
feat(auth): sign the session cookie with HMAC

### DIFF
--- a/app/api/auth/steam/callback/route.ts
+++ b/app/api/auth/steam/callback/route.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto"
 import { cookies } from "next/headers"
 import { isSteamIdWhitelisted } from "@/lib/whitelist"
 import { upsertProfile } from "@/lib/server/steam-store-utils"
+import { signSession } from "@/lib/server/session"
 import { logger } from "@/lib/server/logger"
 
 const STEAM_OPENID_URL = "https://steamcommunity.com/openid/login"
@@ -172,7 +173,7 @@ export async function GET(request: NextRequest) {
 
     cookieStore.set(
       "steam_user",
-      JSON.stringify({
+      signSession({
         steamId: player.steamid,
         displayName: player.personaname,
         avatar: player.avatarfull,

--- a/app/lib/server-auth.ts
+++ b/app/lib/server-auth.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers"
 import type { SteamUser } from "@/lib/auth"
 import { isSteamIdWhitelisted } from "@/lib/whitelist"
 import { isAdmin } from "@/lib/server/admin"
+import { verifySession } from "@/lib/server/session"
 import { logger } from "@/lib/server/logger"
 
 /**
@@ -20,7 +21,13 @@ export async function getCurrentUser(): Promise<SteamUser | null> {
       return null
     }
 
-    const user = JSON.parse(userCookie.value) as SteamUser
+    // Verify the HMAC signature before trusting the payload — a forged cookie
+    // (even with a whitelisted Steam ID) is rejected here.
+    const user = verifySession(userCookie.value)
+    if (!user) {
+      cookieStore.delete("steam_user")
+      return null
+    }
 
     if (!isSteamIdWhitelisted(user.steamId)) {
       cookieStore.delete("steam_user")

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -9,6 +9,9 @@ const envSchema = z.object({
   NEXTAUTH_URL: z.string().url().optional(),
   SQLITE_PATH: z.string().optional(),
   ADMIN_STEAM_ID: z.string().optional(),
+  // HMAC key used to sign the session cookie. Optional — falls back to
+  // STEAM_API_KEY (also a server secret) so sessions are signed out of the box.
+  SESSION_SECRET: z.string().optional(),
   NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 })
 

--- a/lib/server/session.ts
+++ b/lib/server/session.ts
@@ -1,0 +1,53 @@
+import "server-only"
+
+import crypto from "node:crypto"
+import { env } from "@/lib/env"
+import type { SteamUser } from "@/lib/auth"
+
+// HMAC key for signing the session cookie. A dedicated SESSION_SECRET is
+// preferred; we fall back to STEAM_API_KEY (also a server-only secret) so
+// sessions are tamper-proof without requiring a new env var.
+function signingKey(): string {
+  return env.SESSION_SECRET || env.STEAM_API_KEY
+}
+
+function hmac(payload: string): string {
+  return crypto.createHmac("sha256", signingKey()).update(payload).digest("base64url")
+}
+
+/**
+ * Encodes a user into a signed session token: `<base64url(json)>.<hmac>`.
+ * The signature is what makes the cookie tamper-proof — a forged payload (even
+ * with a whitelisted Steam ID) won't carry a valid HMAC.
+ */
+export function signSession(user: SteamUser): string {
+  const payload = Buffer.from(JSON.stringify(user)).toString("base64url")
+  return `${payload}.${hmac(payload)}`
+}
+
+/**
+ * Verifies a session token and returns the user, or null if the token is
+ * missing, malformed, or its signature doesn't match (tampered/forged).
+ */
+export function verifySession(token: string | undefined | null): SteamUser | null {
+  if (!token) return null
+
+  const dot = token.lastIndexOf(".")
+  if (dot <= 0) return null
+
+  const payload = token.slice(0, dot)
+  const signature = token.slice(dot + 1)
+
+  const expected = hmac(payload)
+  const sigBuf = Buffer.from(signature)
+  const expBuf = Buffer.from(expected)
+  if (sigBuf.length !== expBuf.length || !crypto.timingSafeEqual(sigBuf, expBuf)) {
+    return null
+  }
+
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as SteamUser
+  } catch {
+    return null
+  }
+}

--- a/test/app-lib-auth.test.ts
+++ b/test/app-lib-auth.test.ts
@@ -31,6 +31,11 @@ vi.mock("@/lib/whitelist", () => ({
 
 import { getCurrentUser, requireAuth } from "@/app/lib/server-auth"
 import { isSteamIdWhitelisted } from "@/lib/whitelist"
+import { signSession } from "@/lib/server/session"
+
+// signSession/verifySession sign with env.SESSION_SECRET (the env mock reads
+// process.env), so set it before any token is created or verified.
+process.env.SESSION_SECRET = "test-session-secret"
 
 const mockUser = {
   steamId: "76561198023709299",
@@ -62,7 +67,7 @@ describe("getCurrentUser", () => {
   })
 
   it("returns the user when the cookie JSON is valid and id is whitelisted", async () => {
-    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: signSession(mockUser) })
     vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
     const user = await getCurrentUser()
     expect(user?.steamId).toBe("76561198023709299")
@@ -70,7 +75,7 @@ describe("getCurrentUser", () => {
 
   it("decorates the user with isAdmin=true when steamId matches ADMIN_STEAM_ID", async () => {
     process.env.ADMIN_STEAM_ID = "76561198023709299"
-    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: signSession(mockUser) })
     vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
     try {
       const user = await getCurrentUser()
@@ -82,7 +87,7 @@ describe("getCurrentUser", () => {
 
   it("decorates the user with isAdmin=false when steamId does not match ADMIN_STEAM_ID", async () => {
     process.env.ADMIN_STEAM_ID = "99999999999999999"
-    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: signSession(mockUser) })
     vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
     try {
       const user = await getCurrentUser()
@@ -93,7 +98,7 @@ describe("getCurrentUser", () => {
   })
 
   it("clears the cookie and returns null when the id is NOT whitelisted", async () => {
-    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: signSession(mockUser) })
     vi.mocked(isSteamIdWhitelisted).mockReturnValue(false)
     const user = await getCurrentUser()
     expect(user).toBeNull()
@@ -109,7 +114,7 @@ describe("getCurrentUser", () => {
 
 describe("requireAuth", () => {
   it("returns the user when authenticated", async () => {
-    cookieStore.get.mockReturnValue({ name: "steam_user", value: JSON.stringify(mockUser) })
+    cookieStore.get.mockReturnValue({ name: "steam_user", value: signSession(mockUser) })
     vi.mocked(isSteamIdWhitelisted).mockReturnValue(true)
     const user = await requireAuth()
     expect(user.steamId).toBe("76561198023709299")

--- a/test/auth-callback-route.test.ts
+++ b/test/auth-callback-route.test.ts
@@ -28,6 +28,7 @@ vi.mock("next/headers", () => ({
 }))
 
 import { GET } from "@/app/api/auth/steam/callback/route"
+import { verifySession } from "@/lib/server/session"
 
 describe("GET /api/auth/steam/callback", () => {
   const originalEnv = {
@@ -226,9 +227,12 @@ describe("GET /api/auth/steam/callback", () => {
     expect(response.headers.get("location")).toBe("https://example.com/dashboard")
     expect(mockCookieStore.set).toHaveBeenCalledWith(
       "steam_user",
-      expect.stringContaining(steamId),
+      expect.any(String),
       expect.objectContaining({ httpOnly: true, path: "/" }),
     )
+    // The cookie is a signed token, not raw JSON — verify it decodes to the user.
+    const cookieValue = mockCookieStore.set.mock.calls[0][1] as string
+    expect(verifySession(cookieValue)?.steamId).toBe(steamId)
   })
 
   it("includes steam level and badges in session cookie", async () => {
@@ -293,10 +297,10 @@ describe("GET /api/auth/steam/callback", () => {
     expect(response.status).toBe(307)
 
     const cookiePayload = mockCookieStore.set.mock.calls[0][1] as string
-    const parsed = JSON.parse(cookiePayload)
-    expect(parsed.steamLevel).toBe(42)
+    const parsed = verifySession(cookiePayload)
+    expect(parsed?.steamLevel).toBe(42)
     // Only community badges (no appid) should be stored
-    expect(parsed.badges).toEqual([{ badgeid: 13, level: 50 }])
+    expect(parsed?.badges).toEqual([{ badgeid: 13, level: 50 }])
   })
 
   it("handles auth error gracefully", async () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from "vitest"
+import crypto from "node:crypto"
+import { signSession, verifySession } from "@/lib/server/session"
+import type { SteamUser } from "@/lib/auth"
+
+const USER: SteamUser = {
+  steamId: "76561198023709299",
+  displayName: "Jay",
+  avatar: "https://cdn/a.png",
+  profileUrl: "https://steamcommunity.com/id/jay",
+  timecreated: 1234567890,
+  personaState: 1,
+  communityVisibilityState: 3,
+  steamLevel: 42,
+  badges: [{ badgeid: 1, level: 5 }],
+}
+
+beforeAll(() => {
+  // session.ts signs with SESSION_SECRET (or STEAM_API_KEY); env validation
+  // also requires STEAM_API_KEY to be present.
+  process.env.STEAM_API_KEY = "test-api-key"
+  process.env.SESSION_SECRET = "unit-test-session-secret"
+})
+
+describe("session signing", () => {
+  it("round-trips a signed session (including nested badges)", () => {
+    const token = signSession(USER)
+    expect(token).toContain(".")
+    expect(verifySession(token)).toEqual(USER)
+  })
+
+  it("rejects a forged payload with no/invalid signature (the core fix)", () => {
+    // What an attacker who knows a whitelisted Steam64 ID would try: a plain
+    // JSON cookie like the old format.
+    const forged = JSON.stringify({ steamId: "76561198023709299" })
+    expect(verifySession(forged)).toBeNull()
+    expect(verifySession(Buffer.from(forged).toString("base64url") + ".deadbeef")).toBeNull()
+  })
+
+  it("rejects a tampered payload (signature no longer matches)", () => {
+    const token = signSession(USER)
+    const [payload, sig] = token.split(".")
+    const tampered = Buffer.from(JSON.stringify({ ...USER, steamId: "00000000000000000" })).toString("base64url")
+    expect(verifySession(`${tampered}.${sig}`)).toBeNull()
+    expect(verifySession(`${payload}.${sig}`)).toEqual(USER)
+  })
+
+  it("returns null for missing / malformed tokens", () => {
+    expect(verifySession(undefined)).toBeNull()
+    expect(verifySession(null)).toBeNull()
+    expect(verifySession("")).toBeNull()
+    expect(verifySession("nodothere")).toBeNull()
+    expect(verifySession(".sigonly")).toBeNull()
+  })
+
+  it("returns null when a validly-signed payload isn't valid JSON", () => {
+    const payload = Buffer.from("not json{").toString("base64url")
+    const sig = crypto.createHmac("sha256", "unit-test-session-secret").update(payload).digest("base64url")
+    expect(verifySession(`${payload}.${sig}`)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem
The `steam_user` session cookie was **plain JSON**. Since Steam64 IDs are public and the cookie is unsigned, anyone who knew a whitelisted Steam ID could forge a valid (even admin) session.

## Fix
The cookie is now a signed token: `<base64url(json)>.<hmac-sha256>`, signed with `SESSION_SECRET` (falling back to `STEAM_API_KEY` — also a server secret — so it works with no new env var). `getCurrentUser()` verifies the HMAC (timing-safe) before trusting the payload; forged or tampered cookies are rejected.

Cookie attributes unchanged and solid: `httpOnly`, `secure` in production (HTTPS-only), `sameSite=lax`, 7-day expiry.

## Impact
- Existing sessions become invalid once → users re-login.
- Optional `SESSION_SECRET` env var to decouple from the API key.

Mirrors the same fix applied to csgo-inventory-tracker. New `test/session.test.ts` (round-trip, forged-payload rejection, tamper detection, malformed tokens) + updated the auth tests that asserted the old plain-JSON cookie. Full suite: 481 tests, coverage thresholds met, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cryptographic session signing and verification to enhance authentication security.
  * Sessions are now validated for integrity on each authenticated request to prevent unauthorized tampering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->