### PR TITLE
fix(steam-api): cap cumulative 429 retry wait per request

### DIFF
--- a/lib/steam-api.ts
+++ b/lib/steam-api.ts
@@ -121,6 +121,14 @@ const MAX_BACKOFF_MS = 30_000
 // error) than to sleep for minutes — and retrying *before* the window closes
 // would just hit the same throttle again.
 const MAX_RETRY_AFTER_WAIT_MS = 60_000
+// Ceiling on the TOTAL time a single request will spend sleeping across all
+// of its retries. MAX_RETRY_AFTER_WAIT_MS only bounds each individual wait —
+// with MAX_STEAM_RETRIES=3, three back-to-back ~60s Retry-After waits could
+// still hold a request handler open for minutes, well past typical proxy/
+// gateway timeouts. This budget makes the request-handler-visible latency
+// predictable regardless of how many retries Valve's Retry-After values add
+// up to.
+const MAX_TOTAL_RETRY_WAIT_MS = 60_000
 
 class SteamAPIError extends Error {
   constructor(
@@ -182,7 +190,7 @@ async function steamAPIRequest(endpoint: string, params: Record<string, string>)
     url.searchParams.set(key, value)
   })
 
-  for (let attempt = 0; ; attempt++) {
+  for (let attempt = 0, totalWaitMs = 0; ; attempt++) {
     try {
       const response = await fetch(url.toString(), {
         cache: "no-store",
@@ -193,17 +201,22 @@ async function steamAPIRequest(endpoint: string, params: Record<string, string>)
       if (response.status === 429) {
         const retryAfterHeader = response.headers?.get?.("retry-after")
         const delay = attempt < MAX_STEAM_RETRIES ? nextBackoffMs(attempt, retryAfterHeader) : null
-        if (delay !== null) {
+        // Beyond the per-attempt ceiling above, also cap the *cumulative*
+        // sleep across all attempts (MAX_TOTAL_RETRY_WAIT_MS) — otherwise a
+        // request handler could stay open for minutes across several
+        // large-but-individually-valid Retry-After waits.
+        if (delay !== null && totalWaitMs + delay <= MAX_TOTAL_RETRY_WAIT_MS) {
           logger.warn(
             { endpoint, attempt: attempt + 1, delayMs: delay, retryAfter: retryAfterHeader ?? null },
             "Steam API rate limited (429) — backing off before retry",
           )
           await sleep(delay)
+          totalWaitMs += delay
           continue
         }
         logger.error(
           { endpoint, attempts: attempt + 1, retryAfter: retryAfterHeader ?? null },
-          "Steam API rate limited (429) — giving up (retries exhausted or Retry-After too long)",
+          "Steam API rate limited (429) — giving up (retries exhausted, Retry-After too long, or retry budget exhausted)",
         )
         throw new SteamAPIError(`Steam API rate limited: 429`, 429)
       }

--- a/test/steam-api.test.ts
+++ b/test/steam-api.test.ts
@@ -450,4 +450,64 @@ describe("429 rate-limit backoff", () => {
       expect.any(String),
     )
   })
+
+  describe("cumulative retry budget (MAX_TOTAL_RETRY_WAIT_MS)", () => {
+    it("cuts off retries once the accumulated wait would exceed the total budget, even though each Retry-After is within the per-attempt ceiling", async () => {
+      // Two 40s waits are each within the 60s per-attempt ceiling, but back
+      // to back they'd total 80s — over the 60s cumulative budget — so the
+      // second retry must give up instead of sleeping again.
+      mockFetchSequence([
+        { ok: false, status: 429, retryAfter: "40" },
+        { ok: false, status: 429, retryAfter: "40" },
+      ])
+      const { getOwnedGames } = await import("@/lib/steam-api")
+      vi.useFakeTimers()
+      const promise = getOwnedGames("76561198023709299")
+      await vi.runAllTimersAsync()
+      const games = await promise
+      expect(games).toEqual([])
+      // Initial request + one retry the budget still allowed; the second 429
+      // is answered by giving up rather than a third fetch.
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+      expect(loggerMock.warn).toHaveBeenCalledTimes(1)
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.objectContaining({ retryAfter: "40" }),
+        expect.stringContaining("giving up"),
+      )
+    })
+
+    it("still retries normally while the accumulated wait stays within the total budget", async () => {
+      // Two 20s waits total 40s, under the 60s cumulative budget, so both
+      // retries proceed exactly like before this change.
+      mockFetchSequence([
+        { ok: false, status: 429, retryAfter: "20" },
+        { ok: false, status: 429, retryAfter: "20" },
+        { body: { response: { games: [{ appid: 620, name: "Portal 2", playtime_forever: 1 }] } } },
+      ])
+      const { getOwnedGames } = await import("@/lib/steam-api")
+      vi.useFakeTimers()
+      const promise = getOwnedGames("76561198023709299")
+      await vi.runAllTimersAsync()
+      const games = await promise
+      expect(games).toHaveLength(1)
+      expect(globalThis.fetch).toHaveBeenCalledTimes(3)
+      expect(loggerMock.warn).toHaveBeenCalledTimes(2)
+      expect(loggerMock.error).not.toHaveBeenCalled()
+    })
+
+    it("allows a single wait exactly equal to the total budget (only 'exceeds' cuts off, not 'meets')", async () => {
+      mockFetchSequence([{ ok: false, status: 429, retryAfter: "60" }, { body: { response: { games: [] } } }])
+      const { getOwnedGames } = await import("@/lib/steam-api")
+      vi.useFakeTimers()
+      const promise = getOwnedGames("76561198023709299")
+      await vi.runAllTimersAsync()
+      await promise
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ delayMs: 60000, retryAfter: "60" }),
+        expect.any(String),
+      )
+      expect(loggerMock.error).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- The Web API retry loop honours `Retry-After` in full up to a 60s per-attempt ceiling (`MAX_RETRY_AFTER_WAIT_MS`), but that only bounds each individual sleep. With `MAX_STEAM_RETRIES = 3`, three back-to-back large-but-valid `Retry-After` waits could still hold a request handler open for several minutes — well past typical proxy/gateway timeouts (e.g. `GET /api/steam/games`).
- Adds a cumulative wait budget per request, `MAX_TOTAL_RETRY_WAIT_MS = 60_000`: before each sleep, if the time already waited plus the next delay would exceed the budget, retrying stops and the existing rate-limit error (`SteamAPIError` / 429) is thrown, same as the other give-up paths.
- No change to per-attempt semantics: `Retry-After` is still honoured in full when it fits both the per-attempt ceiling and the remaining budget; exponential backoff fallback is untouched.

## Test plan
- [x] `pnpm lint` (oxlint + typecheck)
- [x] `pnpm format:check`
- [x] `pnpm test` — 527/527 passing, including 3 new cases in `test/steam-api.test.ts`: budget exceeded cuts off retries, within-budget behaves as before, and the exact-equal-to-budget boundary still proceeds
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)