### PR TITLE
fix(auth): harden OpenID callback nonce and return_to validation

### DIFF
--- a/app/api/auth/steam/callback/route.ts
+++ b/app/api/auth/steam/callback/route.ts
@@ -19,6 +19,33 @@ function getAppUrl(path: string, request: NextRequest): string {
 }
 
 /**
+ * Constant-time comparison of the `nonce` query param against the nonce
+ * cookie. `crypto.timingSafeEqual` throws a RangeError on buffers of
+ * different lengths, so check lengths first (same pattern as
+ * `verifySession` in lib/server/session.ts) — an attacker-supplied
+ * `?nonce=` of the wrong length must fail validation, not crash the route.
+ */
+function nonceMatches(nonce: string, expected: string): boolean {
+  const nonceBuf = Buffer.from(nonce)
+  const expectedBuf = Buffer.from(expected)
+  return nonceBuf.length === expectedBuf.length && crypto.timingSafeEqual(nonceBuf, expectedBuf)
+}
+
+/**
+ * Checks that `openid.return_to` points back at our own origin. Compares
+ * parsed origins instead of a string prefix so that a lookalike host such
+ * as `https://app.example.com.evil.com` cannot pass a check against
+ * `https://app.example.com`. Unparseable URLs fail closed.
+ */
+function returnToMatchesRealm(returnTo: string, expectedRealm: string): boolean {
+  try {
+    return new URL(returnTo).origin === new URL(expectedRealm).origin
+  } catch {
+    return false
+  }
+}
+
+/**
  * GET /api/auth/steam/callback
  *
  * Handles the Steam OpenID callback after the user authenticates with Steam.
@@ -39,7 +66,7 @@ export async function GET(request: NextRequest) {
   const nonce = searchParams.get("nonce")
   const nonceCookie = cookieStore.get("steam_openid_nonce")
 
-  if (!nonce || !nonceCookie?.value || !crypto.timingSafeEqual(Buffer.from(nonce), Buffer.from(nonceCookie.value))) {
+  if (!nonce || !nonceCookie?.value || !nonceMatches(nonce, nonceCookie.value)) {
     logger.info("Auth failed: invalid or missing nonce")
     cookieStore.delete("steam_openid_nonce")
     return NextResponse.redirect(getAppUrl("/?error=auth_failed", request))
@@ -89,7 +116,7 @@ export async function GET(request: NextRequest) {
     // --- Verify return_to matches our realm ---
     const returnTo = searchParams.get("openid.return_to") ?? ""
     const expectedRealm = process.env.NEXTAUTH_URL || new URL("/", request.url).origin
-    if (!returnTo.startsWith(expectedRealm)) {
+    if (!returnToMatchesRealm(returnTo, expectedRealm)) {
       return NextResponse.redirect(getAppUrl("/?error=auth_failed", request))
     }
 

--- a/test/auth-callback-route.test.ts
+++ b/test/auth-callback-route.test.ts
@@ -86,6 +86,24 @@ describe("GET /api/auth/steam/callback", () => {
     expect(response.headers.get("location")).toBe("https://example.com/?error=auth_failed")
   })
 
+  it("redirects to auth_failed when nonce length differs from cookie (no RangeError)", async () => {
+    process.env.NEXTAUTH_URL = "https://example.com"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
+
+    // crypto.timingSafeEqual throws RangeError on different-length buffers;
+    // a short attacker-supplied ?nonce= must redirect, not crash with a 500.
+    mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
+
+    const request = new NextRequest(
+      `https://example.com/api/auth/steam/callback?nonce=short&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=https://example.com/api/auth/steam/callback`,
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toBe("https://example.com/?error=auth_failed")
+  })
+
   it("redirects to auth_failed when Steam ID format is invalid", async () => {
     process.env.NEXTAUTH_URL = "https://example.com"
     process.env.STEAM_WHITELIST_IDS = "76561198023709299"
@@ -170,6 +188,54 @@ describe("GET /api/auth/steam/callback", () => {
 
     const request = new NextRequest(
       `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=https://evil.com/callback`,
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toBe("https://example.com/?error=auth_failed")
+  })
+
+  it("redirects to auth_failed when return_to host merely prefixes the realm", async () => {
+    process.env.NEXTAUTH_URL = "https://example.com"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
+
+    mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        text: async () => "is_valid:true",
+      }),
+    )
+
+    // "https://example.com.evil.com" passes a naive startsWith("https://example.com")
+    // check; origins must be compared instead.
+    const request = new NextRequest(
+      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=https://example.com.evil.com/api/auth/steam/callback`,
+    )
+
+    const response = await GET(request)
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get("location")).toBe("https://example.com/?error=auth_failed")
+  })
+
+  it("redirects to auth_failed when return_to is not a parseable URL", async () => {
+    process.env.NEXTAUTH_URL = "https://example.com"
+    process.env.STEAM_WHITELIST_IDS = "76561198023709299"
+
+    mockCookieStore.get.mockReturnValue({ value: TEST_NONCE })
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        text: async () => "is_valid:true",
+      }),
+    )
+
+    const request = new NextRequest(
+      `https://example.com/api/auth/steam/callback?nonce=${TEST_NONCE}&openid.claimed_id=https://steamcommunity.com/openid/id/76561198023709299&openid.return_to=not-a-url`,
     )
 
     const response = await GET(request)


### PR DESCRIPTION
## Resumen

Dos fixes de endurecimiento en el callback de Steam OpenID (`app/api/auth/steam/callback/route.ts`):

### 1. Comparación de nonce sin RangeError

`crypto.timingSafeEqual(Buffer.from(nonce), Buffer.from(nonceCookie.value))` lanza `RangeError` cuando los buffers tienen longitudes distintas, y la comprobación estaba **fuera** del bloque `try`. Resultado: un `?nonce=` de longitud distinta (trivial de fabricar por un atacante) producía un 500 sin manejar en vez del redirect a `/?error=auth_failed`.

**Fix:** helper `nonceMatches()` que compara longitudes antes de `timingSafeEqual` — mismo patrón que ya usa `verifySession()` en `lib/server/session.ts`. La comparación sigue siendo en tiempo constante para longitudes iguales y ahora falla cerrada para longitudes distintas.

### 2. Validación de `openid.return_to` por origin parseado

`returnTo.startsWith(expectedRealm)` es un prefix-check débil: `https://example.com.evil.com/callback` pasa la comprobación para el realm `https://example.com`.

**Fix:** helper `returnToMatchesRealm()` que compara `new URL(returnTo).origin === new URL(expectedRealm).origin`, con try/catch para que las URLs no parseables fallen cerradas.

## Tests

Tres tests de regresión nuevos en `test/auth-callback-route.test.ts` (patrón existente del fichero):

- nonce de longitud distinta a la cookie → redirect `auth_failed` (antes: RangeError/500)
- `return_to` con host lookalike (`https://example.com.evil.com`) → redirect `auth_failed` (antes: pasaba)
- `return_to` no parseable → redirect `auth_failed`

## Checks

- `pnpm lint` (oxlint + typecheck) ✅
- `pnpm test` — 484 tests, 53 ficheros ✅ (481 previos + 3 nuevos)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)