### PR TITLE
fix: preserve prior data when a background steam-data refresh fails

### DIFF
--- a/hooks/use-steam-data.ts
+++ b/hooks/use-steam-data.ts
@@ -97,7 +97,9 @@ export function useSteamAchievementsBatch(appIds: number[]) {
         hasLoadedRef.current = true
       } else {
         setError(errorMessage)
-        setAchievementsMap({})
+        if (!hasLoadedRef.current) {
+          setAchievementsMap({})
+        }
       }
       setLoading(false)
       setIsRefreshing(false)
@@ -195,7 +197,9 @@ export function useSteamGames(type: "recent" | "all" = "recent") {
         hasLoadedRef.current = true
       } else {
         setError(errorMessage)
-        setGames([])
+        if (!hasLoadedRef.current) {
+          setGames([])
+        }
       }
       setLoading(false)
       setIsRefreshing(false)
@@ -285,7 +289,9 @@ export function useSteamStats() {
       hasLoadedRef.current = true
     } else {
       setError(errorMessage)
-      setStats(null)
+      if (!hasLoadedRef.current) {
+        setStats(null)
+      }
     }
     setLoading(false)
     setIsRefreshing(false)
@@ -356,6 +362,8 @@ export function useSteamExtras() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  const hasLoadedRef = useRef(false)
+
   const runLoad = useCallback(async () => {
     let nextGames: SteamExtraGame[] | null = null
     let errorMessage: string | null = null
@@ -369,9 +377,12 @@ export function useSteamExtras() {
     }
     if (nextGames) {
       setGames(nextGames)
+      hasLoadedRef.current = true
     } else {
       setError(errorMessage)
-      setGames([])
+      if (!hasLoadedRef.current) {
+        setGames([])
+      }
     }
     setLoading(false)
   }, [])
@@ -416,6 +427,8 @@ export function useSteamHiddenGames() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  const hasLoadedRef = useRef(false)
+
   const runLoad = useCallback(async () => {
     let nextGames: SteamHiddenGame[] | null = null
     let errorMessage: string | null = null
@@ -429,9 +442,12 @@ export function useSteamHiddenGames() {
     }
     if (nextGames) {
       setGames(nextGames)
+      hasLoadedRef.current = true
     } else {
       setError(errorMessage)
-      setGames([])
+      if (!hasLoadedRef.current) {
+        setGames([])
+      }
     }
     setLoading(false)
   }, [])
@@ -516,7 +532,9 @@ export function useSteamAchievements(appId: number | null) {
         hasLoadedRef.current = true
       } else {
         setError(errorMessage)
-        setAchievements([])
+        if (!hasLoadedRef.current) {
+          setAchievements([])
+        }
       }
       setLoading(false)
       setIsRefreshing(false)

--- a/test/use-steam-data.test.tsx
+++ b/test/use-steam-data.test.tsx
@@ -95,6 +95,28 @@ describe("useSteamGames", () => {
     })
     await waitFor(() => expect(calls).toBeGreaterThan(initial))
   })
+
+  it("keeps previously loaded games and sets error when a background refresh fails", async () => {
+    let calls = 0
+    mockFetchSequence(async () => {
+      calls++
+      if (calls === 1) {
+        return ok({ games: [{ appid: 620, name: "Portal 2", playtime_forever: 100 }] })
+      }
+      return err(500)
+    })
+    const { useSteamGames } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamGames("recent"))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.games).toHaveLength(1)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steam-data-invalidated"))
+    })
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch games"))
+    expect(result.current.games).toHaveLength(1)
+    expect(result.current.isRefreshing).toBe(false)
+  })
 })
 
 describe("useSteamAchievementsBatch", () => {
@@ -141,6 +163,28 @@ describe("useSteamAchievementsBatch", () => {
     const { result } = renderHook(() => useSteamAchievementsBatch([620]))
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.error).toBe("Failed to fetch achievements batch")
+    expect(result.current.achievementsMap).toEqual({})
+  })
+
+  it("keeps the previously loaded map and sets error when a background refresh fails", async () => {
+    let calls = 0
+    mockFetchSequence(async () => {
+      calls++
+      if (calls === 1) {
+        return ok({ achievementsMap: { "620": [] } })
+      }
+      return err(500)
+    })
+    const { useSteamAchievementsBatch } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamAchievementsBatch([620]))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.achievementsMap).toEqual({ 620: [] })
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steam-data-invalidated"))
+    })
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch achievements batch"))
+    expect(result.current.achievementsMap).toEqual({ 620: [] })
   })
 })
 
@@ -195,6 +239,25 @@ describe("useSteamStats", () => {
     })
     expect(urls.some((u) => u.includes("refresh=1"))).toBe(true)
   })
+
+  it("keeps previously loaded stats and sets error when a manual refresh fails", async () => {
+    let calls = 0
+    mockFetchSequence(async () => {
+      calls++
+      if (calls === 1) return ok(sampleStats)
+      return err(500)
+    })
+    const { useSteamStats } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamStats())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.stats?.totalGames).toBe(10)
+
+    await act(async () => {
+      await result.current.refetch({ force: true })
+    })
+    expect(result.current.error).toBe("Failed to fetch stats")
+    expect(result.current.stats?.totalGames).toBe(10)
+  })
 })
 
 describe("useSteamExtras", () => {
@@ -243,6 +306,38 @@ describe("useSteamExtras", () => {
       window.dispatchEvent(new CustomEvent("steam-data-invalidated"))
     })
     await waitFor(() => expect(calls).toBeGreaterThan(initial))
+  })
+
+  it("keeps previously loaded extras and sets error when a background refresh fails", async () => {
+    let calls = 0
+    mockFetchSequence(async () => {
+      calls++
+      if (calls === 1) {
+        return ok({
+          games: [
+            {
+              appid: 111,
+              name: "Refunded Game",
+              playtime_forever: 100,
+              rtime_first_played: 1_000_000_000,
+              rtime_last_played: 1_100_000_000,
+              synced_at: "2026-04-11T10:00:00.000Z",
+            },
+          ],
+        })
+      }
+      return err(500)
+    })
+    const { useSteamExtras } = await import("@/hooks/use-steam-data")
+    const { result } = renderHook(() => useSteamExtras())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.games).toHaveLength(1)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("steam-data-invalidated"))
+    })
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch extras"))
+    expect(result.current.games).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
## Summary
- The error paths in `hooks/use-steam-data.ts` (`useSteamAchievementsBatch`, `useSteamGames`, `useSteamStats`, `useSteamExtras`, `useSteamHiddenGames`, `useSteamAchievements`) unconditionally cleared state to empty/null on any fetch failure.
- A failed background refresh (the `steam-data-invalidated` event, e.g. a tab regaining focus) would wipe an already-rendered UI even though the previous data was still valid.
- Fix: each hook now only resets to empty/null when there is no prior successfully-loaded data (tracked via the existing/added `hasLoadedRef`); once data has loaded, a later failed fetch just sets `error` (and `loading=false`) while keeping the previous state intact. Initial-load failures still behave exactly as before (empty state + error).
- Added `hasLoadedRef` to `useSteamExtras` and `useSteamHiddenGames`, which didn't previously track first-load status, to apply the same pattern consistently across all six hooks.

## Test plan
- [x] Added test cases to `test/use-steam-data.test.tsx` for `useSteamGames`, `useSteamStats`, `useSteamExtras`, and `useSteamAchievementsBatch`: data loaded → background/manual refresh fails → previous data intact + `error` set.
- [x] Existing "initial load fails" tests still pass (empty state + error unchanged).
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test` (all 500 tests pass)
- [x] `pnpm build` (with dummy env vars per `ci.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)