### PR TITLE
fix: don't persist transient Steam failures as broken achievements

### DIFF
--- a/lib/server/steam-achievements-sync.ts
+++ b/lib/server/steam-achievements-sync.ts
@@ -4,6 +4,8 @@ import {
   getGameSchema,
   getGlobalAchievementPercentages,
   getPlayerAchievements,
+  TransientSteamAPIError,
+  type GameAchievements,
   type GameSchema,
   type GlobalAchievementPercent,
   type SteamAchievement,
@@ -352,7 +354,28 @@ export async function getAchievementsForGame(steamId: string, appId: number, opt
     }
   }
 
-  const [playerAchievements] = await Promise.all([getPlayerAchievements(steamId, appId), ensureSchema(appId, options)])
+  let playerAchievements: GameAchievements | null
+  try {
+    const [result] = await Promise.all([getPlayerAchievements(steamId, appId), ensureSchema(appId, options)])
+    playerAchievements = result
+  } catch (error) {
+    if (!(error instanceof TransientSteamAPIError)) throw error
+
+    // A rate-limit/network/5xx blip says nothing about whether this game has
+    // achievements — don't persist over it (that would cache "broken" for up
+    // to ACHIEVEMENTS_STALE_MS). Serve whatever we already have instead, and
+    // leave achievements_synced_at untouched so the next request retries.
+    const cached = readStoredAchievementsList(steamId, appId)
+    if (cached) {
+      return {
+        steamID: steamId,
+        gameName: game.name,
+        achievements: cached,
+        success: true,
+      }
+    }
+    return null
+  }
 
   if (!playerAchievements) {
     // Mark as checked with 0 achievements so we don't retry broken/retired games

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -258,7 +258,39 @@ export async function getRecentlyPlayedGames(steamId: string): Promise<SteamGame
   }
 }
 
-/** Fetches a player's achievements for a specific game, or null if unavailable. */
+/**
+ * Thrown by {@link getPlayerAchievements} when a request fails in a way that
+ * says nothing about whether the game actually has stats — rate limiting
+ * exhausted (429), a Steam-side server error (5xx), or a network failure.
+ *
+ * Unlike the definitive "no stats" case (a plain `null` return — see below),
+ * callers must NOT treat this as "this game has no achievements": doing so
+ * would cache that false conclusion for up to 7 days (ACHIEVEMENTS_STALE_MS)
+ * over what is most likely a momentary blip. Callers should catch this,
+ * avoid persisting anything, and let the next sync retry — see
+ * `getAchievementsForGame` in steam-achievements-sync.ts, the per-game
+ * workers in steam-stats-compute.ts and extra-games.ts, and
+ * ensurePinnedGamesSynced in pinned-games.ts.
+ */
+export class TransientSteamAPIError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message)
+    this.name = "TransientSteamAPIError"
+  }
+}
+
+/**
+ * Fetches a player's achievements for a specific game, or `null` when Steam
+ * gives a *definitive* answer that the game has no stats (400/403, or a 200
+ * response with `success: false`).
+ *
+ * @throws {TransientSteamAPIError} on rate-limit exhaustion (429), a Steam
+ *   server error (5xx), or a network failure — none of those mean "no
+ *   achievements", so they must not be conflated with the null case above.
+ */
 export async function getPlayerAchievements(steamId: string, appId: number): Promise<GameAchievements | null> {
   try {
     const data = await steamAPIRequest("/ISteamUserStats/GetPlayerAchievements/v1/", {
@@ -282,11 +314,14 @@ export async function getPlayerAchievements(steamId: string, appId: number): Pro
     // common for older titles, DLC-only entries, stats-only games, etc).
     // That's the signal the caller expects — a null return value — so don't
     // spam the console with "errors" for the normal case.
-    if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403 || error.status === 500)) {
+    if (error instanceof SteamAPIError && (error.status === 400 || error.status === 403)) {
       return null
     }
-    logger.warn({ err: error, appId }, "Unexpected error fetching achievements")
-    return null
+    // Everything else — 429 with retries exhausted, 5xx, or a network
+    // failure — is transient: it says nothing about whether the game has
+    // achievements, so it must not be swallowed into the null case above.
+    logger.warn({ err: error, appId }, "Transient error fetching achievements — will retry on next sync")
+    throw new TransientSteamAPIError("Transient error fetching player achievements", error)
   }
 }
 

--- a/test/achievements-sync-gaps.test.ts
+++ b/test/achievements-sync-gaps.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { TransientSteamAPIError } from "@/lib/steam-api"
 
 vi.mock("@/lib/env", () => ({
   env: new Proxy(
@@ -66,6 +67,7 @@ function mockSteamApi(mocks: {
     getPlayerAchievements: mocks.getPlayerAchievements ?? vi.fn().mockResolvedValue(null),
     getGameSchema: mocks.getGameSchema ?? vi.fn().mockResolvedValue(null),
     getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    TransientSteamAPIError,
   }))
   vi.doMock("@/lib/server/steam-images", () => ({
     ensureGameImages: vi.fn().mockResolvedValue(undefined),
@@ -257,5 +259,71 @@ describe("getAchievementsForGame", () => {
     const result = await getAchievementsForGame(STEAM_ID, APPID)
     expect(getPlayerAchievements).toHaveBeenCalled()
     expect(result?.gameName).toBe("Portal 2")
+  })
+})
+
+describe("getAchievementsForGame — transient failures must not be persisted as broken", () => {
+  it("serves the stale cached achievements instead of persisting a broken (0-count) result", async () => {
+    const getPlayerAchievements = vi.fn().mockRejectedValue(new TransientSteamAPIError("rate limited"))
+    mockSteamApi({ getPlayerAchievements })
+    const db = await seedProfileAndGame()
+    const now = new Date().toISOString()
+
+    // Seed a real, previously-synced achievement. Its sync timestamp is 8
+    // days old (past ACHIEVEMENTS_STALE_MS) so getAchievementsForGame will
+    // attempt to re-fetch — and hit the mocked transient failure.
+    db.prepare(
+      `INSERT INTO game_achievements (appid, apiname, display_name, description, icon, icon_gray, hidden, created_at, updated_at)
+       VALUES (?, 'ACH_ONE', 'One', 'First', 'icon.jpg', 'icon_bw.jpg', 0, ?, ?)`,
+    ).run(APPID, now, now)
+    db.prepare(
+      `INSERT INTO user_achievements (steam_id, appid, apiname, achieved, unlock_time, created_at, updated_at)
+       VALUES (?, ?, 'ACH_ONE', 1, 1700000000, ?, ?)`,
+    ).run(STEAM_ID, APPID, now, now)
+    const eightDaysAgoIso = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+    db.prepare(
+      `UPDATE user_games SET achievements_synced_at = ?, total_count = 1, unlocked_count = 1 WHERE steam_id = ? AND appid = ?`,
+    ).run(eightDaysAgoIso, STEAM_ID, APPID)
+
+    const { getAchievementsForGame } = await import("@/lib/server/steam-achievements-sync")
+    const result = await getAchievementsForGame(STEAM_ID, APPID)
+
+    // The previously-synced achievement is served, not dropped.
+    expect(result?.achievements).toHaveLength(1)
+
+    // Crucially: nothing was re-persisted — total_count wasn't zeroed and
+    // achievements_synced_at wasn't bumped, so the transient blip doesn't
+    // read as "verified broken" and the next request retries again.
+    const row = db
+      .prepare("SELECT total_count, achievements_synced_at FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, APPID) as { total_count: number; achievements_synced_at: string }
+    expect(row.total_count).toBe(1)
+    expect(row.achievements_synced_at).toBe(eightDaysAgoIso)
+  })
+
+  it("returns null without persisting a broken marker when there is no prior cache", async () => {
+    const getPlayerAchievements = vi.fn().mockRejectedValue(new TransientSteamAPIError("network blip"))
+    mockSteamApi({ getPlayerAchievements })
+    const db = await seedProfileAndGame()
+
+    const { getAchievementsForGame } = await import("@/lib/server/steam-achievements-sync")
+    const result = await getAchievementsForGame(STEAM_ID, APPID)
+    expect(result).toBeNull()
+
+    // Nothing was persisted: still never-synced, not "verified broken".
+    const row = db
+      .prepare("SELECT total_count, achievements_synced_at FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, APPID) as { total_count: number | null; achievements_synced_at: string | null }
+    expect(row.achievements_synced_at).toBeNull()
+    expect(row.total_count).toBeNull()
+  })
+
+  it("propagates non-transient errors instead of swallowing them into a broken marker", async () => {
+    const getPlayerAchievements = vi.fn().mockRejectedValue(new Error("boom - programmer error"))
+    mockSteamApi({ getPlayerAchievements })
+    await seedProfileAndGame()
+
+    const { getAchievementsForGame } = await import("@/lib/server/steam-achievements-sync")
+    await expect(getAchievementsForGame(STEAM_ID, APPID)).rejects.toThrow("boom - programmer error")
   })
 })

--- a/test/achievements-sync.test.ts
+++ b/test/achievements-sync.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { TransientSteamAPIError } from "@/lib/steam-api"
 
 vi.mock("@/lib/env", () => ({
   env: new Proxy(
@@ -210,6 +211,73 @@ describe("syncAchievementsForStats (per-game)", () => {
       .get(STEAM_ID, 440) as { achievements_synced_at: string | null; unlocked_count: number }
     expect(ok.achievements_synced_at).not.toBeNull()
     expect(ok.unlocked_count).toBe(1)
+  })
+
+  it("a transient failure on a has_community_visible_stats=null game does not mark it permanently broken", async () => {
+    // Regression test: before the fix, any thrown error from
+    // getPlayerAchievements (transient or not) still left the game
+    // never-synced — that part was already correct here, since this
+    // worker's try/catch already skips persisting on throw. The bug this
+    // guards is the *other* path (getAchievementsForGame persisting `[]` on
+    // a null return) plus the general risk of conflating transient and
+    // definitive failures. This test locks in that a transient error keeps
+    // the game retryable indefinitely, regardless of has_community_visible_stats.
+    const mockGetPlayerAchievements = vi
+      .fn()
+      .mockRejectedValueOnce(new TransientSteamAPIError("rate limited"))
+      .mockResolvedValueOnce({
+        steamID: STEAM_ID,
+        gameName: "Assassin's Creed",
+        achievements: [{ apiname: "ACH_ONE", achieved: 1, unlocktime: 1 }],
+        success: true,
+      })
+
+    vi.doMock("@/lib/steam-api", () => ({
+      getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
+      getOwnedGames: vi.fn().mockResolvedValue([]),
+      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
+      getPlayerAchievements: mockGetPlayerAchievements,
+      getGameSchema: vi.fn().mockResolvedValue(null),
+      getLastPlayedTimes: vi.fn().mockResolvedValue([]),
+    }))
+    vi.doMock("@/lib/server/steam-images", () => ({
+      ensureGameImages: vi.fn().mockResolvedValue(undefined),
+    }))
+
+    const db = await seedOwnedGames([{ appid: 15100, name: "Assassin's Creed", hasStats: null }])
+    const now = new Date().toISOString()
+    db.prepare(`UPDATE steam_profile SET last_owned_games_sync_at = ? WHERE steam_id = ?`).run(now, STEAM_ID)
+
+    const { getStatsForUser } = await import("@/lib/server/steam-stats-compute")
+
+    // First sync hits the transient failure.
+    await getStatsForUser(STEAM_ID, { forceRefresh: false })
+
+    const afterFirstSync = db
+      .prepare("SELECT achievements_synced_at FROM user_games WHERE steam_id = ? AND appid = ?")
+      .get(STEAM_ID, 15100) as { achievements_synced_at: string | null }
+    // Nothing was persisted over the transient error — still never-synced,
+    // not "verified broken".
+    expect(afterFirstSync.achievements_synced_at).toBeNull()
+
+    // Force the stats_snapshot cache to expire so syncAchievementsForStats runs again.
+    db.prepare(`DELETE FROM stats_snapshot WHERE steam_id = ?`).run(STEAM_ID)
+
+    // Second sync succeeds — proving the game gets retried instead of being
+    // stuck broken forever (which the old has_community_visible_stats===true-only
+    // recovery rule would have caused if the earlier blip had been persisted).
+    const stats = await getStatsForUser(STEAM_ID, { forceRefresh: false })
+    expect(mockGetPlayerAchievements).toHaveBeenCalledTimes(2)
+
+    const afterSecondSync = db
+      .prepare(
+        "SELECT total_count, unlocked_count, achievements_synced_at FROM user_games WHERE steam_id = ? AND appid = ?",
+      )
+      .get(STEAM_ID, 15100) as { total_count: number; unlocked_count: number; achievements_synced_at: string | null }
+    expect(afterSecondSync.total_count).toBe(1)
+    expect(afterSecondSync.unlocked_count).toBe(1)
+    expect(afterSecondSync.achievements_synced_at).not.toBeNull()
+    expect(stats.totalAchievements).toBe(1)
   })
 
   it("marks broken/retired games (null response) with total_count=0 so they stop retrying", async () => {

--- a/test/steam-api.test.ts
+++ b/test/steam-api.test.ts
@@ -226,19 +226,42 @@ describe("getPlayerAchievements", () => {
     expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
-  it("returns null *silently* on 500 (broken stats) — no console noise", async () => {
+  it("throws TransientSteamAPIError on 500 (Steam-side error) instead of returning null", async () => {
+    // A 500 says nothing about whether the game has stats — treating it the
+    // same as a definitive 400/403 would let a transient Steam-side error
+    // get persisted as "no achievements" for up to 7 days. See
+    // steam-achievements-sync.ts's getAchievementsForGame.
     mockFetchSequence([{ ok: false, status: 500, body: {} }])
-    const { getPlayerAchievements } = await import("@/lib/steam-api")
-    expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
+    const { getPlayerAchievements, TransientSteamAPIError } = await import("@/lib/steam-api")
+    await expect(getPlayerAchievements("76561198023709299", 620)).rejects.toThrow(TransientSteamAPIError)
+    expect(loggerMock.warn).toHaveBeenCalled()
     expect(loggerMock.error).not.toHaveBeenCalled()
   })
 
-  it("returns null on network error and warns (not errors)", async () => {
+  it("throws TransientSteamAPIError on network error (and warns, not errors)", async () => {
     mockFetchRejecting(new Error("socket hangup"))
-    const { getPlayerAchievements } = await import("@/lib/steam-api")
-    expect(await getPlayerAchievements("76561198023709299", 620)).toBeNull()
+    const { getPlayerAchievements, TransientSteamAPIError } = await import("@/lib/steam-api")
+    await expect(getPlayerAchievements("76561198023709299", 620)).rejects.toThrow(TransientSteamAPIError)
     expect(loggerMock.warn).toHaveBeenCalled()
     expect(loggerMock.error).not.toHaveBeenCalled()
+  })
+
+  it("throws TransientSteamAPIError when 429 retries are exhausted", async () => {
+    mockFetchSequence([
+      { ok: false, status: 429, retryAfter: "0" },
+      { ok: false, status: 429, retryAfter: "0" },
+      { ok: false, status: 429, retryAfter: "0" },
+      { ok: false, status: 429, retryAfter: "0" },
+    ])
+    const { getPlayerAchievements, TransientSteamAPIError } = await import("@/lib/steam-api")
+    vi.useFakeTimers()
+    const promise = getPlayerAchievements("76561198023709299", 620)
+    // Attach a rejection handler before advancing timers so the eventual
+    // rejection is never briefly "unhandled" mid-flight.
+    const assertion = expect(promise).rejects.toThrow(TransientSteamAPIError)
+    await vi.runAllTimersAsync()
+    await assertion
+    expect(loggerMock.error).toHaveBeenCalled()
   })
 
   it("defaults achievements to [] when the response omits the array", async () => {


### PR DESCRIPTION
## Summary
- `getPlayerAchievements` was collapsing every failure mode into a single `null` return — a definitive "this game has no stats" (400/403) response was indistinguishable from a transient one (429 with retries exhausted, 5xx, network error). Every caller treated `null` the same way, so a momentary Steam blip got persisted as `total_count=0` and cached as a "broken game" for up to 7 days (`ACHIEVEMENTS_STALE_MS`).
- Worse: for games where `has_community_visible_stats` isn't explicitly `true`, the recovery filter in `steam-stats-compute.ts` never retries a game once it's marked broken, so a single network blip could mark it broken *permanently*.
- Fix: `getPlayerAchievements` now throws a new `TransientSteamAPIError` for anything that isn't a definitive 400/403 (429-exhausted, 5xx, network errors), instead of swallowing it into the `null`/"no stats" case.
- `getAchievementsForGame` (`lib/server/steam-achievements-sync.ts`) now catches `TransientSteamAPIError` and serves the previously cached result (or `null`) without touching `achievements_synced_at` or persisting an empty achievement list — so the next sync retries instead of trusting a false "no achievements" conclusion.
- The other three call sites (`steam-stats-compute.ts`'s per-game worker, `extra-games.ts`, `pinned-games.ts`) already wrap this call in a try/catch that skips persisting and logs "will retry on next sync" on any thrown error — they needed **no changes**, since the fix simply routes the transient case into that existing correct path instead of the incorrect null one.

## Test plan
- [x] `pnpm install`
- [x] `pnpm lint` (oxlint + tsc)
- [x] `pnpm format:check`
- [x] `pnpm test` — 501/501 passing, including new cases:
  - `getPlayerAchievements` throws `TransientSteamAPIError` on 500, network error, and 429-with-retries-exhausted (`test/steam-api.test.ts`)
  - `getAchievementsForGame` serves stale cached achievements (not a persisted broken marker) on a transient failure, returns `null` without persisting when there's no prior cache, and still propagates genuinely unexpected errors (`test/achievements-sync-gaps.test.ts`)
  - a `has_community_visible_stats: null` game hit by one transient failure is retried on the next sync instead of getting stuck "broken" (`test/achievements-sync.test.ts`)
- [x] `pnpm test:coverage` — all thresholds pass (lines 93.29% / statements 91.75% / branches 83.66% / functions 92.5%, vs floors of 92/90/83/81)
- [x] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)