### PR TITLE
chore(csp): remove unused steampowered.com from connect-src

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,7 +34,7 @@ const nextConfig = {
               "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com",
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https://steamcdn-a.akamaihd.net https://cdn.akamai.steamstatic.com https://avatars.steamstatic.com https://store.steampowered.com https://shared.akamai.steamstatic.com https://shared.fastly.steamstatic.com https://cdn.fastly.steamstatic.com https://media.steampowered.com https://community.steamstatic.com https://community.fastly.steamstatic.com https://shared.steamstatic.com",
-              "connect-src 'self' https://static.cloudflareinsights.com https://api.steampowered.com",
+              "connect-src 'self' https://static.cloudflareinsights.com",
               "font-src 'self'",
             ].join("; "),
           },


### PR DESCRIPTION
## Summary
- `connect-src` in the CSP (`next.config.mjs`) allowlisted `https://api.steampowered.com`, but no client-side code ever calls it directly — all Steam Web API access happens server-side in `app/api/*/route.ts` and `lib/steam-api.ts` (which is marked `server-only`).
- Every client `fetch()` call targets a relative `/api/*` path (same-origin, already covered by `'self'`).
- Removed the unnecessary origin from `connect-src` to reduce attack surface (e.g. XSS exfiltration to an allowlisted origin). `img-src` is untouched — steamstatic.com CDN images are legitimately loaded client-side.

## Verification
- Grepped `components/`, `hooks/`, `app/` for `steampowered`/`steamstatic` references: all hits are either `img-src`-covered CDN image URLs, `<a href>` navigation links (not governed by `connect-src`), or server-side route handlers.
- `pnpm lint` — pass
- `pnpm format:check` — pass
- `pnpm test` — 524/524 pass
- `pnpm build` — pass
- Booted the standalone build and curled the response headers directly to confirm the resulting `Content-Security-Policy` header no longer includes `api.steampowered.com` in `connect-src`, with `img-src` unchanged.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Manually inspected the CSP response header from the built standalone server

🤖 Generated with [Claude Code](https://claude.com/claude-code)