### PR TITLE
chore(dependabot): make the commit prefix explicit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   # npm/pnpm dependencies
   - package-ecosystem: "npm"
     directory: "/"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -16,6 +19,9 @@ updates:
   # GitHub Actions used by the CI workflow
   - package-ecosystem: "github-actions"
     directory: "/"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Why

Dependabot PR titles differ across the finallyjay repos: some use `chore(deps)` / `chore(deps-dev)` (detected from commit history), daily-dev-roulette uses `deps` / `deps-dev`, GitHub Actions bumps use `ci` in a couple of repos, and personal-deck had a duplicated scope until #70. Making the prefix explicit gives every repo the same, deterministic titles regardless of what Dependabot infers from history.

## What

- `.github/dependabot.yml`: add `commit-message: { prefix: "chore", include: "scope" }` to every ecosystem entry. Dependabot appends the scope itself, so titles become `chore(deps): …` and `chore(deps-dev): …`. Schedules, groups and limits are untouched.

Same change is being applied to every finallyjay repo with a Dependabot config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaN67cqjmynmoHj6hJs9TP
