### PR TITLE
docs: fix stale toolchain and merge-policy statements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Pre-commit hooks run oxfmt + oxlint via Husky + lint-staged.
 
 ## Architecture
 
-Next.js 16 App Router with React 19, TypeScript strict mode, Tailwind CSS 4, shadcn/ui (new-york style) + Radix UI primitives. Uses pnpm 11.7 and Node 24.13.
+Next.js 16 App Router with React 19, TypeScript strict mode, Tailwind CSS 4, shadcn/ui (new-york style) + Radix UI primitives. Uses pnpm (pinned in `packageManager`) and Node 24 (`.nvmrc`).
 
 ### Data flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This is a personal project, but contributions are welcome. This guide captures t
 
 ## Setup
 
-Requires **Node 24.13+** and **pnpm 11.7** (see `packageManager` in `package.json` — Corepack picks it up automatically).
+Requires **Node 24** (see `.nvmrc`) and **pnpm** (the exact version is pinned in `packageManager` in `package.json` — Corepack picks it up automatically).
 
 ```bash
 pnpm install
@@ -21,7 +21,7 @@ All changes go through **issue → branch → PR → merge**. Direct commits to 
 2. **Create a branch**: `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `docs/<slug>`, or `refactor/<slug>`.
 3. **Push + open a PR**. The PR template will prompt you for a Summary and Test plan.
 4. **CI runs** `pnpm lint` + `pnpm test` + `pnpm build` via the `quality` check. All three must pass before merging.
-5. **Merge with a regular merge commit** — squash merges are not used, history is preserved on `main`.
+5. **Squash merge.** Every PR lands on `main` as a single commit whose message is the PR title, so keep the title in Conventional Commits form.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ A self-hosted dashboard for tracking your Steam library, monitoring achievement 
 | Testing         | [Vitest](https://vitest.dev/) + Testing Library                                                                   |
 | Linting         | [oxlint](https://oxc.rs/docs/guide/usage/linter) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter)             |
 | CI/CD           | GitHub Actions                                                                                                    |
-| Package Manager | pnpm 11.7                                                                                                         |
+| Package Manager | pnpm (version pinned in `packageManager`)                                                                          |
 
 ## Prerequisites
 
-- Node.js `24.13.1` (see `.nvmrc`)
-- pnpm `11.7.0` (see `packageManager` in `package.json` — Corepack picks it up automatically)
+- Node.js 24 (see `.nvmrc`; `engines` requires `>=24 <25`)
+- pnpm (see `packageManager` in `package.json` — Corepack picks it up automatically)
 
 ## Getting Started
 
@@ -266,7 +266,7 @@ Ensure `NEXTAUTH_URL` matches your public URL for Steam OpenID redirects.
 4. Pre-commit hooks will run oxfmt and oxlint automatically
 5. Create an issue first, then open a Pull Request that closes it
 
-CI runs `lint → test → build` on all PRs.
+CI runs `lint → test → build` on all PRs; pull requests are squash-merged.
 
 ## License
 


### PR DESCRIPTION
## Why

Several statements in the docs no longer matched the repository:

- README / CONTRIBUTING / CLAUDE.md said **Node 24.13.1** and **pnpm 11.7.0**. `.nvmrc` pins `24` (the LTS line, with `engines: >=24 <25`), and the pnpm version is whatever `packageManager` says — hard-coded numbers in prose go stale on every bump.
- CONTRIBUTING said PRs are merged with a **regular merge commit** and that squash merges are not used. The repository is now squash-only (single ruleset, `allowed_merge_methods: [squash]`).

## What

- `README.md`: Tech Stack row and Prerequisites reference `packageManager` / `.nvmrc` instead of literal versions; Contributing section notes that PRs are squash-merged.
- `CONTRIBUTING.md`: Setup paragraph as above; step 5 now describes squash merging and why the PR title matters.
- `CLAUDE.md`: same version sentence.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaN67cqjmynmoHj6hJs9TP
