### PR TITLE
fix(steam-api): robustez ante 429, logging con pino y CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Explicit HTTP 429 handling in the Steam API client (`lib/steam-api.ts`): rate-limited
-  requests are now retried with capped exponential backoff, honouring the `Retry-After`
-  header when Valve sends one, instead of being swallowed as a generic failure that made
-  `getOwnedGames` return an empty library.
+  requests are now retried with exponential backoff, honouring the `Retry-After` header in
+  full when Valve sends one (only the exponential fallback is capped). Previously a 429 was
+  swallowed as a generic failure. These retries run _before_ the existing empty-library
+  guard in `runHeavyOwnedGamesSync`; that guard is unchanged, so if retries are exhausted
+  `getOwnedGames` still returns `[]` and the sync preserves the previously stored library
+  rather than wiping them.
 - `STEAM_API_LOCALE` environment variable to override the locale (`l=`) sent to Steam.
   Defaults to `es` to preserve previous behaviour.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Explicit HTTP 429 handling in the Steam API client (`lib/steam-api.ts`): rate-limited
+  requests are now retried with capped exponential backoff, honouring the `Retry-After`
+  header when Valve sends one, instead of being swallowed as a generic failure that made
+  `getOwnedGames` return an empty library.
+- `STEAM_API_LOCALE` environment variable to override the locale (`l=`) sent to Steam.
+  Defaults to `es` to preserve previous behaviour.
+
+### Changed
+
+- `lib/steam-api.ts` now logs through the shared pino logger (`lib/server/logger`) instead
+  of `console.error` / `console.warn`, bringing it in line with the rest of `lib/server`.
+  Pure CDN URL builders (`getSteamImageUrl`, `getSteamHeaderImageUrl`,
+  `getSteamPortraitImageUrl`) moved to a client-safe `lib/steam-image-urls` module so the
+  Steam API client can be `server-only` without pulling the logger into the browser bundle.
+- Migrated tooling to the current stack: TypeScript 7, `next` 16.3, oxlint for linting,
+  pnpm 11 with overrides moved to `pnpm-workspace.yaml`, and Vitest 4. CI now reads the pnpm
+  version from the `packageManager` field instead of a pinned value.
+- Removed the unused `nixpacks.toml` (deploys run via Railpack) and enabled Dependabot
+  version updates; refreshed the dependency lockfile (Vite 8 drops esbuild dev advisories,
+  jsdom 29, lucide-react 1.x, and a large minor/patch group across the tree).
+
+### Security
+
+- Hardened the OpenID sign-in callback with stricter nonce and `return_to` validation to
+  prevent open-redirect and replay abuse.
+- Session cookie is now signed with an HMAC to detect tampering.
+- Bumped `undici` to 7.28.0 to pick up upstream security advisories.
+
+## [0.10.15] - 2026-05-12
+
+### Security
+
+- Bumped `next` to 16.2.6 and pinned `postcss >= 8.5.10` to pick up upstream security fixes.
+
+## [0.10.14] - 2026-04-26
+
+### Added
+
+- Release-year and "Legacy" badges to disambiguate indistinguishable duplicate listings.
+
+## [0.10.13] - 2026-04-26
+
+### Fixed
+
+- Platforms sync now requests `filters=platforms` (the `basic` filter excludes the field),
+  so windows/mac/linux support is populated correctly.
+
+[Unreleased]: https://github.com/finallyjay/steam-backlog-hunter/compare/v0.10.15...HEAD
+[0.10.15]: https://github.com/finallyjay/steam-backlog-hunter/compare/v0.10.14...v0.10.15
+[0.10.14]: https://github.com/finallyjay/steam-backlog-hunter/compare/v0.10.13...v0.10.14
+[0.10.13]: https://github.com/finallyjay/steam-backlog-hunter/releases/tag/v0.10.13

--- a/app/extras/page.tsx
+++ b/app/extras/page.tsx
@@ -12,7 +12,7 @@ import { GameCard } from "@/components/ui/game-card"
 import { InputFrame } from "@/components/ui/input-frame"
 import { Skeleton } from "@/components/ui/skeleton"
 import { SurfaceCard } from "@/components/ui/surface-card"
-import { getSteamHeaderImageUrl } from "@/lib/steam-api"
+import { getSteamHeaderImageUrl } from "@/lib/steam-image-urls"
 
 type Tab = "extras" | "hidden"
 

--- a/components/dashboard/library-overview.tsx
+++ b/components/dashboard/library-overview.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Skeleton } from "@/components/ui/skeleton"
 import { SurfaceCard } from "@/components/ui/surface-card"
 import { useSteamAchievementsBatch, useSteamGames } from "@/hooks/use-steam-data"
-import { getSteamHeaderImageUrl } from "@/lib/steam-api"
+import { getSteamHeaderImageUrl } from "@/lib/steam-image-urls"
 import { buildGamesWithStats, mapOwnedGamesToGameCards, sortGames } from "@/lib/games-mapping"
 import type { SteamGameCardModel } from "@/lib/types/steam"
 

--- a/components/dashboard/recent-games.tsx
+++ b/components/dashboard/recent-games.tsx
@@ -7,7 +7,7 @@ import { GameCard } from "@/components/ui/game-card"
 import { SurfaceCard } from "@/components/ui/surface-card"
 import { useSteamGames, useSteamAchievementsBatch } from "@/hooks/use-steam-data"
 import { useMemo, useState, useCallback } from "react"
-import { getSteamHeaderImageUrl } from "@/lib/steam-api"
+import { getSteamHeaderImageUrl } from "@/lib/steam-image-urls"
 export function RecentGames() {
   const { games, loading, error } = useSteamGames("recent")
   const [locallyHidden, setLocallyHidden] = useState<Set<number>>(new Set())

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -1,3 +1,7 @@
+import "server-only"
+
+import { logger } from "@/lib/server/logger"
+
 export interface SteamGame {
   appid: number
   name: string
@@ -76,6 +80,24 @@ export interface GameSchema {
 
 const STEAM_API_BASE = "https://api.steampowered.com"
 
+/**
+ * Locale passed to Steam as the `l=` parameter (localizes game names,
+ * achievement text, etc). Defaults to Spanish to preserve historical
+ * behaviour; override with STEAM_API_LOCALE (e.g. "en", "fr", "de").
+ */
+function steamLocale(): string {
+  return process.env.STEAM_API_LOCALE || "es"
+}
+
+// Rate-limit backoff tuning. Steam returns HTTP 429 when Valve throttles the
+// key — common during the heavy owned-games sync, which fans out hundreds of
+// per-app achievement/schema calls. Without a retry those blips silently turn
+// into empty results (getOwnedGames → []), so we retry with capped exponential
+// backoff, honouring the Retry-After header when Valve sends one.
+const MAX_STEAM_RETRIES = 3
+const BASE_BACKOFF_MS = 1_000
+const MAX_BACKOFF_MS = 30_000
+
 class SteamAPIError extends Error {
   constructor(
     message: string,
@@ -84,6 +106,31 @@ class SteamAPIError extends Error {
     super(message)
     this.name = "SteamAPIError"
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Parses a `Retry-After` header into milliseconds. Steam may send either a
+ * delay in seconds ("120") or an HTTP-date. Returns null when the header is
+ * absent or unparseable so the caller can fall back to exponential backoff.
+ */
+function parseRetryAfterMs(header: string | null | undefined): number | null {
+  if (!header) return null
+  const seconds = Number(header)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1_000)
+  const dateMs = Date.parse(header)
+  if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now())
+  return null
+}
+
+/** Backoff for a given attempt: Retry-After if present, else capped exponential. */
+function backoffDelayMs(attempt: number, retryAfterHeader: string | null | undefined): number {
+  const retryAfter = parseRetryAfterMs(retryAfterHeader)
+  if (retryAfter !== null) return Math.min(retryAfter, MAX_BACKOFF_MS)
+  return Math.min(BASE_BACKOFF_MS * 2 ** attempt, MAX_BACKOFF_MS)
 }
 
 async function steamAPIRequest(endpoint: string, params: Record<string, string>) {
@@ -100,21 +147,40 @@ async function steamAPIRequest(endpoint: string, params: Record<string, string>)
     url.searchParams.set(key, value)
   })
 
-  try {
-    const response = await fetch(url.toString(), {
-      cache: "no-store",
-    })
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const response = await fetch(url.toString(), {
+        cache: "no-store",
+      })
 
-    if (!response.ok) {
-      throw new SteamAPIError(`Steam API request failed: ${response.status}`, response.status)
-    }
+      // Explicit rate-limit handling: back off and retry rather than letting
+      // Valve's throttle surface as a generic failure the callers swallow.
+      if (response.status === 429) {
+        const retryAfterHeader = response.headers?.get?.("retry-after")
+        if (attempt < MAX_STEAM_RETRIES) {
+          const delay = backoffDelayMs(attempt, retryAfterHeader)
+          logger.warn(
+            { endpoint, attempt: attempt + 1, delayMs: delay, retryAfter: retryAfterHeader ?? null },
+            "Steam API rate limited (429) — backing off before retry",
+          )
+          await sleep(delay)
+          continue
+        }
+        logger.error({ endpoint, attempts: attempt + 1 }, "Steam API rate limited (429) — retries exhausted, giving up")
+        throw new SteamAPIError(`Steam API rate limited: 429`, 429)
+      }
 
-    return await response.json()
-  } catch (error) {
-    if (error instanceof SteamAPIError) {
-      throw error
+      if (!response.ok) {
+        throw new SteamAPIError(`Steam API request failed: ${response.status}`, response.status)
+      }
+
+      return await response.json()
+    } catch (error) {
+      if (error instanceof SteamAPIError) {
+        throw error
+      }
+      throw new SteamAPIError(`Network error: ${error instanceof Error ? error.message : "Unknown error"}`)
     }
-    throw new SteamAPIError(`Network error: ${error instanceof Error ? error.message : "Unknown error"}`)
   }
 }
 
@@ -128,12 +194,12 @@ export async function getOwnedGames(steamId: string): Promise<SteamGame[]> {
       // skip_unvetted_apps=0 pulls in playtests and early-access experiments
       // that Steam normally hides (e.g. SquadBlast Playtest, ForeVR Cornhole).
       skip_unvetted_apps: "0",
-      l: "es",
+      l: steamLocale(),
     })
 
     return data.response?.games || []
   } catch (error) {
-    console.error("Error fetching owned games:", error)
+    logger.error({ err: error, steamId }, "Error fetching owned games")
     return []
   }
 }
@@ -144,12 +210,12 @@ export async function getRecentlyPlayedGames(steamId: string): Promise<SteamGame
     const data = await steamAPIRequest("/IPlayerService/GetRecentlyPlayedGames/v1/", {
       steamid: steamId,
       count: "25",
-      l: "es",
+      l: steamLocale(),
     })
 
     return data.response?.games || []
   } catch (error) {
-    console.error("Error fetching recently played games:", error)
+    logger.error({ err: error, steamId }, "Error fetching recently played games")
     return []
   }
 }
@@ -160,7 +226,7 @@ export async function getPlayerAchievements(steamId: string, appId: number): Pro
     const data = await steamAPIRequest("/ISteamUserStats/GetPlayerAchievements/v1/", {
       steamid: steamId,
       appid: appId.toString(),
-      l: "es",
+      l: steamLocale(),
     })
 
     if (!data.playerstats?.success) {
@@ -181,10 +247,7 @@ export async function getPlayerAchievements(steamId: string, appId: number): Pro
     if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403 || error.status === 500)) {
       return null
     }
-    console.warn(
-      `[steam-api] Unexpected error fetching achievements for app ${appId}:`,
-      error instanceof Error ? error.message : error,
-    )
+    logger.warn({ err: error, appId }, "Unexpected error fetching achievements")
     return null
   }
 }
@@ -218,7 +281,7 @@ export async function getLastPlayedTimes(steamId: string): Promise<LastPlayedGam
     if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
       return []
     }
-    console.error("Error fetching last played times:", error)
+    logger.error({ err: error, steamId }, "Error fetching last played times")
     return []
   }
 }
@@ -258,10 +321,7 @@ export async function getGlobalAchievementPercentages(appId: number): Promise<Gl
     if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403 || error.status === 404)) {
       return null
     }
-    console.warn(
-      `[steam-api] Unexpected error fetching global percentages for app ${appId}:`,
-      error instanceof Error ? error.message : error,
-    )
+    logger.warn({ err: error, appId }, "Unexpected error fetching global achievement percentages")
     return null
   }
 }
@@ -281,24 +341,11 @@ export async function getGameSchema(appId: number): Promise<GameSchema | null> {
     if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
       return null
     }
-    console.error("Error fetching game schema for app:", appId, error)
+    logger.error({ err: error, appId }, "Error fetching game schema")
     return null
   }
 }
 
-/** Builds a Steam community image URL from an app ID and image hash. */
-export function getSteamImageUrl(appId: number, imageHash: string): string {
-  if (!imageHash) return "/placeholder-icon.svg"
-
-  return `https://media.steampowered.com/steamcommunity/public/images/apps/${appId}/${imageHash}.jpg`
-}
-
-/** Builds a Steam store header image URL for a game (landscape 460x215). */
-export function getSteamHeaderImageUrl(appId: number): string {
-  return `https://shared.steamstatic.com/store_item_assets/steam/apps/${appId}/header.jpg`
-}
-
-/** Builds a Steam library portrait image URL for a game (600x900, 2:3). */
-export function getSteamPortraitImageUrl(appId: number): string {
-  return `https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/${appId}/library_600x900.jpg`
-}
+// Pure CDN URL builders live in a client-safe module (this file is
+// `server-only`). Re-exported here for existing server-side importers.
+export { getSteamImageUrl, getSteamHeaderImageUrl, getSteamPortraitImageUrl } from "@/lib/steam-image-urls"

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -1,6 +1,23 @@
+// This module talks to the Steam Web API and logs through the server-only
+// pino logger, so it is marked `server-only`. Client components only ever
+// import *types* from here (e.g. `SteamGame`), which TypeScript erases at
+// compile time — there is no runtime import — so the boundary holds and the
+// build stays green. Runtime helpers a client needs (CDN URL builders) live
+// in the client-safe `lib/steam-image-urls` module instead.
 import "server-only"
 
+import { createHash } from "node:crypto"
+
 import { logger } from "@/lib/server/logger"
+
+/**
+ * Steam IDs are personal identifiers, so never log them raw (CWE-532). This
+ * returns a short, stable hash that's enough to correlate log lines for the
+ * same account without exposing the id itself.
+ */
+function redactSteamId(steamId: string): string {
+  return `sid_${createHash("sha256").update(steamId).digest("hex").slice(0, 10)}`
+}
 
 export interface SteamGame {
   appid: number
@@ -92,11 +109,18 @@ function steamLocale(): string {
 // Rate-limit backoff tuning. Steam returns HTTP 429 when Valve throttles the
 // key — common during the heavy owned-games sync, which fans out hundreds of
 // per-app achievement/schema calls. Without a retry those blips silently turn
-// into empty results (getOwnedGames → []), so we retry with capped exponential
+// into empty results (getOwnedGames → []), so we retry with exponential
 // backoff, honouring the Retry-After header when Valve sends one.
 const MAX_STEAM_RETRIES = 3
 const BASE_BACKOFF_MS = 1_000
+// Caps ONLY the exponential fallback delay — never a server-provided
+// Retry-After (that must be honoured in full, see nextBackoffMs).
 const MAX_BACKOFF_MS = 30_000
+// Ceiling on how long we'll actually hold a request open waiting out a
+// Retry-After. Beyond this it's cheaper to fail fast (return the rate-limit
+// error) than to sleep for minutes — and retrying *before* the window closes
+// would just hit the same throttle again.
+const MAX_RETRY_AFTER_WAIT_MS = 60_000
 
 class SteamAPIError extends Error {
   constructor(
@@ -126,10 +150,21 @@ function parseRetryAfterMs(header: string | null | undefined): number | null {
   return null
 }
 
-/** Backoff for a given attempt: Retry-After if present, else capped exponential. */
-function backoffDelayMs(attempt: number, retryAfterHeader: string | null | undefined): number {
+/**
+ * Delay (ms) to wait before the next 429 retry, or `null` to stop retrying.
+ *
+ * - A valid Retry-After is honoured *in full* (never capped to MAX_BACKOFF_MS)
+ *   as long as it's within MAX_RETRY_AFTER_WAIT_MS. Capping it would retry
+ *   while Valve is still throttling us and burn the remaining attempts early.
+ * - A Retry-After beyond that ceiling returns `null`: give up now rather than
+ *   retry too soon or hold the request open for minutes.
+ * - Without Retry-After, fall back to capped exponential backoff.
+ */
+function nextBackoffMs(attempt: number, retryAfterHeader: string | null | undefined): number | null {
   const retryAfter = parseRetryAfterMs(retryAfterHeader)
-  if (retryAfter !== null) return Math.min(retryAfter, MAX_BACKOFF_MS)
+  if (retryAfter !== null) {
+    return retryAfter <= MAX_RETRY_AFTER_WAIT_MS ? retryAfter : null
+  }
   return Math.min(BASE_BACKOFF_MS * 2 ** attempt, MAX_BACKOFF_MS)
 }
 
@@ -157,8 +192,8 @@ async function steamAPIRequest(endpoint: string, params: Record<string, string>)
       // Valve's throttle surface as a generic failure the callers swallow.
       if (response.status === 429) {
         const retryAfterHeader = response.headers?.get?.("retry-after")
-        if (attempt < MAX_STEAM_RETRIES) {
-          const delay = backoffDelayMs(attempt, retryAfterHeader)
+        const delay = attempt < MAX_STEAM_RETRIES ? nextBackoffMs(attempt, retryAfterHeader) : null
+        if (delay !== null) {
           logger.warn(
             { endpoint, attempt: attempt + 1, delayMs: delay, retryAfter: retryAfterHeader ?? null },
             "Steam API rate limited (429) — backing off before retry",
@@ -166,7 +201,10 @@ async function steamAPIRequest(endpoint: string, params: Record<string, string>)
           await sleep(delay)
           continue
         }
-        logger.error({ endpoint, attempts: attempt + 1 }, "Steam API rate limited (429) — retries exhausted, giving up")
+        logger.error(
+          { endpoint, attempts: attempt + 1, retryAfter: retryAfterHeader ?? null },
+          "Steam API rate limited (429) — giving up (retries exhausted or Retry-After too long)",
+        )
         throw new SteamAPIError(`Steam API rate limited: 429`, 429)
       }
 
@@ -199,7 +237,7 @@ export async function getOwnedGames(steamId: string): Promise<SteamGame[]> {
 
     return data.response?.games || []
   } catch (error) {
-    logger.error({ err: error, steamId }, "Error fetching owned games")
+    logger.error({ err: error, steamIdHash: redactSteamId(steamId) }, "Error fetching owned games")
     return []
   }
 }
@@ -215,7 +253,7 @@ export async function getRecentlyPlayedGames(steamId: string): Promise<SteamGame
 
     return data.response?.games || []
   } catch (error) {
-    logger.error({ err: error, steamId }, "Error fetching recently played games")
+    logger.error({ err: error, steamIdHash: redactSteamId(steamId) }, "Error fetching recently played games")
     return []
   }
 }
@@ -281,7 +319,7 @@ export async function getLastPlayedTimes(steamId: string): Promise<LastPlayedGam
     if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
       return []
     }
-    logger.error({ err: error, steamId }, "Error fetching last played times")
+    logger.error({ err: error, steamIdHash: redactSteamId(steamId) }, "Error fetching last played times")
     return []
   }
 }

--- a/lib/steam-image-urls.ts
+++ b/lib/steam-image-urls.ts
@@ -1,0 +1,21 @@
+// Pure Steam CDN URL builders. Kept in their own module (no `server-only`,
+// no network access) so client components can import them without pulling
+// the server-side Steam API client — and its pino logger — into the browser
+// bundle.
+
+/** Builds a Steam community image URL from an app ID and image hash. */
+export function getSteamImageUrl(appId: number, imageHash: string): string {
+  if (!imageHash) return "/placeholder-icon.svg"
+
+  return `https://media.steampowered.com/steamcommunity/public/images/apps/${appId}/${imageHash}.jpg`
+}
+
+/** Builds a Steam store header image URL for a game (landscape 460x215). */
+export function getSteamHeaderImageUrl(appId: number): string {
+  return `https://shared.steamstatic.com/store_item_assets/steam/apps/${appId}/header.jpg`
+}
+
+/** Builds a Steam library portrait image URL for a game (600x900, 2:3). */
+export function getSteamPortraitImageUrl(appId: number): string {
+  return `https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/${appId}/library_600x900.jpg`
+}

--- a/test/last-played-times.test.ts
+++ b/test/last-played-times.test.ts
@@ -78,24 +78,23 @@ describe("getLastPlayedTimes (Steam API wrapper)", () => {
     globalThis.fetch = vi.fn(async () => ({
       ok: false,
       status: 400,
+      headers: { get: () => null },
       json: async () => ({}),
     })) as unknown as typeof fetch
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { logger } = await import("@/lib/server/logger")
     const { getLastPlayedTimes } = await import("@/lib/steam-api")
     expect(await getLastPlayedTimes(STEAM_ID)).toEqual([])
-    expect(consoleSpy).not.toHaveBeenCalled()
-    consoleSpy.mockRestore()
+    expect(logger.error).not.toHaveBeenCalled()
   })
 
   it("returns [] and logs on network failure", async () => {
     globalThis.fetch = vi.fn(async () => {
       throw new Error("ECONNRESET")
     }) as unknown as typeof fetch
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const { logger } = await import("@/lib/server/logger")
     const { getLastPlayedTimes } = await import("@/lib/steam-api")
     expect(await getLastPlayedTimes(STEAM_ID)).toEqual([])
-    expect(consoleSpy).toHaveBeenCalled()
-    consoleSpy.mockRestore()
+    expect(logger.error).toHaveBeenCalled()
   })
 })
 

--- a/test/steam-api.test.ts
+++ b/test/steam-api.test.ts
@@ -6,19 +6,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 // names, localized apinames, silent 400s, etc.) gets caught at CI time
 // instead of on a dashboard load.
 
+// steam-api.ts routes all diagnostics through the pino logger, so we mock
+// the logger module (rather than spying on console) to assert on its calls.
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock("@/lib/server/logger", () => ({ logger: loggerMock }))
+
 const ORIGINAL_FETCH = globalThis.fetch
-const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 
 beforeEach(() => {
   process.env.STEAM_API_KEY = "fake-key"
-  consoleErrorSpy.mockClear()
-  consoleWarnSpy.mockClear()
+  loggerMock.info.mockClear()
+  loggerMock.warn.mockClear()
+  loggerMock.error.mockClear()
 })
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH
   delete process.env.STEAM_API_KEY
+  delete process.env.STEAM_API_LOCALE
+  vi.useRealTimers()
   vi.resetModules()
 })
 
@@ -26,6 +34,8 @@ type JsonResponse = {
   ok?: boolean
   status?: number
   body?: unknown
+  /** Value returned by response.headers.get("retry-after"). */
+  retryAfter?: string | null
 }
 
 /** Queues fetch responses in order; the wrapper always calls fetch once per request. */
@@ -37,6 +47,7 @@ function mockFetchSequence(responses: JsonResponse[]) {
     return {
       ok: next.ok ?? true,
       status: next.status ?? 200,
+      headers: { get: (name: string) => (name.toLowerCase() === "retry-after" ? (next.retryAfter ?? null) : null) },
       json: async () => next.body,
     } as unknown as Response
   }) as unknown as typeof fetch
@@ -67,6 +78,15 @@ describe("getSteamHeaderImageUrl", () => {
     const { getSteamHeaderImageUrl } = await import("@/lib/steam-api")
     expect(getSteamHeaderImageUrl(620)).toBe(
       "https://shared.steamstatic.com/store_item_assets/steam/apps/620/header.jpg",
+    )
+  })
+})
+
+describe("getSteamPortraitImageUrl", () => {
+  it("builds the library portrait url from appid", async () => {
+    const { getSteamPortraitImageUrl } = await import("@/lib/steam-api")
+    expect(getSteamPortraitImageUrl(620)).toBe(
+      "https://shared.akamai.steamstatic.com/store_item_assets/steam/apps/620/library_600x900.jpg",
     )
   })
 })
@@ -111,7 +131,7 @@ describe("getOwnedGames", () => {
     mockFetchRejecting(new Error("ECONNREFUSED"))
     const { getOwnedGames } = await import("@/lib/steam-api")
     expect(await getOwnedGames("76561198023709299")).toEqual([])
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    expect(loggerMock.error).toHaveBeenCalled()
   })
 
   it("returns an empty array when the response body has no games field", async () => {
@@ -125,7 +145,7 @@ describe("getOwnedGames", () => {
     mockFetchSequence([{ body: {} }]) // unused
     const { getOwnedGames } = await import("@/lib/steam-api")
     expect(await getOwnedGames("76561198023709299")).toEqual([])
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    expect(loggerMock.error).toHaveBeenCalled()
   })
 })
 
@@ -154,7 +174,7 @@ describe("getRecentlyPlayedGames", () => {
     mockFetchRejecting(new Error("EHOSTUNREACH"))
     const { getRecentlyPlayedGames } = await import("@/lib/steam-api")
     expect(await getRecentlyPlayedGames("76561198023709299")).toEqual([])
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    expect(loggerMock.error).toHaveBeenCalled()
   })
 })
 
@@ -193,29 +213,29 @@ describe("getPlayerAchievements", () => {
     mockFetchSequence([{ ok: false, status: 400, body: { playerstats: { error: "Requested app has no stats" } } }])
     const { getPlayerAchievements } = await import("@/lib/steam-api")
     expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
   it("returns null *silently* on 403 (no stats / private)", async () => {
     mockFetchSequence([{ ok: false, status: 403, body: {} }])
     const { getPlayerAchievements } = await import("@/lib/steam-api")
     expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
   it("returns null *silently* on 500 (broken stats) — no console noise", async () => {
     mockFetchSequence([{ ok: false, status: 500, body: {} }])
     const { getPlayerAchievements } = await import("@/lib/steam-api")
     expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
   it("returns null on network error and warns (not errors)", async () => {
     mockFetchRejecting(new Error("socket hangup"))
     const { getPlayerAchievements } = await import("@/lib/steam-api")
     expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
-    expect(consoleWarnSpy).toHaveBeenCalled()
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(loggerMock.warn).toHaveBeenCalled()
+    expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
   it("defaults achievements to [] when the response omits the array", async () => {
@@ -256,27 +276,122 @@ describe("getGameSchema", () => {
     mockFetchSequence([{ ok: false, status: 400, body: {} }])
     const { getGameSchema } = await import("@/lib/steam-api")
     expect(await getGameSchema(620)).toBeNull()
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
   it("returns null silently on 403", async () => {
     mockFetchSequence([{ ok: false, status: 403, body: {} }])
     const { getGameSchema } = await import("@/lib/steam-api")
     expect(await getGameSchema(620)).toBeNull()
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
   it("logs on 500 and returns null", async () => {
     mockFetchSequence([{ ok: false, status: 500, body: {} }])
     const { getGameSchema } = await import("@/lib/steam-api")
     expect(await getGameSchema(620)).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    expect(loggerMock.error).toHaveBeenCalled()
   })
 
   it("logs on network error and returns null", async () => {
     mockFetchRejecting(new Error("DNS failure"))
     const { getGameSchema } = await import("@/lib/steam-api")
     expect(await getGameSchema(620)).toBeNull()
-    expect(consoleErrorSpy).toHaveBeenCalled()
+    expect(loggerMock.error).toHaveBeenCalled()
+  })
+})
+
+describe("locale configuration (STEAM_API_LOCALE)", () => {
+  it("defaults to l=es when STEAM_API_LOCALE is unset", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ response: { games: [] } }),
+    })) as unknown as typeof fetch
+    globalThis.fetch = fetchMock
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    await getOwnedGames("76561198023709299")
+    const url = (fetchMock as unknown as { mock: { calls: [[string, unknown]] } }).mock.calls[0][0]
+    expect(url).toContain("l=es")
+  })
+
+  it("uses the STEAM_API_LOCALE override when set", async () => {
+    process.env.STEAM_API_LOCALE = "en"
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ response: { games: [] } }),
+    })) as unknown as typeof fetch
+    globalThis.fetch = fetchMock
+    const { getRecentlyPlayedGames } = await import("@/lib/steam-api")
+    await getRecentlyPlayedGames("76561198023709299")
+    const url = (fetchMock as unknown as { mock: { calls: [[string, unknown]] } }).mock.calls[0][0]
+    expect(url).toContain("l=en")
+    expect(url).not.toContain("l=es")
+  })
+})
+
+describe("429 rate-limit backoff", () => {
+  it("retries after a 429 and succeeds on the follow-up request", async () => {
+    mockFetchSequence([
+      { ok: false, status: 429, retryAfter: "0" },
+      { body: { response: { games: [{ appid: 620, name: "Portal 2", playtime_forever: 1 }] } } },
+    ])
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    vi.useFakeTimers()
+    const promise = getOwnedGames("76561198023709299")
+    await vi.runAllTimersAsync()
+    const games = await promise
+    expect(games).toHaveLength(1)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    expect(loggerMock.warn).toHaveBeenCalled()
+    expect(loggerMock.error).not.toHaveBeenCalled()
+  })
+
+  it("honours the Retry-After header when computing the backoff delay", async () => {
+    mockFetchSequence([{ ok: false, status: 429, retryAfter: "2" }, { body: { response: { games: [] } } }])
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    vi.useFakeTimers()
+    const promise = getOwnedGames("76561198023709299")
+    await vi.runAllTimersAsync()
+    await promise
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ delayMs: 2000, retryAfter: "2" }),
+      expect.any(String),
+    )
+  })
+
+  it("gives up after exhausting retries and returns the empty fallback", async () => {
+    mockFetchSequence([
+      { ok: false, status: 429, retryAfter: "0" },
+      { ok: false, status: 429, retryAfter: "0" },
+      { ok: false, status: 429, retryAfter: "0" },
+      { ok: false, status: 429, retryAfter: "0" },
+    ])
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    vi.useFakeTimers()
+    const promise = getOwnedGames("76561198023709299")
+    await vi.runAllTimersAsync()
+    const games = await promise
+    expect(games).toEqual([])
+    // 1 initial + 3 retries
+    expect(globalThis.fetch).toHaveBeenCalledTimes(4)
+    expect(loggerMock.error).toHaveBeenCalled()
+  })
+
+  it("falls back to exponential backoff when no Retry-After header is present", async () => {
+    mockFetchSequence([{ ok: false, status: 429, retryAfter: null }, { body: { response: { games: [] } } }])
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    vi.useFakeTimers()
+    const promise = getOwnedGames("76561198023709299")
+    await vi.runAllTimersAsync()
+    await promise
+    // attempt 0 → BASE_BACKOFF_MS * 2**0 = 1000ms
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ delayMs: 1000, retryAfter: null }),
+      expect.any(String),
+    )
   })
 })

--- a/test/steam-api.test.ts
+++ b/test/steam-api.test.ts
@@ -17,6 +17,9 @@ const ORIGINAL_FETCH = globalThis.fetch
 
 beforeEach(() => {
   process.env.STEAM_API_KEY = "fake-key"
+  // Clear here too (not just in afterEach) so a focused run or an inherited
+  // shell value can't leak into the default-locale test.
+  delete process.env.STEAM_API_LOCALE
   loggerMock.info.mockClear()
   loggerMock.warn.mockClear()
   loggerMock.error.mockClear()
@@ -361,6 +364,36 @@ describe("429 rate-limit backoff", () => {
       expect.objectContaining({ delayMs: 2000, retryAfter: "2" }),
       expect.any(String),
     )
+  })
+
+  it("honours a Retry-After larger than the exponential cap WITHOUT capping it to MAX_BACKOFF", async () => {
+    // 45s Retry-After is > the 30s exponential cap but <= the 60s wait ceiling:
+    // it must be waited out in full, not truncated to 30s (which would retry
+    // while Steam is still throttling).
+    mockFetchSequence([{ ok: false, status: 429, retryAfter: "45" }, { body: { response: { games: [] } } }])
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    vi.useFakeTimers()
+    const promise = getOwnedGames("76561198023709299")
+    await vi.runAllTimersAsync()
+    await promise
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ delayMs: 45000, retryAfter: "45" }),
+      expect.any(String),
+    )
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("gives up immediately (no early retry) when Retry-After exceeds the wait ceiling", async () => {
+    // 120s > the 60s ceiling: retrying before that window closes would just
+    // hit the same throttle, so we fail fast instead of retrying too soon.
+    mockFetchSequence([{ ok: false, status: 429, retryAfter: "120" }])
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    const games = await getOwnedGames("76561198023709299")
+    expect(games).toEqual([])
+    // Only the initial request — no retry was attempted.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(loggerMock.warn).not.toHaveBeenCalled()
+    expect(loggerMock.error).toHaveBeenCalled()
   })
 
   it("gives up after exhausting retries and returns the empty fallback", async () => {


### PR DESCRIPTION
## Resumen

Endurece el cliente de la Steam Web API (`lib/steam-api.ts`) a partir de tres hallazgos de la auditoría.

### 1. Manejo explícito del 429 con backoff
Hasta ahora un rate-limit de Valve (HTTP 429) se tragaba como error genérico, así que `getOwnedGames` devolvía `[]` — justo durante el sync pesado de la librería, que dispara cientos de llamadas por-app y es donde más se dispara el throttle.

Ahora `steamAPIRequest` detecta el 429 de forma explícita y reintenta con backoff exponencial acotado (base 1s, tope 30s, hasta 3 reintentos), respetando el header `Retry-After` cuando Valve lo envía (soporta tanto segundos como HTTP-date). Como el retry vive en `steamAPIRequest`, todo el pipeline se beneficia (`runHeavyOwnedGamesSync`, achievements, schema, etc.).

### 2. `console.*` → pino
`lib/steam-api.ts` era el único fichero de la lib que usaba `console.error/warn`. Ahora enruta todo por el logger pino compartido (`lib/server/logger`), en línea con el resto de `lib/server`.

Para no arrastrar el logger `server-only` al bundle del cliente (los componentes cliente importaban `getSteamHeaderImageUrl` de este fichero), los constructores de URL puros (`getSteamImageUrl`, `getSteamHeaderImageUrl`, `getSteamPortraitImageUrl`) se movieron a un módulo client-safe `lib/steam-image-urls.ts`, y `steam-api.ts` pasa a ser `server-only`. Los imports de valor en los 3 componentes cliente se actualizaron al nuevo módulo; los imports de tipo (`SteamGame`, etc.) se borran en compilación, así que no arrastran nada.

### 3. CHANGELOG.md
Se añade un CHANGELOG siguiendo Keep a Changelog. Los cambios de este PR y el trabajo reciente aún sin taggear (endurecimiento del callback OpenID, cookie de sesión firmada con HMAC, Next 16.3, TypeScript 7, oxlint, pnpm 11, undici 7.28.0, retirada de `nixpacks.toml`) quedan bajo `[Unreleased]`; las versiones ya taggeadas (0.10.15/0.10.14/0.10.13) reflejan únicamente lo que realmente entró en cada tag.

### Opcional: locale configurable
El `l: "es"` hardcodeado ahora es configurable vía `STEAM_API_LOCALE` (por defecto `es`).

## Tests
Se migran los asserts de `console` al logger mockeado (via `vi.mock`) y se añaden tests para: backoff 429 (reintento con éxito, `Retry-After` respetado, backoff exponencial por defecto, reintentos agotados), locale por defecto y override, y la URL de portrait.

## Verificación
- `pnpm lint` (oxlint + typecheck): OK
- `pnpm test`: 491/491 en verde
- `pnpm test:coverage`: por encima de los umbrales
- `pnpm build`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)