### PR TITLE
fix(session): sign session expiry and require SESSION_SECRET in production

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -20,8 +20,10 @@ STEAM_WHITELIST_IDS=76561198000000000,76561198000000001
 # back to the right origin. Defaults to the request origin in development.
 # NEXTAUTH_URL=https://steam.example.com
 
-# HMAC key used to sign the session cookie (optional). Falls back to
-# STEAM_API_KEY when unset. Generate one with:
+# HMAC key used to sign the session cookie. Required in production (the app
+# fails fast at startup without it) — falls back to STEAM_API_KEY in
+# development/test only, so sessions still sign out of the box locally.
+# Generate one with:
 #   openssl rand -base64 32
 # SESSION_SECRET=
 

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ The app will be available at `http://localhost:3000`.
 
 ## Environment Variables
 
-| Variable              | Required   | Description                                                               |
-| --------------------- | ---------- | ------------------------------------------------------------------------- |
-| `STEAM_API_KEY`       | Yes        | Steam Web API key ([get one here](https://steamcommunity.com/dev/apikey)) |
-| `ADMIN_STEAM_ID`      | Yes        | Steam64 ID with admin access (always allowed to sign in + `/admin`)       |
-| `NEXTAUTH_URL`        | Production | Your app's public URL (e.g. `https://steam.example.com`)                  |
-| `SQLITE_PATH`         | No         | Custom SQLite database path (see [Database](#database))                   |
-| `STEAM_WHITELIST_IDS` | No         | Comma-separated Steam64 IDs for initial seed (managed via `/admin` after) |
-| `SESSION_SECRET`      | No         | HMAC key for signing the session cookie (falls back to `STEAM_API_KEY`)   |
-| `LOG_LEVEL`           | No         | Pino log level (default: `info`)                                          |
+| Variable              | Required   | Description                                                                     |
+| --------------------- | ---------- | ------------------------------------------------------------------------------- |
+| `STEAM_API_KEY`       | Yes        | Steam Web API key ([get one here](https://steamcommunity.com/dev/apikey))       |
+| `ADMIN_STEAM_ID`      | Yes        | Steam64 ID with admin access (always allowed to sign in + `/admin`)             |
+| `NEXTAUTH_URL`        | Production | Your app's public URL (e.g. `https://steam.example.com`)                        |
+| `SQLITE_PATH`         | No         | Custom SQLite database path (see [Database](#database))                         |
+| `STEAM_WHITELIST_IDS` | No         | Comma-separated Steam64 IDs for initial seed (managed via `/admin` after)       |
+| `SESSION_SECRET`      | Production | HMAC key for signing the session cookie (dev/test fall back to `STEAM_API_KEY`) |
+| `LOG_LEVEL`           | No         | Pino log level (default: `info`)                                                |
 
 ## Scripts
 

--- a/app/api/auth/steam/callback/route.ts
+++ b/app/api/auth/steam/callback/route.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto"
 import { cookies } from "next/headers"
 import { isSteamIdWhitelisted } from "@/lib/whitelist"
 import { upsertProfile } from "@/lib/server/steam-store-utils"
-import { signSession } from "@/lib/server/session"
+import { signSession, SESSION_MAX_AGE_SECONDS } from "@/lib/server/session"
 import { logger } from "@/lib/server/logger"
 
 const STEAM_OPENID_URL = "https://steamcommunity.com/openid/login"
@@ -216,7 +216,7 @@ export async function GET(request: NextRequest) {
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         path: "/",
-        maxAge: 60 * 60 * 24 * 7, // 7 days
+        maxAge: SESSION_MAX_AGE_SECONDS, // 7 days — kept in sync with the signed exp in session.ts
       },
     )
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -3,17 +3,35 @@ import "server-only"
 import { z } from "zod"
 import { logger } from "@/lib/server/logger"
 
-const envSchema = z.object({
-  STEAM_API_KEY: z.string().min(1, "STEAM_API_KEY is required"),
-  STEAM_WHITELIST_IDS: z.string().optional(),
-  NEXTAUTH_URL: z.string().url().optional(),
-  SQLITE_PATH: z.string().optional(),
-  ADMIN_STEAM_ID: z.string().optional(),
-  // HMAC key used to sign the session cookie. Optional — falls back to
-  // STEAM_API_KEY (also a server secret) so sessions are signed out of the box.
-  SESSION_SECRET: z.string().optional(),
-  NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
-})
+const envSchema = z
+  .object({
+    STEAM_API_KEY: z.string().min(1, "STEAM_API_KEY is required"),
+    STEAM_WHITELIST_IDS: z.string().optional(),
+    NEXTAUTH_URL: z.string().url().optional(),
+    SQLITE_PATH: z.string().optional(),
+    ADMIN_STEAM_ID: z.string().optional(),
+    // HMAC key used to sign the session cookie. Required in production. In
+    // development/test only, it falls back to STEAM_API_KEY (also a server
+    // secret) so sessions are signed out of the box — see the superRefine
+    // below, which enforces the production requirement.
+    SESSION_SECRET: z.string().optional(),
+    NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+  })
+  .superRefine((data, ctx) => {
+    // In production, falling back to STEAM_API_KEY means rotating that key
+    // (e.g. after a leak) silently invalidates every signed-in session, and
+    // means the session-signing secret and the Steam API credential are the
+    // same value. Require a dedicated SESSION_SECRET in production; the
+    // fallback stays for local dev/test convenience only.
+    if (data.NODE_ENV === "production" && !data.SESSION_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["SESSION_SECRET"],
+        message:
+          "SESSION_SECRET is required in production (falling back to STEAM_API_KEY would mean rotating the Steam API key silently invalidates every session).",
+      })
+    }
+  })
 
 let cached: z.infer<typeof envSchema> | null = null
 
@@ -25,6 +43,12 @@ function validateEnv() {
   if (!result.success) {
     logger.error({ issues: result.error.issues }, "Environment variable validation failed")
     throw new Error("Invalid environment variables. See above for details.")
+  }
+
+  if (!result.data.SESSION_SECRET) {
+    logger.warn(
+      "SESSION_SECRET is not set; falling back to STEAM_API_KEY to sign sessions. This is only safe outside production.",
+    )
   }
 
   cached = result.data

--- a/lib/server/session.ts
+++ b/lib/server/session.ts
@@ -4,9 +4,18 @@ import crypto from "node:crypto"
 import { env } from "@/lib/env"
 import type { SteamUser } from "@/lib/auth"
 
+// How long a signed session token is valid for. Kept in sync with the
+// `steam_user` cookie's maxAge in app/api/auth/steam/callback/route.ts — the
+// cookie is just the browser-enforced expiry; this is the server-enforced one
+// baked into the signature itself, so a copied/stolen cookie can't outlive it.
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7 // 7 days
+
+type SignedPayload = SteamUser & { exp: number }
+
 // HMAC key for signing the session cookie. A dedicated SESSION_SECRET is
 // preferred; we fall back to STEAM_API_KEY (also a server-only secret) so
-// sessions are tamper-proof without requiring a new env var.
+// sessions are tamper-proof without requiring a new env var. In production,
+// lib/env.ts fails fast unless SESSION_SECRET is set (see there for why).
 function signingKey(): string {
   return env.SESSION_SECRET || env.STEAM_API_KEY
 }
@@ -18,16 +27,27 @@ function hmac(payload: string): string {
 /**
  * Encodes a user into a signed session token: `<base64url(json)>.<hmac>`.
  * The signature is what makes the cookie tamper-proof — a forged payload (even
- * with a whitelisted Steam ID) won't carry a valid HMAC.
+ * with a whitelisted Steam ID) won't carry a valid HMAC. The payload also
+ * carries a signed `exp` timestamp so a stolen token can't be replayed
+ * forever — verifySession() enforces it independently of the cookie's own
+ * (browser-enforced, hence spoofable) maxAge.
  */
 export function signSession(user: SteamUser): string {
-  const payload = Buffer.from(JSON.stringify(user)).toString("base64url")
+  const withExpiry: SignedPayload = { ...user, exp: Date.now() + SESSION_MAX_AGE_SECONDS * 1000 }
+  const payload = Buffer.from(JSON.stringify(withExpiry)).toString("base64url")
   return `${payload}.${hmac(payload)}`
 }
 
 /**
  * Verifies a session token and returns the user, or null if the token is
- * missing, malformed, or its signature doesn't match (tampered/forged).
+ * missing, malformed, expired, or its signature doesn't match (tampered/forged).
+ *
+ * Tokens signed before this expiry check existed carry no `exp` field at all
+ * and are rejected (treated the same as an expired token) rather than granted
+ * a grace period: they're indistinguishable from a forged payload that simply
+ * omits `exp`, and honoring them would let a token stolen before this fix
+ * shipped keep working indefinitely — exactly the bug this closes. The cost
+ * is a single forced re-login per affected user.
  */
 export function verifySession(token: string | undefined | null): SteamUser | null {
   if (!token) return null
@@ -46,7 +66,13 @@ export function verifySession(token: string | undefined | null): SteamUser | nul
   }
 
   try {
-    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as SteamUser
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Partial<SignedPayload> | null
+    if (!parsed || typeof parsed !== "object") return null
+
+    const { exp, ...user } = parsed
+    if (typeof exp !== "number" || Date.now() >= exp) return null
+
+    return user as SteamUser
   } catch {
     return null
   }

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -37,3 +37,59 @@ describe("env validation", () => {
     expect(mod.env.SQLITE_PATH).toBeUndefined()
   })
 })
+
+describe("env validation: SESSION_SECRET", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it("falls back to STEAM_API_KEY outside production when unset, logging a warning", async () => {
+    vi.stubEnv("STEAM_API_KEY", "test-api-key")
+    vi.stubEnv("SESSION_SECRET", undefined)
+    vi.stubEnv("NODE_ENV", "development")
+
+    const { logger } = await import("@/lib/server/logger")
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never)
+
+    const mod = await import("@/lib/env")
+    expect(mod.env.SESSION_SECRET).toBeUndefined()
+    expect(mod.env.STEAM_API_KEY).toBe("test-api-key")
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("SESSION_SECRET is not set"))
+
+    warnSpy.mockRestore()
+  })
+
+  it("does not warn when SESSION_SECRET is set outside production", async () => {
+    vi.stubEnv("STEAM_API_KEY", "test-api-key")
+    vi.stubEnv("SESSION_SECRET", "dev-secret")
+    vi.stubEnv("NODE_ENV", "development")
+
+    const { logger } = await import("@/lib/server/logger")
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined as never)
+
+    const mod = await import("@/lib/env")
+    expect(mod.env.SESSION_SECRET).toBe("dev-secret")
+    expect(warnSpy).not.toHaveBeenCalled()
+
+    warnSpy.mockRestore()
+  })
+
+  it("fails fast when SESSION_SECRET is unset in production", async () => {
+    vi.stubEnv("STEAM_API_KEY", "test-api-key")
+    vi.stubEnv("SESSION_SECRET", undefined)
+    vi.stubEnv("NODE_ENV", "production")
+
+    const mod = await import("@/lib/env")
+    expect(() => mod.env.SESSION_SECRET).toThrow("Invalid environment variables")
+  })
+
+  it("passes validation in production when SESSION_SECRET is set", async () => {
+    vi.stubEnv("STEAM_API_KEY", "test-api-key")
+    vi.stubEnv("SESSION_SECRET", "a-dedicated-prod-secret")
+    vi.stubEnv("NODE_ENV", "production")
+
+    const mod = await import("@/lib/env")
+    expect(mod.env.SESSION_SECRET).toBe("a-dedicated-prod-secret")
+  })
+})

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect, beforeAll } from "vitest"
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest"
 import crypto from "node:crypto"
-import { signSession, verifySession } from "@/lib/server/session"
+import { signSession, verifySession, SESSION_MAX_AGE_SECONDS } from "@/lib/server/session"
 import type { SteamUser } from "@/lib/auth"
+
+/** Signs an arbitrary payload the same way session.ts does, for tests that need to construct tokens signSession() itself won't produce (e.g. an expired or exp-less token). */
+function signRaw(payload: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url")
+  const sig = crypto.createHmac("sha256", "unit-test-session-secret").update(encoded).digest("base64url")
+  return `${encoded}.${sig}`
+}
 
 const USER: SteamUser = {
   steamId: "76561198023709299",
@@ -57,5 +64,52 @@ describe("session signing", () => {
     const payload = Buffer.from("not json{").toString("base64url")
     const sig = crypto.createHmac("sha256", "unit-test-session-secret").update(payload).digest("base64url")
     expect(verifySession(`${payload}.${sig}`)).toBeNull()
+  })
+})
+
+describe("session expiry", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("signs sessions with a future exp, and accepts them", () => {
+    const token = signSession(USER)
+    const [payload] = token.split(".")
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"))
+
+    expect(parsed.exp).toBeGreaterThan(Date.now())
+    expect(parsed.exp).toBeLessThanOrEqual(Date.now() + SESSION_MAX_AGE_SECONDS * 1000)
+    expect(verifySession(token)).toEqual(USER)
+  })
+
+  it("rejects an expired token even with a valid signature", () => {
+    const expired = signRaw({ ...USER, exp: Date.now() - 1000 })
+    expect(verifySession(expired)).toBeNull()
+  })
+
+  it("accepts a token right up until its exp, then rejects it once past", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    const token = signSession(USER)
+
+    vi.setSystemTime(SESSION_MAX_AGE_SECONDS * 1000 - 1)
+    expect(verifySession(token)).toEqual(USER)
+
+    vi.setSystemTime(SESSION_MAX_AGE_SECONDS * 1000)
+    expect(verifySession(token)).toBeNull()
+  })
+
+  it("rejects legacy tokens signed before the exp field existed (no grace period)", () => {
+    // Policy: a signed payload with no `exp` at all is treated the same as an
+    // expired token, not honored for a grace period — see the doc comment on
+    // verifySession(). This also covers a forged payload that omits `exp`.
+    const legacy = signRaw(USER)
+    expect(verifySession(legacy)).toBeNull()
+  })
+
+  it("rejects a token with a non-numeric exp", () => {
+    const malformed = signRaw({ ...USER, exp: "not-a-number" })
+    expect(verifySession(malformed)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- **Signed session expiry.** `verifySession()` only checked the HMAC signature — it never validated `exp`/`iat`, so the 7-day cookie `maxAge` was purely a browser-enforced expiry. A stolen `steam_user` cookie stayed valid forever (mitigated, but not bounded, by the whitelist revalidation on each request). `signSession()` now bakes an `exp` timestamp (7 days out, matching the cookie's `maxAge` — both now read from one shared `SESSION_MAX_AGE_SECONDS` constant in `lib/server/session.ts`) into the signed payload, and `verifySession()` rejects it once expired.
- **Legacy (pre-fix) tokens are rejected, not grace-perioded.** A token signed before this change has no `exp` field at all, which is indistinguishable from a forged payload that simply omits `exp`. Honoring it for a grace period would mean any token stolen before this fix shipped keeps working indefinitely — exactly the bug being closed. The cost is one forced re-login for currently signed-in users, which is cheap and acceptable for a self-hosted single/few-user app like this one.
- **`SESSION_SECRET` fail-fast in production.** The sibling finding: `SESSION_SECRET` silently fell back to `STEAM_API_KEY` with no guardrail. In production that means (a) the session-signing secret and the Steam API credential are the same value, and (b) rotating `STEAM_API_KEY` (e.g. after a leak) silently invalidates every signed-in session. `lib/env.ts` now fails fast (`superRefine`) when `NODE_ENV=production` and `SESSION_SECRET` is unset; dev/test keep the fallback, now with a `logger.warn` so it's not silent there either. (Same pattern already shipped in `csgo-inventory-tracker`.)
- Updated `README.md` and `.env.local.example` to describe `SESSION_SECRET` as required in production rather than fully optional.

## Test plan

- [x] `pnpm lint` (oxlint + typecheck)
- [x] `pnpm format:check` (oxfmt)
- [x] `pnpm test` — 505 tests pass, including new coverage in `test/session.test.ts` (future exp accepted, expired rejected, exp-less/legacy token rejected, non-numeric exp rejected, boundary right up to/at exp) and `test/env.test.ts` (fails fast in production without `SESSION_SECRET`, passes when set, warns-but-allows outside production)
- [x] `pnpm build` — succeeds with no env vars set (matches how `ci.yml`'s build step runs today, since env validation is lazy/per-request, not at build time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)