### PR TITLE
docs: move the API reference to docs/API.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,4 +66,4 @@ Where type is one of `feat`, `fix`, `chore`, `docs`, `test`, `refactor`. Use `fe
 
 ## Architecture
 
-See `CLAUDE.md` at the repository root for an overview of the data flow (Steam API → SQLite → API routes → client hooks → UI), the key modules, and the auth model.
+See the [Architecture](README.md#architecture), [Authentication](README.md#authentication) and [Database](README.md#database) sections of the README for the data flow (Steam API → SQLite → API routes → client hooks → UI), the key modules and the auth model, and [`docs/API.md`](docs/API.md) for the route reference.

--- a/README.md
+++ b/README.md
@@ -156,56 +156,7 @@ lib/
 
 ## API Reference
 
-All data endpoints require authentication via `steam_user` httpOnly cookie. JSDoc documentation is available on every route handler and public function.
-
-### Authentication
-
-| Method | Path                       | Description                                               |
-| ------ | -------------------------- | --------------------------------------------------------- |
-| `GET`  | `/api/auth/steam`          | Initiate Steam OpenID login (rate limited: 10/min per IP) |
-| `GET`  | `/api/auth/steam/callback` | Handle OpenID callback (CSRF nonce validated)             |
-| `POST` | `/api/auth/logout`         | Clear session cookie                                      |
-| `GET`  | `/api/auth/me`             | Get current authenticated user                            |
-
-### Steam Data
-
-| Method   | Path                                         | Description                                                         |
-| -------- | -------------------------------------------- | ------------------------------------------------------------------- |
-| `GET`    | `/api/steam/games?type=recent\|all`          | List owned or recently played games                                 |
-| `POST`   | `/api/steam/games/hide`                      | Hide a game from the library                                        |
-| `DELETE` | `/api/steam/games/hide`                      | Unhide a previously hidden game                                     |
-| `GET`    | `/api/steam/achievements?appId=N`            | Get achievements for a game                                         |
-| `GET`    | `/api/steam/achievements/batch?appIds=1,2,3` | Batch get achievements (max 200)                                    |
-| `GET`    | `/api/steam/game/:id`                        | Get single game details                                             |
-| `POST`   | `/api/steam/game/:id/sync`                   | Force-refresh a single game's achievement data from the Steam API   |
-| `GET`    | `/api/steam/extras`                          | List "extras" — played-but-not-owned games (`?hidden=1` for hidden) |
-| `GET`    | `/api/steam/extras/:id`                      | Get one extra game's detail + enriched achievements                 |
-| `GET`    | `/api/steam/stats`                           | Get aggregated user stats                                           |
-| `GET`    | `/api/steam/sync`                            | Get last sync timestamps                                            |
-| `POST`   | `/api/steam/sync`                            | Trigger full data sync (rate limited: 5/min per user)               |
-
-### Admin
-
-Admin-only routes, gated by `requireAdmin()` (the signed-in user's Steam ID must equal `ADMIN_STEAM_ID`).
-
-| Method   | Path                             | Description                                                             |
-| -------- | -------------------------------- | ----------------------------------------------------------------------- |
-| `GET`    | `/api/admin/users`               | List allowed users with profile info                                    |
-| `POST`   | `/api/admin/users`               | Add an allowed user                                                     |
-| `DELETE` | `/api/admin/users`               | Remove an allowed user                                                  |
-| `PATCH`  | `/api/admin/users`               | Refresh a user's Steam profile data                                     |
-| `GET`    | `/api/admin/pinned-games`        | List globally pinned appids                                             |
-| `POST`   | `/api/admin/pinned-games`        | Add an appid to the global pinned list                                  |
-| `DELETE` | `/api/admin/pinned-games`        | Remove an appid from the global pinned list                             |
-| `GET`    | `/api/admin/orphan-names`        | List appids with a NULL/empty `games.name` referenced by a user         |
-| `PUT`    | `/api/admin/orphan-names/:appid` | Set a manual name for an appid (freezes it as `name_source = 'manual'`) |
-| `DELETE` | `/api/admin/orphan-names/:appid` | Clear a manual name so auto-sync can resolve it again                   |
-
-### Infrastructure
-
-| Method | Path          | Description                                 |
-| ------ | ------------- | ------------------------------------------- |
-| `GET`  | `/api/health` | Health check (SQLite connectivity, no auth) |
+Every route handler is documented in [`docs/API.md`](docs/API.md) — authentication, Steam data, admin and infrastructure endpoints, with methods, paths and rate limits.
 
 ## Authentication
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,52 @@
+# API Reference
+
+All data endpoints require authentication via `steam_user` httpOnly cookie. JSDoc documentation is available on every route handler and public function.
+
+## Authentication
+
+| Method | Path                       | Description                                               |
+| ------ | -------------------------- | --------------------------------------------------------- |
+| `GET`  | `/api/auth/steam`          | Initiate Steam OpenID login (rate limited: 10/min per IP) |
+| `GET`  | `/api/auth/steam/callback` | Handle OpenID callback (CSRF nonce validated)             |
+| `POST` | `/api/auth/logout`         | Clear session cookie                                      |
+| `GET`  | `/api/auth/me`             | Get current authenticated user                            |
+
+## Steam Data
+
+| Method   | Path                                         | Description                                                         |
+| -------- | -------------------------------------------- | ------------------------------------------------------------------- |
+| `GET`    | `/api/steam/games?type=recent\|all`          | List owned or recently played games                                 |
+| `POST`   | `/api/steam/games/hide`                      | Hide a game from the library                                        |
+| `DELETE` | `/api/steam/games/hide`                      | Unhide a previously hidden game                                     |
+| `GET`    | `/api/steam/achievements?appId=N`            | Get achievements for a game                                         |
+| `GET`    | `/api/steam/achievements/batch?appIds=1,2,3` | Batch get achievements (max 200)                                    |
+| `GET`    | `/api/steam/game/:id`                        | Get single game details                                             |
+| `POST`   | `/api/steam/game/:id/sync`                   | Force-refresh a single game's achievement data from the Steam API   |
+| `GET`    | `/api/steam/extras`                          | List "extras" — played-but-not-owned games (`?hidden=1` for hidden) |
+| `GET`    | `/api/steam/extras/:id`                      | Get one extra game's detail + enriched achievements                 |
+| `GET`    | `/api/steam/stats`                           | Get aggregated user stats                                           |
+| `GET`    | `/api/steam/sync`                            | Get last sync timestamps                                            |
+| `POST`   | `/api/steam/sync`                            | Trigger full data sync (rate limited: 5/min per user)               |
+
+## Admin
+
+Admin-only routes, gated by `requireAdmin()` (the signed-in user's Steam ID must equal `ADMIN_STEAM_ID`).
+
+| Method   | Path                             | Description                                                             |
+| -------- | -------------------------------- | ----------------------------------------------------------------------- |
+| `GET`    | `/api/admin/users`               | List allowed users with profile info                                    |
+| `POST`   | `/api/admin/users`               | Add an allowed user                                                     |
+| `DELETE` | `/api/admin/users`               | Remove an allowed user                                                  |
+| `PATCH`  | `/api/admin/users`               | Refresh a user's Steam profile data                                     |
+| `GET`    | `/api/admin/pinned-games`        | List globally pinned appids                                             |
+| `POST`   | `/api/admin/pinned-games`        | Add an appid to the global pinned list                                  |
+| `DELETE` | `/api/admin/pinned-games`        | Remove an appid from the global pinned list                             |
+| `GET`    | `/api/admin/orphan-names`        | List appids with a NULL/empty `games.name` referenced by a user         |
+| `PUT`    | `/api/admin/orphan-names/:appid` | Set a manual name for an appid (freezes it as `name_source = 'manual'`) |
+| `DELETE` | `/api/admin/orphan-names/:appid` | Clear a manual name so auto-sync can resolve it again                   |
+
+## Infrastructure
+
+| Method | Path          | Description                                 |
+| ------ | ------------- | ------------------------------------------- |
+| `GET`  | `/api/health` | Health check (SQLite connectivity, no auth) |


### PR DESCRIPTION
## Why

At 270+ lines the README was doing two jobs: project overview and full API reference. The endpoint tables (auth, Steam data, admin, infrastructure) are the part a reader of the overview scrolls past, and the part an integrator wants on its own page.

## What

- New `docs/API.md` with the four endpoint tables, verbatim, headings promoted one level.
- `README.md`: the **API Reference** section becomes a one-paragraph pointer to `docs/API.md`; the table of contents entry still resolves.
- `CONTRIBUTING.md`: the Architecture paragraph links to the README's Architecture / Authentication / Database sections and to `docs/API.md` instead of to `CLAUDE.md` (which is assistant guidance, not contributor docs).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaN67cqjmynmoHj6hJs9TP
