### PR TITLE
chore: remove unused nixpacks.toml (deploying via Railpack)

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,0 @@
-[phases.setup]
-nixPkgs = ["nodejs_24"]
-
-[start]
-cmd = "node .next/standalone/server.js"


### PR DESCRIPTION
## What

Removes `nixpacks.toml`. It's dead config — the deploy uses **Railpack** on Dokploy, which doesn't read Nixpacks files at all.

## Why it's safe

Everything `nixpacks.toml` provided is already covered by `package.json`, which Railpack reads:

| Old `nixpacks.toml` | Covered by |
|---|---|
| `nixPkgs = ["nodejs_24"]` | `engines.node: ">=24.13.1 <25"` (Railpack resolves Node from `engines.node`) |
| `cmd = "node .next/standalone/server.js"` | the `start` script (Railpack uses the `start` script as the start command) |

Static-asset copying into the standalone output lives in the `build` script, which Railpack runs as the build command — so the standalone server remains self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->