### PR TITLE
test(admin): cover AdminSubNav; exclude type-only lib/auth.ts

### DIFF
--- a/test/admin-sub-nav.test.tsx
+++ b/test/admin-sub-nav.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const pathnameRef = { current: "/admin" }
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathnameRef.current,
+}))
+
+import { AdminSubNav } from "@/components/admin/admin-sub-nav"
+
+beforeEach(() => {
+  pathnameRef.current = "/admin"
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("AdminSubNav", () => {
+  it("renders a nav landmark with both tab links", () => {
+    render(<AdminSubNav />)
+    expect(screen.getByRole("navigation", { name: "Admin sections" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Users/i })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Orphan names/i })).toBeInTheDocument()
+  })
+
+  it("points each link at the correct href", () => {
+    render(<AdminSubNav />)
+    expect(screen.getByRole("link", { name: /Users/i })).toHaveAttribute("href", "/admin")
+    expect(screen.getByRole("link", { name: /Orphan names/i })).toHaveAttribute("href", "/admin/orphan-names")
+  })
+
+  it("marks the Users tab active when on /admin", () => {
+    pathnameRef.current = "/admin"
+    render(<AdminSubNav />)
+    const usersLink = screen.getByRole("link", { name: /Users/i })
+    const orphanLink = screen.getByRole("link", { name: /Orphan names/i })
+    expect(usersLink.className).toContain("bg-accent")
+    expect(orphanLink.className).not.toContain("bg-accent")
+  })
+
+  it("marks the Orphan names tab active when on /admin/orphan-names", () => {
+    pathnameRef.current = "/admin/orphan-names"
+    render(<AdminSubNav />)
+    const usersLink = screen.getByRole("link", { name: /Users/i })
+    const orphanLink = screen.getByRole("link", { name: /Orphan names/i })
+    expect(orphanLink.className).toContain("bg-accent")
+    expect(usersLink.className).not.toContain("bg-accent")
+  })
+
+  it("marks neither tab active on an unrelated route", () => {
+    pathnameRef.current = "/dashboard"
+    render(<AdminSubNav />)
+    const usersLink = screen.getByRole("link", { name: /Users/i })
+    const orphanLink = screen.getByRole("link", { name: /Orphan names/i })
+    expect(usersLink.className).not.toContain("bg-accent")
+    expect(orphanLink.className).not.toContain("bg-accent")
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
         // Type-only / re-export barrels
         "lib/types/**",
         "lib/server/steam-store.ts",
+        // Interfaces only (SteamBadge/SteamUser); erased at compile time,
+        // so it has zero executable statements to cover.
+        "lib/auth.ts",
       ],
       // Baseline thresholds locked to the current honest numbers. Each
       // coverage PR ratchets these up; CI fails if a PR regresses below


### PR DESCRIPTION
## Summary

Closes out the last two 0%-coverage files on the backlog.

- **`components/admin/admin-sub-nav.tsx`**: had no tests at all (0% lines/functions). Added `test/admin-sub-nav.test.tsx` following the existing `dashboard-header.test.tsx` pattern (mocked `usePathname`, `@testing-library/react`): renders the nav landmark and both links, correct `href`s, and active-tab styling for `/admin`, `/admin/orphan-names`, and an unrelated route.
- **`lib/auth.ts`**: re-verified with `pnpm test:coverage` and it's the repo's other reported 0%, but the file only declares the `SteamBadge`/`SteamUser` **interfaces** — everywhere it's imported (`app/lib/server-auth.ts`, `hooks/use-current-user.ts`, `components/dashboard/*`, etc.) it's an `import type`, so there are 0 executable statements after TypeScript erases the types. There is no real function here to write a unit test against. Instead of faking coverage, added it to `vitest.config.ts`'s `exclude` list next to the repo's existing type-only entries (`lib/types/**`, `lib/server/steam-store.ts`).

## Coverage before → after

| File | Lines before | Lines after |
|---|---|---|
| `components/admin/admin-sub-nav.tsx` | 0% (0/6) | **100% (6/6)** |
| `lib/auth.ts` | 0% (0/0, type-only) | excluded from coverage (matches `lib/types/**` convention) |

Overall: 93.42% → 93.71% lines (thresholds hold: lines 92, statements 90, branches 83, functions 81).

## Test plan
- [x] `pnpm lint` (oxlint + typecheck)
- [x] `pnpm format:check`
- [x] `pnpm test` — 55 files / 529 tests passing (was 54/524)
- [x] `pnpm test:coverage` — both target files out of the 0% bucket
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)