### PR TITLE
chore: fix onboarding docs and declare @testing-library/dom

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,8 @@
 # Steam Backlog Hunter — environment variables
 # Copy this file to .env.local and fill in your values:
 #   cp .env.local.example .env.local
-# All variables are validated at runtime in lib/env.ts.
+# All variables except LOG_LEVEL are validated at runtime in lib/env.ts
+# (LOG_LEVEL is read directly by lib/server/logger.ts).
 
 # Steam Web API key (required).
 # Get one at https://steamcommunity.com/dev/apikey

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,32 @@
+# Steam Backlog Hunter — environment variables
+# Copy this file to .env.local and fill in your values:
+#   cp .env.local.example .env.local
+# All variables are validated at runtime in lib/env.ts.
+
+# Steam Web API key (required).
+# Get one at https://steamcommunity.com/dev/apikey
+STEAM_API_KEY=your-steam-api-key
+
+# Steam64 ID with admin access — always allowed to sign in and can manage
+# the whitelist at /admin.
+ADMIN_STEAM_ID=76561198000000000
+
+# Comma-separated Steam64 IDs allowed to sign in (initial seed; managed via
+# /admin afterwards). If missing or empty, all non-admin access is denied.
+STEAM_WHITELIST_IDS=76561198000000000,76561198000000001
+
+# Public URL of the app. Required in production so Steam OpenID redirects
+# back to the right origin. Defaults to the request origin in development.
+# NEXTAUTH_URL=https://steam.example.com
+
+# HMAC key used to sign the session cookie (optional). Falls back to
+# STEAM_API_KEY when unset. Generate one with:
+#   openssl rand -base64 32
+# SESSION_SECRET=
+
+# Custom SQLite database path (optional). Defaults to /data/steam-backlog-hunter.sqlite
+# when /data is writable (containers), otherwise .data/steam-backlog-hunter.sqlite.
+# SQLITE_PATH=./.data/steam-backlog-hunter.sqlite
+
+# Pino log level (optional, default: info).
+# LOG_LEVEL=debug

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ node_modules/
 # pnpm dev/build/typecheck all regenerate it automatically.
 next-env.d.ts
 
-# Local environment variables
+# Local environment variables (keep the example template tracked)
 .env*
+!.env.local.example
 
 # Logs
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,19 +7,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 pnpm dev              # Start dev server (localhost:3000)
 pnpm build            # Production build (standalone output)
-pnpm lint             # ESLint + typecheck (runs both)
+pnpm lint             # oxlint + typecheck (runs both)
 pnpm typecheck        # next typegen + tsc --noEmit
 pnpm test             # Vitest run (all tests)
-pnpm format           # Prettier format all files
+pnpm format           # oxfmt format all files
 pnpm exec vitest run test/<file>.test.ts  # Run single test file
 ```
 
 CI runs: install → lint → test → build (GitHub Actions, on push to main and PRs).
-Pre-commit hooks run Prettier + ESLint via Husky + lint-staged.
+Pre-commit hooks run oxfmt + oxlint via Husky + lint-staged.
 
 ## Architecture
 
-Next.js 16 App Router with React 19, TypeScript strict mode, Tailwind CSS 4, shadcn/ui (new-york style) + Radix UI primitives. Uses pnpm 10.25 and Node 24.13.
+Next.js 16 App Router with React 19, TypeScript strict mode, Tailwind CSS 4, shadcn/ui (new-york style) + Radix UI primitives. Uses pnpm 11.7 and Node 24.13.
 
 ### Data flow
 
@@ -68,7 +68,7 @@ Whitelist-based, multi-user ready. `STEAM_WHITELIST_IDS` (comma-separated Steam6
 - SQLite path resolution: `SQLITE_PATH` env → `/data/` → `.data/` fallback
 - Environment variables validated with Zod lazily on first access (`lib/env.ts`)
 - Structured logging via Pino (`lib/server/logger.ts`)
-- `@next/next/no-img-element` ESLint rule is disabled
+- `nextjs/no-img-element` oxlint rule is disabled (`.oxlintrc.json`)
 - `lib/steam-api.ts` must NOT import `server-only` modules (used by client components for types)
 - Tests live in `test/` directory (Vitest + @testing-library/react + jsdom)
 - All API routes and public functions have JSDoc documentation

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ A self-hosted dashboard for tracking your Steam library, monitoring achievement 
 | Database        | SQLite via Node.js built-in `DatabaseSync`                                                                        |
 | Auth            | Steam OpenID 2.0                                                                                                  |
 | Testing         | [Vitest](https://vitest.dev/) + Testing Library                                                                   |
-| Linting         | ESLint + Prettier                                                                                                 |
+| Linting         | [oxlint](https://oxc.rs/docs/guide/usage/linter) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter)             |
 | CI/CD           | GitHub Actions                                                                                                    |
-| Package Manager | pnpm 10.25                                                                                                        |
+| Package Manager | pnpm 11.7                                                                                                         |
 
 ## Prerequisites
 
 - Node.js `24.13.1` (see `.nvmrc`)
-- pnpm `10.25.0`
+- pnpm `11.7.0` (see `packageManager` in `package.json` — Corepack picks it up automatically)
 
 ## Getting Started
 
@@ -76,6 +76,7 @@ The app will be available at `http://localhost:3000`.
 | `NEXTAUTH_URL`        | Production | Your app's public URL (e.g. `https://steam.example.com`)                  |
 | `SQLITE_PATH`         | No         | Custom SQLite database path (see [Database](#database))                   |
 | `STEAM_WHITELIST_IDS` | No         | Comma-separated Steam64 IDs for initial seed (managed via `/admin` after) |
+| `SESSION_SECRET`      | No         | HMAC key for signing the session cookie (falls back to `STEAM_API_KEY`)   |
 | `LOG_LEVEL`           | No         | Pino log level (default: `info`)                                          |
 
 ## Scripts
@@ -85,10 +86,10 @@ The app will be available at `http://localhost:3000`.
 | `pnpm dev`          | Start development server             |
 | `pnpm build`        | Production build (standalone output) |
 | `pnpm start`        | Run production server                |
-| `pnpm lint`         | ESLint + TypeScript typecheck        |
+| `pnpm lint`         | oxlint + TypeScript typecheck        |
 | `pnpm test`         | Run test suite (Vitest)              |
 | `pnpm typecheck`    | Type generation + `tsc --noEmit`     |
-| `pnpm format`       | Format codebase with Prettier        |
+| `pnpm format`       | Format codebase with oxfmt           |
 | `pnpm format:check` | Check formatting without writing     |
 
 ## Architecture
@@ -235,7 +236,7 @@ Ensure `NEXTAUTH_URL` matches your public URL for Steam OpenID redirects.
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feat/my-feature`)
 3. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
-4. Pre-commit hooks will run Prettier and ESLint automatically
+4. Pre-commit hooks will run oxfmt and oxlint automatically
 5. Create an issue first, then open a Pull Request that closes it
 
 CI runs `lint → test → build` on all PRs.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",
+    "@testing-library/dom": ">=10 <11",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
+      '@testing-library/dom':
+        specifier: '>=10 <11'
+        version: 10.4.1
       '@testing-library/jest-dom':
         specifier: ^7.0.0
         version: 7.0.0(@testing-library/dom@10.4.1)


### PR DESCRIPTION
## Resumen

Arreglos de onboarding del repo público:

### 1. `.env.local.example` (nuevo)

El README manda `cp .env.local.example .env.local` pero el fichero no existía. Se añade con todas las variables que valida `lib/env.ts` (`STEAM_API_KEY`, `ADMIN_STEAM_ID`, `STEAM_WHITELIST_IDS`, `NEXTAUTH_URL`, `SESSION_SECRET`, `SQLITE_PATH`) más `LOG_LEVEL` (leída en `lib/server/logger.ts`), con placeholders y comentarios. También se añade `!.env.local.example` a `.gitignore`, porque el patrón `.env*` existente lo ignoraba.

### 2. README y CLAUDE.md

- Tabla de tech stack: el stack de lint es **oxlint + oxfmt**, no "ESLint + Prettier"; package manager **pnpm 11.7**, no 10.25.
- Prerequisites: pnpm `11.7.0` (el `packageManager` de `package.json`, gestionado por Corepack).
- Tabla de scripts: `pnpm lint` → oxlint + typecheck; `pnpm format` → oxfmt.
- Contributing: los pre-commit hooks ejecutan oxfmt y oxlint, no Prettier/ESLint.
- Tabla de variables de entorno: se documenta `SESSION_SECRET` (existe en `lib/env.ts` y no estaba listada).
- `CLAUDE.md`: mismas correcciones de tooling (oxlint/oxfmt, pnpm 11.7, y la regla deshabilitada es `nextjs/no-img-element` de oxlint en `.oxlintrc.json`, no una regla de ESLint).

No se reescribe nada más de ninguno de los dos documentos.

### 3. `@testing-library/dom` como devDependency explícita

Follow-up pendiente de CodeRabbit: se declara `"@testing-library/dom": ">=10 <11"` en vez de depender de la resolución peer transitiva de `@testing-library/react` / `@testing-library/jest-dom`. Sigue resolviendo a la misma y única `10.4.1` (`pnpm why` confirma una sola versión); el lockfile solo añade la entrada directa.

## Checks

- `pnpm lint` (oxlint + typecheck) ✅
- `pnpm test` — 481 tests, 52 ficheros ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)