### PR TITLE
chore: bump pnpm to 11.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "oxfmt"
     ]
   },
-  "packageManager": "pnpm@11.7.0",
+  "packageManager": "pnpm@11.20.0",
   "engines": {
     "node": ">=24 <25"
   },


### PR DESCRIPTION
## Why

`packageManager` was `pnpm@11.7.0`, the oldest across the finallyjay repos; the rest declare `11.20.0`. CI reads the version from this field, so a one-line bump keeps the toolchain aligned everywhere.

## What

- `package.json`: `packageManager` → `pnpm@11.20.0`. Lockfile unchanged (`pnpm install --frozen-lockfile` succeeds as-is).

## Verification (local, pnpm 11.20.0)

`pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm test` — all pass; CI's `quality` job runs the same plus `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaN67cqjmynmoHj6hJs9TP
