### PR TITLE
docs: sync migration mechanism, API reference, and schema tables with code

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -29,5 +29,9 @@ STEAM_WHITELIST_IDS=76561198000000000,76561198000000001
 # when /data is writable (containers), otherwise .data/steam-backlog-hunter.sqlite.
 # SQLITE_PATH=./.data/steam-backlog-hunter.sqlite
 
+# Locale sent to Steam as the `l=` query param (optional, default: es).
+# Localizes game names, achievement text, etc. Examples: en, fr, de.
+# STEAM_API_LOCALE=en
+
 # Pino log level (optional, default: info).
 # LOG_LEVEL=debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,14 @@ Next.js 16 App Router with React 19, TypeScript strict mode, Tailwind CSS 4, sha
 - `lib/server/steam-stats-compute.ts` — stats aggregation and sync orchestration; computes from `user_games WHERE total_count > 0`
 - `lib/server/steam-store-utils.ts` — shared utilities (staleness checks, timestamps, profile management)
 - `lib/server/steam-store.ts` — barrel re-export of the above modules
-- `lib/server/sqlite.ts` — database schema and versioned migrations (Node.js built-in `DatabaseSync`); tables: `steam_profile`, `games`, `user_games`, `recent_games_snapshot`, `stats_snapshot`, `schema_migrations`
+- `lib/server/sqlite.ts` — database schema and migrations (Node.js built-in `DatabaseSync`); tables: `steam_profile`, `games`, `user_games`, `recent_games_snapshot`, `stats_snapshot`, `hidden_games`, `allowed_users`, `game_achievements`, `user_achievements`, `pinned_games`, `extra_games`, `extra_game_achievements`, `app_catalog_meta`
 - `lib/steam-api.ts` — direct Steam Web API calls (shared between server and client for types/utilities)
 
 ### API routes (`app/api/`)
 
 - `auth/steam/` — Steam OpenID 2.0 login flow with CSRF nonce, whitelist enforcement, rate limiting; fetches level and badges at login
-- `steam/games`, `steam/achievements`, `steam/stats`, `steam/sync`, `steam/game/[id]` — data endpoints; all require authenticated session via `steam_user` httpOnly cookie
+- `steam/games`, `steam/games/hide`, `steam/achievements`, `steam/stats`, `steam/sync`, `steam/game/[id]`, `steam/game/[id]/sync`, `steam/extras`, `steam/extras/[id]` — data endpoints; all require authenticated session via `steam_user` httpOnly cookie
+- `admin/users`, `admin/pinned-games`, `admin/orphan-names` — admin-only endpoints gated by `requireAdmin()`
 - `health/` — infrastructure health check (no auth)
 
 ### Client state (`hooks/`)
@@ -69,9 +70,9 @@ Whitelist-based, multi-user ready. `STEAM_WHITELIST_IDS` (comma-separated Steam6
 - Environment variables validated with Zod lazily on first access (`lib/env.ts`)
 - Structured logging via Pino (`lib/server/logger.ts`)
 - `nextjs/no-img-element` oxlint rule is disabled (`.oxlintrc.json`)
-- `lib/steam-api.ts` must NOT import `server-only` modules (used by client components for types)
+- `lib/steam-api.ts` is `server-only` (logs via Pino, hashes Steam IDs before logging); client components only import _types_ from it (e.g. `SteamGame`), which TypeScript erases at compile time, so the server boundary holds. Runtime helpers a client needs (e.g. CDN image URL builders) live in the client-safe `lib/steam-image-urls.ts` instead
 - Tests live in `test/` directory (Vitest + @testing-library/react + jsdom)
 - All API routes and public functions have JSDoc documentation
-- Database migrations are versioned in `sqlite.ts` — add new migrations to the `migrations` array, never modify existing ones
+- Schema evolution in `sqlite.ts` has three layers: `createBaseSchema` (`CREATE TABLE IF NOT EXISTS`, latest shape for fresh installs), `addColumnIfMissing`/`applyAdditiveMigrations` (additive column changes for existing databases), and the versioned `MIGRATIONS` array tracked via `PRAGMA user_version` (one-off data backfills, run once each). Add new columns to both the `CREATE TABLE` and `applyAdditiveMigrations`; append new data migrations to `MIGRATIONS` — never modify or reorder existing entries
 - All changes go through issue → branch → PR → merge (never commit directly to main)
 - The "tracked games" concept has been removed — stats are computed from games with achievements (total_count > 0)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This is a personal project, but contributions are welcome. This guide captures t
 
 ## Setup
 
-Requires **Node 24.13+** and **pnpm 10.25+**.
+Requires **Node 24.13+** and **pnpm 11.7** (see `packageManager` in `package.json` — Corepack picks it up automatically).
 
 ```bash
 pnpm install
@@ -26,7 +26,7 @@ All changes go through **issue → branch → PR → merge**. Direct commits to 
 ## Code style
 
 - **TypeScript strict mode.** No `any` without a comment explaining why.
-- **Prettier + ESLint** run via Husky + lint-staged on every commit — don't fight the formatter.
+- **oxlint + oxfmt** run via Husky + lint-staged on every commit — don't fight the formatter.
 - **Path alias:** `@/*` maps to the project root.
 - **Default to no comments.** Only write one when the _why_ is non-obvious — hidden constraints, subtle invariants, workarounds for specific bugs.
 - **Don't explain what the code does** — well-named identifiers already do that.
@@ -42,7 +42,15 @@ All changes go through **issue → branch → PR → merge**. Direct commits to 
 
 ## Database changes
 
-Since this project is pre-production, schema changes are applied by editing `createBaseSchema` in `lib/server/sqlite.ts` directly rather than adding migrations. If your change reshapes existing tables, **delete your local `.data/steam-backlog-hunter.sqlite` file** before running the branch — the app will recreate the schema on next startup and resync owned games + achievements from Steam on first login.
+Schema evolution in `lib/server/sqlite.ts` has three layers, all applied on every `getSqliteDatabase()` call:
+
+1. **`createBaseSchema`** — `CREATE TABLE IF NOT EXISTS` statements defining the latest shape for fresh installs.
+2. **`addColumnIfMissing`** (via `applyAdditiveMigrations`) — additive-only column changes for existing databases (checks `PRAGMA table_info`, then `ALTER TABLE ... ADD COLUMN` if missing).
+3. **The `MIGRATIONS` array** (run by `runVersionedMigrations`) — one-off data backfills/fixups, tracked via SQLite's built-in `PRAGMA user_version`. Each entry runs once, in a transaction, the first time a database is opened at a lower version.
+
+To add a new column: add it to the relevant `CREATE TABLE` in `createBaseSchema` **and** add an `addColumnIfMissing` call in `applyAdditiveMigrations`, so both fresh and existing databases pick it up. To add a one-off data migration (backfill, cleanup, etc.): append an entry to the `MIGRATIONS` array with the next `version` number — never modify or reorder existing entries, since it's an append-only history.
+
+If your change reshapes existing tables in a way the additive layers can't express, you can still **delete your local `.data/steam-backlog-hunter.sqlite` file** before running the branch — the app will recreate the schema on next startup and resync owned games + achievements from Steam on first login.
 
 ## Commit messages
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The app will be available at `http://localhost:3000`.
 | `SQLITE_PATH`         | No         | Custom SQLite database path (see [Database](#database))                   |
 | `STEAM_WHITELIST_IDS` | No         | Comma-separated Steam64 IDs for initial seed (managed via `/admin` after) |
 | `SESSION_SECRET`      | No         | HMAC key for signing the session cookie (falls back to `STEAM_API_KEY`)   |
+| `STEAM_API_LOCALE`    | No         | Locale sent to Steam as `l=` (default: `es`; e.g. `en`, `fr`, `de`)       |
 | `LOG_LEVEL`           | No         | Pino log level (default: `info`)                                          |
 
 ## Scripts
@@ -165,15 +166,37 @@ All data endpoints require authentication via `steam_user` httpOnly cookie. JSDo
 
 ### Steam Data
 
-| Method | Path                                         | Description                                           |
-| ------ | -------------------------------------------- | ----------------------------------------------------- |
-| `GET`  | `/api/steam/games?type=recent\|all`          | List owned or recently played games                   |
-| `GET`  | `/api/steam/achievements?appId=N`            | Get achievements for a game                           |
-| `GET`  | `/api/steam/achievements/batch?appIds=1,2,3` | Batch get achievements (max 200)                      |
-| `GET`  | `/api/steam/game/:id`                        | Get single game details                               |
-| `GET`  | `/api/steam/stats`                           | Get aggregated user stats                             |
-| `GET`  | `/api/steam/sync`                            | Get last sync timestamps                              |
-| `POST` | `/api/steam/sync`                            | Trigger full data sync (rate limited: 5/min per user) |
+| Method   | Path                                         | Description                                                         |
+| -------- | -------------------------------------------- | ------------------------------------------------------------------- |
+| `GET`    | `/api/steam/games?type=recent\|all`          | List owned or recently played games                                 |
+| `POST`   | `/api/steam/games/hide`                      | Hide a game from the library                                        |
+| `DELETE` | `/api/steam/games/hide`                      | Unhide a previously hidden game                                     |
+| `GET`    | `/api/steam/achievements?appId=N`            | Get achievements for a game                                         |
+| `GET`    | `/api/steam/achievements/batch?appIds=1,2,3` | Batch get achievements (max 200)                                    |
+| `GET`    | `/api/steam/game/:id`                        | Get single game details                                             |
+| `POST`   | `/api/steam/game/:id/sync`                   | Force-refresh a single game's achievement data from the Steam API   |
+| `GET`    | `/api/steam/extras`                          | List "extras" — played-but-not-owned games (`?hidden=1` for hidden) |
+| `GET`    | `/api/steam/extras/:id`                      | Get one extra game's detail + enriched achievements                 |
+| `GET`    | `/api/steam/stats`                           | Get aggregated user stats                                           |
+| `GET`    | `/api/steam/sync`                            | Get last sync timestamps                                            |
+| `POST`   | `/api/steam/sync`                            | Trigger full data sync (rate limited: 5/min per user)               |
+
+### Admin
+
+Admin-only routes, gated by `requireAdmin()` (the signed-in user's Steam ID must equal `ADMIN_STEAM_ID`).
+
+| Method   | Path                             | Description                                                             |
+| -------- | -------------------------------- | ----------------------------------------------------------------------- |
+| `GET`    | `/api/admin/users`               | List allowed users with profile info                                    |
+| `POST`   | `/api/admin/users`               | Add an allowed user                                                     |
+| `DELETE` | `/api/admin/users`               | Remove an allowed user                                                  |
+| `PATCH`  | `/api/admin/users`               | Refresh a user's Steam profile data                                     |
+| `GET`    | `/api/admin/pinned-games`        | List globally pinned appids                                             |
+| `POST`   | `/api/admin/pinned-games`        | Add an appid to the global pinned list                                  |
+| `DELETE` | `/api/admin/pinned-games`        | Remove an appid from the global pinned list                             |
+| `GET`    | `/api/admin/orphan-names`        | List appids with a NULL/empty `games.name` referenced by a user         |
+| `PUT`    | `/api/admin/orphan-names/:appid` | Set a manual name for an appid (freezes it as `name_source = 'manual'`) |
+| `DELETE` | `/api/admin/orphan-names/:appid` | Clear a manual name so auto-sync can resolve it again                   |
 
 ### Infrastructure
 
@@ -198,9 +221,13 @@ SQLite is the primary store. The schema auto-initializes on first run.
 
 ### Migrations
 
-Schema changes are managed through a **versioned migration system** (`lib/server/sqlite.ts`). A `schema_migrations` table tracks which migrations have run. Each migration executes exactly once, in order, inside a transaction.
+Schema evolution in `lib/server/sqlite.ts` happens in three layers, applied in order on every `getSqliteDatabase()` call:
 
-To add a new migration, append a function to the `migrations` array in `sqlite.ts`. Never modify existing migrations.
+1. **`createBaseSchema`** — `CREATE TABLE IF NOT EXISTS` statements that define the latest shape for fresh installs. Safe to re-run; a no-op once the tables exist.
+2. **`addColumnIfMissing`** (via `applyAdditiveMigrations`) — additive-only column changes for existing databases. Checks `PRAGMA table_info(<table>)` and runs `ALTER TABLE ... ADD COLUMN` only if the column isn't already there.
+3. **Versioned data migrations** (the `MIGRATIONS` array, run by `runVersionedMigrations`) — one-off data backfills/fixups tracked via SQLite's built-in `PRAGMA user_version` (no separate table). Each entry has a `version`, a `name`, and a `run(db)` function; on open, every migration whose `version` is greater than the stored `user_version` runs once inside a transaction, then bumps `user_version` to that migration's version.
+
+To add a new column: add it to the relevant `CREATE TABLE` in `createBaseSchema` **and** add an `addColumnIfMissing` call in `applyAdditiveMigrations` so existing databases pick it up. To add a one-off data migration: append an entry to the `MIGRATIONS` array with the next `version` number — never modify or reorder existing entries, since it's an append-only history.
 
 ### Path Resolution
 
@@ -210,7 +237,7 @@ To add a new migration, append a function to the `migrations` array in `sqlite.t
 
 ### Tables
 
-`steam_profile` · `games` · `user_games` · `recent_games_snapshot` · `stats_snapshot` · `schema_migrations`
+`steam_profile` · `games` · `user_games` · `recent_games_snapshot` · `stats_snapshot` · `hidden_games` · `allowed_users` · `game_achievements` · `user_achievements` · `pinned_games` · `extra_games` · `extra_game_achievements` · `app_catalog_meta`
 
 All user-specific tables are keyed by `steam_id` for multi-user isolation.
 


### PR DESCRIPTION
## Summary

Documentation-only PR that reconciles README.md, CLAUDE.md, CONTRIBUTING.md, and `.env.local.example` with the actual code, since several sections had drifted:

- **Migrations**: README.md and CLAUDE.md described a `schema_migrations` table and a `migrations` array that don't exist, while CONTRIBUTING.md separately claimed schema changes are made by editing `createBaseSchema` directly. The real mechanism in `lib/server/sqlite.ts` is three layers — `createBaseSchema` (`CREATE TABLE IF NOT EXISTS`), `addColumnIfMissing`/`applyAdditiveMigrations` (additive column changes), and a versioned `MIGRATIONS` array tracked via SQLite's built-in `PRAGMA user_version` (no table). All three docs now describe this consistently.
- **API Reference**: the README table was missing `/api/steam/extras`, `/api/steam/extras/[id]`, `/api/steam/games/hide` (POST/DELETE), `/api/steam/game/[id]/sync`, and the whole `/api/admin/*` surface (`users`, `pinned-games`, `orphan-names`). Added a new "Admin" section and filled in the Steam Data table, verified against `find app/api -name route.ts`.
- **Tables**: README.md and CLAUDE.md listed 6 tables; the real schema in `lib/server/sqlite.ts` has 13 (`steam_profile`, `games`, `user_games`, `recent_games_snapshot`, `stats_snapshot`, `hidden_games`, `allowed_users`, `game_achievements`, `user_achievements`, `pinned_games`, `extra_games`, `extra_game_achievements`, `app_catalog_meta`).
- **Toolchain/versions**: CONTRIBUTING.md still said "Prettier + ESLint" and "pnpm 10.25+"; fixed to oxlint/oxfmt and pnpm 11.7 to match `package.json` (README and CLAUDE.md were already correct).
- **`lib/steam-api.ts` convention**: CLAUDE.md said it "must NOT import server-only modules," but it already imports `server-only` and Pino. Rewrote the bullet to describe the real convention — clients only import types from it, runtime helpers (e.g. CDN URL builders) live in `lib/steam-image-urls.ts`.
- **`STEAM_API_LOCALE`**: documented in CHANGELOG.md but missing from the README env var table and `.env.local.example`; added to both.

## Test plan

- [x] `pnpm exec oxfmt --check` on all four changed files
- [x] Pre-commit hook (husky + lint-staged) ran oxfmt on the staged docs/config files cleanly
- [x] Every claim cross-checked against current code: `lib/server/sqlite.ts` (schema/migrations), `find app/api -name route.ts` (routes), `package.json` (pnpm/oxlint/oxfmt versions), `lib/steam-api.ts` (server-only import + STEAM_API_LOCALE)
- No code changes; nothing else to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)