### PR TITLE
fix(hooks): refrescar hidden games tras un sync

### DIFF
--- a/hooks/use-steam-data.ts
+++ b/hooks/use-steam-data.ts
@@ -353,6 +353,14 @@ export function useSteamHiddenGames() {
     void load()
   }, [load])
 
+  useEffect(() => {
+    function handleInvalidate() {
+      void load()
+    }
+    window.addEventListener(STEAM_DATA_INVALIDATED_EVENT, handleInvalidate)
+    return () => window.removeEventListener(STEAM_DATA_INVALIDATED_EVENT, handleInvalidate)
+  }, [load])
+
   return { games, loading, error, refetch: load }
 }
 

--- a/test/use-steam-data.test.tsx
+++ b/test/use-steam-data.test.tsx
@@ -246,6 +246,54 @@ describe("useSteamExtras", () => {
   })
 })
 
+describe("useSteamHiddenGames", () => {
+  it("loads hidden games on mount", async () => {
+    mockFetchSequence(async () =>
+      ok({
+        games: [
+          {
+            appid: 222,
+            name: "Hidden Game",
+            playtime_forever: 50,
+            hidden_at: "2026-04-11T10:00:00.000Z",
+            source: "library",
+          },
+        ],
+      }),
+    )
+    const { useSteamHiddenGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamHiddenGames())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.games).toHaveLength(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("sets error on non-ok response", async () => {
+    mockFetchSequence(async () => err(500))
+    const { useSteamHiddenGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamHiddenGames())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe("Failed to fetch hidden games")
+    expect(result.current.games).toEqual([])
+  })
+
+  it("re-fetches on invalidateSteamData event", async () => {
+    let calls = 0
+    mockFetchSequence(async () => {
+      calls++
+      return ok({ games: [] })
+    })
+    const { useSteamHiddenGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamHiddenGames())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const initial = calls
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steam-data-invalidated"))
+    })
+    await waitFor(() => expect(calls).toBeGreaterThan(initial))
+  })
+})
+
 describe("useSteamAchievements", () => {
   it("returns empty + loading=false when appId is null", async () => {
     const fetchSpy = vi.fn()


### PR DESCRIPTION
## Problema

En `hooks/use-steam-data.ts`, el hook `useSteamHiddenGames` no se suscribía al evento `CustomEvent` de `window` `steam-data-invalidated` al que sí se suscriben el resto de hooks del fichero (`useSteamExtras`, `useSteamGames`, `useSteamStats`, `useSteamAchievements`, `useSteamAchievementsBatch`). Como consecuencia, la lista de hidden games no se refrescaba tras un sync mientras que los demás datos sí.

## Solución

Se aplica el mismo patrón exacto que usan los hooks hermanos: un `useEffect` con dependencia `[load]` que registra `window.addEventListener(STEAM_DATA_INVALIDATED_EVENT, handleInvalidate)` y lo limpia con `removeEventListener` en el cleanup. Es idéntico al de `useSteamExtras`; no se cambia nada más ni se "mejora" el patrón (la unificación de todos los hooks queda como follow-up aparte).

## Tests

Se añade un bloque `describe("useSteamHiddenGames")` en `test/use-steam-data.test.tsx` con tres casos (carga en mount, error en respuesta no-ok y refetch al despachar `steam-data-invalidated`), replicando la cobertura existente de `useSteamExtras`.

## Verificación

- `pnpm lint` verde
- `pnpm test` verde (53 ficheros, 496 tests)
- `pnpm build` verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)