### PR TITLE
chore: drop dead getRecentlyPlayedGames and recent_games_snapshot table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Next.js 16 App Router with React 19, TypeScript strict mode, Tailwind CSS 4, sha
 - `lib/server/steam-stats-compute.ts` — stats aggregation and sync orchestration; computes from `user_games WHERE total_count > 0`
 - `lib/server/steam-store-utils.ts` — shared utilities (staleness checks, timestamps, profile management)
 - `lib/server/steam-store.ts` — barrel re-export of the above modules
-- `lib/server/sqlite.ts` — database schema and migrations (Node.js built-in `DatabaseSync`); tables: `steam_profile`, `games`, `user_games`, `recent_games_snapshot`, `stats_snapshot`, `hidden_games`, `allowed_users`, `game_achievements`, `user_achievements`, `pinned_games`, `extra_games`, `extra_game_achievements`, `app_catalog_meta`
+- `lib/server/sqlite.ts` — database schema and migrations (Node.js built-in `DatabaseSync`); tables: `steam_profile`, `games`, `user_games`, `stats_snapshot`, `hidden_games`, `allowed_users`, `game_achievements`, `user_achievements`, `pinned_games`, `extra_games`, `extra_game_achievements`, `app_catalog_meta`
 - `lib/steam-api.ts` — direct Steam Web API calls (shared between server and client for types/utilities)
 
 ### API routes (`app/api/`)

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ To add a new column: add it to the relevant `CREATE TABLE` in `createBaseSchema`
 
 ### Tables
 
-`steam_profile` · `games` · `user_games` · `recent_games_snapshot` · `stats_snapshot` · `hidden_games` · `allowed_users` · `game_achievements` · `user_achievements` · `pinned_games` · `extra_games` · `extra_game_achievements` · `app_catalog_meta`
+`steam_profile` · `games` · `user_games` · `stats_snapshot` · `hidden_games` · `allowed_users` · `game_achievements` · `user_achievements` · `pinned_games` · `extra_games` · `extra_game_achievements` · `app_catalog_meta`
 
 All user-specific tables are keyed by `steam_id` for multi-user isolation.
 

--- a/lib/server/sqlite.ts
+++ b/lib/server/sqlite.ts
@@ -101,14 +101,6 @@ function createBaseSchema(db: DatabaseSync) {
       FOREIGN KEY (steam_id) REFERENCES steam_profile(steam_id)
     );
 
-    CREATE TABLE IF NOT EXISTS recent_games_snapshot (
-      steam_id TEXT PRIMARY KEY,
-      games_json TEXT NOT NULL,
-      synced_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      FOREIGN KEY (steam_id) REFERENCES steam_profile(steam_id)
-    );
-
     CREATE TABLE IF NOT EXISTS stats_snapshot (
       steam_id TEXT PRIMARY KEY,
       total_games INTEGER NOT NULL,
@@ -415,6 +407,20 @@ const MIGRATIONS: Array<{ version: number; name: string; run: (db: DatabaseSync)
         SET platforms_synced_at = NULL
         WHERE platforms IS NOT NULL AND release_year IS NULL;
       `)
+    },
+  },
+  {
+    version: 4,
+    name: "drop-recent-games-snapshot",
+    /**
+     * `recent_games_snapshot` was created for a caching path that was
+     * never wired up — recently-played games are served from `user_games`
+     * via `getRecentlyPlayedGamesForUser` in steam-games-sync.ts. Nothing
+     * ever read or wrote this table, so it's dropped here for existing
+     * databases; the base schema no longer creates it on fresh installs.
+     */
+    run(db) {
+      db.exec(`DROP TABLE IF EXISTS recent_games_snapshot;`)
     },
   },
 ]

--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -242,22 +242,6 @@ export async function getOwnedGames(steamId: string): Promise<SteamGame[]> {
   }
 }
 
-/** Fetches the 25 most recently played games for a Steam user. */
-export async function getRecentlyPlayedGames(steamId: string): Promise<SteamGame[]> {
-  try {
-    const data = await steamAPIRequest("/IPlayerService/GetRecentlyPlayedGames/v1/", {
-      steamid: steamId,
-      count: "25",
-      l: steamLocale(),
-    })
-
-    return data.response?.games || []
-  } catch (error) {
-    logger.error({ err: error, steamIdHash: redactSteamId(steamId) }, "Error fetching recently played games")
-    return []
-  }
-}
-
 /** Fetches a player's achievements for a specific game, or null if unavailable. */
 export async function getPlayerAchievements(steamId: string, appId: number): Promise<GameAchievements | null> {
   try {

--- a/test/achievements-sync-gaps.test.ts
+++ b/test/achievements-sync-gaps.test.ts
@@ -62,7 +62,6 @@ function mockSteamApi(mocks: {
   vi.doMock("@/lib/steam-api", () => ({
     getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
     getOwnedGames: vi.fn().mockResolvedValue([]),
-    getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
     getPlayerAchievements: mocks.getPlayerAchievements ?? vi.fn().mockResolvedValue(null),
     getGameSchema: mocks.getGameSchema ?? vi.fn().mockResolvedValue(null),
     getLastPlayedTimes: vi.fn().mockResolvedValue([]),

--- a/test/achievements-sync.test.ts
+++ b/test/achievements-sync.test.ts
@@ -99,7 +99,6 @@ describe("syncAchievementsForStats (per-game)", () => {
     vi.doMock("@/lib/steam-api", () => ({
       getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
       getOwnedGames: vi.fn().mockResolvedValue([]),
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: mockGetGameSchema,
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),
@@ -148,7 +147,6 @@ describe("syncAchievementsForStats (per-game)", () => {
     vi.doMock("@/lib/steam-api", () => ({
       getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
       getOwnedGames: vi.fn().mockResolvedValue([]),
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn(),
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),
@@ -181,7 +179,6 @@ describe("syncAchievementsForStats (per-game)", () => {
     vi.doMock("@/lib/steam-api", () => ({
       getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
       getOwnedGames: vi.fn().mockResolvedValue([]),
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn().mockResolvedValue(null),
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),
@@ -218,7 +215,6 @@ describe("syncAchievementsForStats (per-game)", () => {
     vi.doMock("@/lib/steam-api", () => ({
       getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
       getOwnedGames: vi.fn().mockResolvedValue([]),
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn().mockResolvedValue(null),
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),
@@ -250,7 +246,6 @@ describe("syncAchievementsForStats (incremental filter)", () => {
     vi.doMock("@/lib/steam-api", () => ({
       getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
       getOwnedGames: vi.fn().mockResolvedValue([]),
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mockGetPlayerAchievements,
       getGameSchema: vi.fn().mockResolvedValue(null),
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),

--- a/test/extra-games.test.ts
+++ b/test/extra-games.test.ts
@@ -309,7 +309,6 @@ describe("syncExtraAchievements", () => {
   }) {
     vi.doMock("@/lib/steam-api", () => ({
       getOwnedGames: vi.fn().mockResolvedValue([]),
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: mocks.getPlayerAchievements ?? vi.fn().mockResolvedValue(null),
       getGameSchema: mocks.getGameSchema ?? vi.fn().mockResolvedValue(null),
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),

--- a/test/sqlite-migrations.test.ts
+++ b/test/sqlite-migrations.test.ts
@@ -169,4 +169,28 @@ describe("versioned migrations", () => {
     // user_version bumped, second open skips it.
     expect(row.name).toBe("ValveTestApp555")
   })
+
+  it("migration v4 drops the unused recent_games_snapshot table", async () => {
+    const { getSqliteDatabase } = await import("@/lib/server/sqlite")
+    const db = getSqliteDatabase()
+
+    // Simulate a pre-migration database that still has the dead table
+    // (it's no longer part of the base schema created on fresh installs).
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS recent_games_snapshot (
+        steam_id TEXT PRIMARY KEY,
+        games_json TEXT NOT NULL,
+        synced_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `)
+    db.exec("PRAGMA user_version = 3")
+    vi.resetModules()
+    await import("@/lib/server/sqlite").then((m) => m.getSqliteDatabase())
+
+    const table = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'recent_games_snapshot'`)
+      .get()
+    expect(table).toBeUndefined()
+  })
 })

--- a/test/stats-compute-gaps.test.ts
+++ b/test/stats-compute-gaps.test.ts
@@ -50,7 +50,6 @@ function mockSteamApi() {
   vi.doMock("@/lib/steam-api", () => ({
     getGlobalAchievementPercentages: vi.fn().mockResolvedValue(null),
     getOwnedGames: vi.fn().mockResolvedValue([]),
-    getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
     getPlayerAchievements: vi.fn().mockResolvedValue(null),
     getGameSchema: vi.fn().mockResolvedValue(null),
     getLastPlayedTimes: vi.fn().mockResolvedValue([]),
@@ -140,7 +139,6 @@ describe("synchronizeUserData", () => {
           rtime_last_played: 1_800_000_000,
         },
       ]),
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: vi.fn().mockResolvedValue({
         steamID: STEAM_ID,
         gameName: "Portal 2",

--- a/test/steam-api.test.ts
+++ b/test/steam-api.test.ts
@@ -152,35 +152,6 @@ describe("getOwnedGames", () => {
   })
 })
 
-describe("getRecentlyPlayedGames", () => {
-  it("returns the games array on success", async () => {
-    mockFetchSequence([{ body: { response: { games: [{ appid: 620, name: "Portal 2", playtime_forever: 0 }] } } }])
-    const { getRecentlyPlayedGames } = await import("@/lib/steam-api")
-    const games = await getRecentlyPlayedGames("76561198023709299")
-    expect(games).toHaveLength(1)
-  })
-
-  it("passes count=25 as a query parameter", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({ response: { games: [] } }),
-    })) as unknown as typeof fetch
-    globalThis.fetch = fetchMock
-    const { getRecentlyPlayedGames } = await import("@/lib/steam-api")
-    await getRecentlyPlayedGames("76561198023709299")
-    const url = (fetchMock as unknown as { mock: { calls: [[string, unknown]] } }).mock.calls[0][0]
-    expect(url).toContain("count=25")
-  })
-
-  it("returns an empty array on network failure", async () => {
-    mockFetchRejecting(new Error("EHOSTUNREACH"))
-    const { getRecentlyPlayedGames } = await import("@/lib/steam-api")
-    expect(await getRecentlyPlayedGames("76561198023709299")).toEqual([])
-    expect(loggerMock.error).toHaveBeenCalled()
-  })
-})
-
 describe("getPlayerAchievements", () => {
   it("returns the enriched achievements payload on success", async () => {
     mockFetchSequence([
@@ -328,8 +299,8 @@ describe("locale configuration (STEAM_API_LOCALE)", () => {
       json: async () => ({ response: { games: [] } }),
     })) as unknown as typeof fetch
     globalThis.fetch = fetchMock
-    const { getRecentlyPlayedGames } = await import("@/lib/steam-api")
-    await getRecentlyPlayedGames("76561198023709299")
+    const { getOwnedGames } = await import("@/lib/steam-api")
+    await getOwnedGames("76561198023709299")
     const url = (fetchMock as unknown as { mock: { calls: [[string, unknown]] } }).mock.calls[0][0]
     expect(url).toContain("l=en")
     expect(url).not.toContain("l=es")

--- a/test/steam-games-sync.test.ts
+++ b/test/steam-games-sync.test.ts
@@ -48,7 +48,6 @@ function mockSteamApi(
         rtime_last_played: g.rtime_last_played,
       })),
     ),
-    getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
     getPlayerAchievements: vi.fn().mockResolvedValue(null),
     getGameSchema: vi.fn().mockResolvedValue(null),
     getLastPlayedTimes: vi.fn().mockResolvedValue([]),
@@ -85,7 +84,6 @@ describe("ensureOwnedGamesSynced", () => {
     const getOwnedGames = vi.fn().mockResolvedValue([])
     vi.doMock("@/lib/steam-api", () => ({
       getOwnedGames,
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: vi.fn().mockResolvedValue(null),
       getGameSchema: vi.fn().mockResolvedValue(null),
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),
@@ -183,7 +181,6 @@ describe("ensureOwnedGamesSynced", () => {
     const getOwnedGames = vi.fn().mockResolvedValue([])
     vi.doMock("@/lib/steam-api", () => ({
       getOwnedGames,
-      getRecentlyPlayedGames: vi.fn().mockResolvedValue([]),
       getPlayerAchievements: vi.fn().mockResolvedValue(null),
       getGameSchema: vi.fn().mockResolvedValue(null),
       getLastPlayedTimes: vi.fn().mockResolvedValue([]),


### PR DESCRIPTION
## Summary
- Remove `getRecentlyPlayedGames` from `lib/steam-api.ts` — it has no production caller; recently-played games are served from `user_games` via `getRecentlyPlayedGamesForUser` in `steam-games-sync.ts`. Removed its dedicated tests, and swapped the one locale test that incidentally exercised it over to `getOwnedGames`.
- Remove the never-read/never-written `recent_games_snapshot` table: dropped the `CREATE TABLE` from the base schema and added a version-4 entry to the `MIGRATIONS` array (`DROP TABLE IF EXISTS`) so existing databases lose it too, consistent with the repo's `PRAGMA user_version` migration system.
- Updated the table list in `README.md` and `CLAUDE.md` accordingly.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test` (503/503 passing, includes a new migration test asserting `recent_games_snapshot` is dropped on existing DBs)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)