### PR TITLE
docs: add CI and license badges to the README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Steam Backlog Hunter
 
+[![CI](https://github.com/finallyjay/steam-backlog-hunter/actions/workflows/ci.yml/badge.svg)](https://github.com/finallyjay/steam-backlog-hunter/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A self-hosted dashboard for tracking your Steam library, monitoring achievement progress, and hunting down completions.
 
 ## Table of Contents
@@ -41,7 +44,7 @@ A self-hosted dashboard for tracking your Steam library, monitoring achievement 
 | Testing         | [Vitest](https://vitest.dev/) + Testing Library                                                                   |
 | Linting         | [oxlint](https://oxc.rs/docs/guide/usage/linter) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter)             |
 | CI/CD           | GitHub Actions                                                                                                    |
-| Package Manager | pnpm (version pinned in `packageManager`)                                                                          |
+| Package Manager | pnpm (version pinned in `packageManager`)                                                                         |
 
 ## Prerequisites
 


### PR DESCRIPTION
## What

- `README.md`: CI status (`ci.yml` on `main`) and License badges under the title — the same header every finallyjay repository uses. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaN67cqjmynmoHj6hJs9TP
