### PR TITLE
Derive client IP from trusted proxy hop instead of raw x-forwarded-for

### DIFF
--- a/app/api/auth/steam/route.ts
+++ b/app/api/auth/steam/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { cookies } from "next/headers"
 import crypto from "node:crypto"
 
+import { getClientIp } from "@/lib/server/client-ip"
 import { rateLimit } from "@/lib/server/rate-limit"
 
 const STEAM_OPENID_URL = "https://steamcommunity.com/openid/login"
@@ -18,7 +19,7 @@ const STEAM_OPENID_URL = "https://steamcommunity.com/openid/login"
  * @throws 429 - Too many requests
  */
 export async function GET(request: NextRequest) {
-  const ip = request.headers.get("x-forwarded-for") || request.headers.get("x-real-ip") || "unknown"
+  const ip = getClientIp(request.headers)
   const { success } = rateLimit(`auth:${ip}`, 10, 60_000)
   if (!success) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 })

--- a/lib/server/client-ip.ts
+++ b/lib/server/client-ip.ts
@@ -1,0 +1,75 @@
+import "server-only"
+
+const UNKNOWN_IP = "unknown"
+
+/**
+ * Resolves the client IP address for rate-limiting and logging purposes.
+ *
+ * Deployment assumption: the app runs behind exactly one trusted reverse
+ * proxy (e.g. Vercel's edge network). That proxy appends the connecting
+ * client's address to the end of `x-forwarded-for` before forwarding the
+ * request — every entry to the *left* of it was supplied by the client (or
+ * an earlier untrusted hop) and can be freely spoofed. Taking the
+ * *rightmost* entry — rather than the first, commonly-used-but-wrong
+ * choice — is what makes this resistant to spoofing: a client can prepend
+ * as many fake addresses as it wants, but it cannot control what the
+ * trusted proxy appends after them. This is the same pattern applied in
+ * personal-deck.
+ *
+ * Without a trusted proxy in front of the app (e.g. running the container
+ * directly, exposed to the internet), `x-forwarded-for` is attacker
+ * controlled end-to-end and this function's result cannot be trusted as a
+ * real client identity — it will simply reflect whatever the client sent.
+ * Deploy behind a trusted proxy that sets/overwrites this header, or behind
+ * one that sets `x-real-ip`, for the result to be meaningful.
+ *
+ * Falls back to `x-real-ip` (a single-address header some proxies set),
+ * then to the literal string "unknown" so callers always get a stable,
+ * non-empty bucket key.
+ *
+ * @param headers - Request headers to read `x-forwarded-for` / `x-real-ip` from
+ * @returns A normalized client IP (trimmed, no port suffix), or "unknown"
+ */
+export function getClientIp(headers: Headers): string {
+  const forwardedFor = headers.get("x-forwarded-for")
+  if (forwardedFor) {
+    const entries = forwardedFor
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+    const rightmost = entries[entries.length - 1]
+    if (rightmost) {
+      return normalizeIp(rightmost)
+    }
+  }
+
+  const realIp = headers.get("x-real-ip")?.trim()
+  if (realIp) {
+    return normalizeIp(realIp)
+  }
+
+  return UNKNOWN_IP
+}
+
+/**
+ * Strips a trailing port from an IPv4 address or bracketed IPv6 literal.
+ * Bare (unbracketed) IPv6 addresses are returned as-is since they contain
+ * colons that are indistinguishable from a port separator.
+ */
+function normalizeIp(value: string): string {
+  const trimmed = value.trim()
+
+  // Bracketed IPv6, optionally with a port: "[::1]" or "[::1]:8080"
+  const bracketedMatch = /^\[([^\]]+)\](?::\d+)?$/.exec(trimmed)
+  if (bracketedMatch) {
+    return bracketedMatch[1]
+  }
+
+  // IPv4, optionally with a port: "1.2.3.4" or "1.2.3.4:8080"
+  const ipv4WithPortMatch = /^(\d{1,3}(?:\.\d{1,3}){3}):\d+$/.exec(trimmed)
+  if (ipv4WithPortMatch) {
+    return ipv4WithPortMatch[1]
+  }
+
+  return trimmed
+}

--- a/test/client-ip.test.ts
+++ b/test/client-ip.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+
+import { getClientIp } from "@/lib/server/client-ip"
+
+function headersWith(entries: Record<string, string>): Headers {
+  return new Headers(entries)
+}
+
+describe("getClientIp", () => {
+  it("takes the last entry from a multi-hop x-forwarded-for list", () => {
+    const headers = headersWith({
+      "x-forwarded-for": "203.0.113.1, 198.51.100.2, 192.0.2.3",
+    })
+    // 192.0.2.3 is the address the trusted proxy appended; everything to
+    // its left was supplied by untrusted, possibly-spoofed hops.
+    expect(getClientIp(headers)).toBe("192.0.2.3")
+  })
+
+  it("falls back to x-real-ip when x-forwarded-for is absent", () => {
+    const headers = headersWith({ "x-real-ip": "198.51.100.42" })
+    expect(getClientIp(headers)).toBe("198.51.100.42")
+  })
+
+  it("falls back to 'unknown' when no IP headers are present", () => {
+    const headers = headersWith({})
+    expect(getClientIp(headers)).toBe("unknown")
+  })
+
+  it("is not fooled by spoofing earlier entries in the list", () => {
+    const trustedTail = "192.0.2.3"
+    const withoutSpoofing = headersWith({ "x-forwarded-for": trustedTail })
+    const withSpoofing = headersWith({
+      "x-forwarded-for": `1.1.1.1, 2.2.2.2, 3.3.3.3, ${trustedTail}`,
+    })
+
+    // Prepending fake addresses does not change the resolved key, since
+    // only the rightmost (proxy-appended) entry is trusted.
+    expect(getClientIp(withSpoofing)).toBe(getClientIp(withoutSpoofing))
+    expect(getClientIp(withSpoofing)).toBe(trustedTail)
+  })
+
+  it("prefers x-forwarded-for over x-real-ip when both are present", () => {
+    const headers = headersWith({
+      "x-forwarded-for": "198.51.100.2, 192.0.2.9",
+      "x-real-ip": "203.0.113.55",
+    })
+    expect(getClientIp(headers)).toBe("192.0.2.9")
+  })
+
+  it("strips a trailing port from an IPv4 address", () => {
+    const headers = headersWith({ "x-forwarded-for": "192.0.2.9:54321" })
+    expect(getClientIp(headers)).toBe("192.0.2.9")
+  })
+
+  it("handles bracketed IPv6 addresses with a port", () => {
+    const headers = headersWith({ "x-forwarded-for": "[2001:db8::1]:54321" })
+    expect(getClientIp(headers)).toBe("2001:db8::1")
+  })
+
+  it("handles bracketed IPv6 addresses without a port", () => {
+    const headers = headersWith({ "x-forwarded-for": "[2001:db8::1]" })
+    expect(getClientIp(headers)).toBe("2001:db8::1")
+  })
+
+  it("trims surrounding whitespace around entries", () => {
+    const headers = headersWith({ "x-forwarded-for": "  1.1.1.1  ,  192.0.2.9  " })
+    expect(getClientIp(headers)).toBe("192.0.2.9")
+  })
+
+  it("ignores a trailing empty entry after a stray comma", () => {
+    const headers = headersWith({ "x-forwarded-for": "192.0.2.9, " })
+    expect(getClientIp(headers)).toBe("192.0.2.9")
+  })
+})


### PR DESCRIPTION
## Summary
- The Steam login rate limiter (`app/api/auth/steam/route.ts`) used the full `x-forwarded-for` header value as its bucket key. Without a proxy that overwrites the header, any client can bypass the limit by sending an arbitrary value; with multiple hops the header is a comma-separated list, not a single IP, so the limiter was effectively keying on list contents rather than a stable client identity.
- Adds `getClientIp(headers)` in `lib/server/client-ip.ts`: takes the **rightmost** `x-forwarded-for` entry (the one appended by the trusted edge proxy — client-supplied entries to its left are untrustworthy), falls back to `x-real-ip`, then to `"unknown"`, and normalizes ports/IPv6 brackets. The deployment assumption (single trusted proxy, e.g. Vercel) and the no-proxy caveat are documented in the function's doc comment.
- Wires the helper into `GET /api/auth/steam`. Grepped the repo for other `x-forwarded-for`/`x-real-ip` usages — this route was the only one.

## Test plan
- [x] `pnpm lint` (oxlint + typecheck)
- [x] `pnpm format:check` (oxfmt)
- [x] `pnpm test` — 515 tests passing across 54 files, including a new `test/client-ip.test.ts` covering: multi-hop list takes the last entry, missing header falls back to `x-real-ip` then `"unknown"`, left-side spoofing doesn't change the resolved key, `x-forwarded-for` takes precedence over `x-real-ip`, and IPv4/IPv6 port/bracket normalization
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)